### PR TITLE
유저 스트릭 현황, 누적 데이터, 스트릭 갱신 API 개발  

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AnswerEvaluationModule } from './answer-evaluation/answer-evaluation.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { typeOrmModuleOptions } from './configs/typeorm.config';
-import { UserModule } from './user/user.module';
-import { AnswerEvaluationModule } from './answer-evaluation/answer-evaluation.module';
 import { AudioStreamModule } from './audio-stream/audio-stream.module';
+import { typeOrmModuleOptions } from './configs/typeorm.config';
+import { StreaksModule } from './streaks/streaks.module';
+import { UserModule } from './user/user.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { AudioStreamModule } from './audio-stream/audio-stream.module';
     UserModule,
     AnswerEvaluationModule,
     AudioStreamModule,
+    StreaksModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/streaks/dtos/streaks-count.dto.ts
+++ b/apps/api/src/streaks/dtos/streaks-count.dto.ts
@@ -1,0 +1,7 @@
+export class GetYearlyActivityCountResponseDto {
+  streakCount: number;
+}
+
+export class GetConsecutiveDayCountResponseDto {
+  sequencyDailyCount: number;
+}

--- a/apps/api/src/streaks/dtos/streaks-reocrd.dto.ts
+++ b/apps/api/src/streaks/dtos/streaks-reocrd.dto.ts
@@ -1,0 +1,7 @@
+export class RecordDailyActivityRequestDto {
+  submittedAt?: string;
+}
+
+export class RecordDailyActivityResponseDto {
+  success: boolean;
+}

--- a/apps/api/src/streaks/dtos/streaks.dto.ts
+++ b/apps/api/src/streaks/dtos/streaks.dto.ts
@@ -1,0 +1,7 @@
+export class StreaksCountResponseDto {
+  streakCount: number;
+}
+
+export class StreaksRecordRequestDto {
+  submittedAt?: string;
+}

--- a/apps/api/src/streaks/dtos/streaks.dto.ts
+++ b/apps/api/src/streaks/dtos/streaks.dto.ts
@@ -1,7 +1,0 @@
-export class StreaksCountResponseDto {
-  streakCount: number;
-}
-
-export class StreaksRecordRequestDto {
-  submittedAt?: string;
-}

--- a/apps/api/src/streaks/entities/streaks.entity.ts
+++ b/apps/api/src/streaks/entities/streaks.entity.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Streaks {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ name: 'acitivity_date', type: 'date' })
+  activityDate: Date;
+
+  @Column({ name: 'user_id', type: 'int' })
+  userId: number;
+}

--- a/apps/api/src/streaks/streaks.controller.ts
+++ b/apps/api/src/streaks/streaks.controller.ts
@@ -9,7 +9,14 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import type { Request } from 'express';
-import { StreaksRecordRequestDto } from './dtos/streaks.dto';
+import {
+  GetConsecutiveDayCountResponseDto,
+  GetYearlyActivityCountResponseDto,
+} from './dtos/streaks-count.dto';
+import {
+  RecordDailyActivityRequestDto,
+  RecordDailyActivityResponseDto,
+} from './dtos/streaks-reocrd.dto';
 import { StreaksService } from './streaks.service';
 
 @Controller('streaks')
@@ -20,7 +27,7 @@ export class StreaksController {
   async getYearlyActivityCount(
     @Req() req: Request,
     @Query('year', new ParseIntPipe({ optional: true })) year?: number,
-  ) {
+  ): Promise<GetYearlyActivityCountResponseDto> {
     const userId = Number((req.cookies as { userId?: string })?.userId);
     if (!userId) {
       throw new UnauthorizedException('로그인이 필요합니다.');
@@ -32,7 +39,9 @@ export class StreaksController {
   }
 
   @Get('/sequence')
-  async getConsecutiveDayCount(@Req() req: Request) {
+  async getConsecutiveDayCount(
+    @Req() req: Request,
+  ): Promise<GetConsecutiveDayCountResponseDto> {
     const userId = Number((req.cookies as { userId?: string })?.userId);
     if (!userId) {
       throw new UnauthorizedException('로그인이 필요합니다.');
@@ -43,8 +52,8 @@ export class StreaksController {
   @Post()
   async recordDailyActivity(
     @Req() req: Request,
-    @Body() requestDto?: StreaksRecordRequestDto,
-  ) {
+    @Body() requestDto?: RecordDailyActivityRequestDto,
+  ): Promise<RecordDailyActivityResponseDto> {
     const userId = Number((req.cookies as { userId?: string })?.userId);
     if (!userId) {
       throw new UnauthorizedException('로그인이 필요합니다.');

--- a/apps/api/src/streaks/streaks.controller.ts
+++ b/apps/api/src/streaks/streaks.controller.ts
@@ -32,12 +32,12 @@ export class StreaksController {
   }
 
   @Get('/sequence')
-  async getSequenceDailyCount(@Req() req: Request) {
+  async getConsecutiveDayCount(@Req() req: Request) {
     const userId = Number((req.cookies as { userId?: string })?.userId);
     if (!userId) {
       throw new UnauthorizedException('로그인이 필요합니다.');
     }
-    return this.streaksService.getSequencyDailyCount(userId);
+    return this.streaksService.getConsecutiveDayCount(userId);
   }
 
   @Post()

--- a/apps/api/src/streaks/streaks.controller.ts
+++ b/apps/api/src/streaks/streaks.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Body,
+  Controller,
+  Get,
+  ParseIntPipe,
+  Post,
+  Query,
+  Req,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { StreaksRecordRequestDto } from './dtos/streaks.dto';
+import { StreaksService } from './streaks.service';
+
+@Controller('streaks')
+export class StreaksController {
+  constructor(private readonly streaksService: StreaksService) {}
+
+  @Get()
+  async getYearlyActivityCount(
+    @Req() req: Request,
+    @Query('year', new ParseIntPipe({ optional: true })) year?: number,
+  ) {
+    const userId = Number((req.cookies as { userId?: string })?.userId);
+    if (!userId) {
+      throw new UnauthorizedException('로그인이 필요합니다.');
+    }
+    if (!year) {
+      year = new Date().getFullYear();
+    }
+    return this.streaksService.getYearlyActivityCount(userId, year);
+  }
+
+  @Post()
+  async recordDailyActivity(
+    @Req() req: Request,
+    @Body() requestDto?: StreaksRecordRequestDto,
+  ) {
+    const userId = Number((req.cookies as { userId?: string })?.userId);
+    if (!userId) {
+      throw new UnauthorizedException('로그인이 필요합니다.');
+    }
+    const submittedAt = requestDto?.submittedAt
+      ? new Date(requestDto.submittedAt)
+      : new Date();
+    return this.streaksService.recordDailyActivity(userId, submittedAt);
+  }
+}

--- a/apps/api/src/streaks/streaks.controller.ts
+++ b/apps/api/src/streaks/streaks.controller.ts
@@ -31,6 +31,15 @@ export class StreaksController {
     return this.streaksService.getYearlyActivityCount(userId, year);
   }
 
+  @Get('/sequence')
+  async getSequenceDailyCount(@Req() req: Request) {
+    const userId = Number((req.cookies as { userId?: string })?.userId);
+    if (!userId) {
+      throw new UnauthorizedException('로그인이 필요합니다.');
+    }
+    return this.streaksService.getSequencyDailyCount(userId);
+  }
+
   @Post()
   async recordDailyActivity(
     @Req() req: Request,

--- a/apps/api/src/streaks/streaks.module.ts
+++ b/apps/api/src/streaks/streaks.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Streaks } from './entities/streaks.entity';
+import { StreaksController } from './streaks.controller';
+import { StreaksService } from './streaks.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Streaks])],
+  controllers: [StreaksController],
+  providers: [StreaksService],
+  exports: [StreaksService],
+})
+export class StreaksModule {}

--- a/apps/api/src/streaks/streaks.service.spec.ts
+++ b/apps/api/src/streaks/streaks.service.spec.ts
@@ -1,0 +1,255 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { StreaksService } from './streaks.service';
+import { Streaks } from './entities/streaks.entity';
+
+describe('StreaksService', () => {
+  let service: StreaksService;
+
+  const mockStreaksRepository = {
+    findBy: jest.fn(),
+    find: jest.fn(),
+    findOneBy: jest.fn(),
+    insert: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StreaksService,
+        {
+          provide: getRepositoryToken(Streaks),
+          useValue: mockStreaksRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<StreaksService>(StreaksService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  describe('getYearlyActivityCount', () => {
+    it('2026년 기준으로 데이터가 없으면 0이 리턴된다', async () => {
+      mockStreaksRepository.findBy.mockResolvedValue([]);
+
+      const result = await service.getYearlyActivityCount(1, 2026);
+
+      expect(result).toEqual({ streakCount: 0 });
+    });
+
+    it('2026년 기준으로 데이터가 5개 있으면 5가 리턴된다', async () => {
+      const mockData = [
+        { id: 1, userId: 1, activityDate: new Date('2026-01-01') },
+        { id: 2, userId: 1, activityDate: new Date('2026-01-02') },
+        { id: 3, userId: 1, activityDate: new Date('2026-01-03') },
+        { id: 4, userId: 1, activityDate: new Date('2026-01-04') },
+        { id: 5, userId: 1, activityDate: new Date('2026-01-05') },
+      ];
+      mockStreaksRepository.findBy.mockResolvedValue(mockData);
+
+      const result = await service.getYearlyActivityCount(1, 2026);
+
+      expect(result).toEqual({ streakCount: 5 });
+    });
+
+    it('2025년 기준으로 데이터가 없으면 0을 리턴한다', async () => {
+      mockStreaksRepository.findBy.mockResolvedValue([]);
+
+      const result = await service.getYearlyActivityCount(1, 2025);
+
+      expect(result).toEqual({ streakCount: 0 });
+    });
+
+    it('2025년 기준으로 데이터가 5개 있으면 5를 리턴한다', async () => {
+      const mockData = [
+        { id: 1, userId: 1, activityDate: new Date('2025-01-01') },
+        { id: 2, userId: 1, activityDate: new Date('2025-01-02') },
+        { id: 3, userId: 1, activityDate: new Date('2025-01-03') },
+        { id: 4, userId: 1, activityDate: new Date('2025-01-04') },
+        { id: 5, userId: 1, activityDate: new Date('2025-01-05') },
+      ];
+      mockStreaksRepository.findBy.mockResolvedValue(mockData);
+
+      const result = await service.getYearlyActivityCount(1, 2025);
+
+      expect(result).toEqual({ streakCount: 5 });
+    });
+
+    it('2025년 3개 + 2026년 5개 혼합 시 2026년 조회하면 5를 리턴한다', async () => {
+      const mockData = [
+        { id: 1, userId: 1, activityDate: new Date('2025-12-01') },
+        { id: 2, userId: 1, activityDate: new Date('2025-12-02') },
+        { id: 3, userId: 1, activityDate: new Date('2025-12-03') },
+        { id: 4, userId: 1, activityDate: new Date('2026-01-01') },
+        { id: 5, userId: 1, activityDate: new Date('2026-01-02') },
+        { id: 6, userId: 1, activityDate: new Date('2026-01-03') },
+        { id: 7, userId: 1, activityDate: new Date('2026-01-04') },
+        { id: 8, userId: 1, activityDate: new Date('2026-01-05') },
+      ];
+      mockStreaksRepository.findBy.mockResolvedValue(mockData);
+
+      const result = await service.getYearlyActivityCount(1, 2026);
+
+      expect(result).toEqual({ streakCount: 5 });
+    });
+
+    it('userId별로 데이터를 구분하여 조회한다', async () => {
+      const mockDataForUser1 = [
+        { id: 1, userId: 1, activityDate: new Date('2026-01-01') },
+        { id: 2, userId: 1, activityDate: new Date('2026-01-02') },
+        { id: 3, userId: 1, activityDate: new Date('2026-01-03') },
+        { id: 4, userId: 1, activityDate: new Date('2026-01-04') },
+        { id: 5, userId: 1, activityDate: new Date('2026-01-05') },
+      ];
+      mockStreaksRepository.findBy.mockResolvedValue(mockDataForUser1);
+
+      const result = await service.getYearlyActivityCount(1, 2026);
+
+      expect(mockStreaksRepository.findBy).toHaveBeenCalledWith({ userId: 1 });
+      expect(result).toEqual({ streakCount: 5 });
+    });
+  });
+
+  describe('getSequencyDailyCount', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-01-08T00:00:00.000Z'));
+    });
+
+    it('오늘이 2026.01.08일 때 01.01~01.07까지 스트릭을 갱신했다면 7을 리턴한다', async () => {
+      const mockData = [
+        { id: 7, userId: 1, activityDate: new Date('2026-01-07') },
+        { id: 6, userId: 1, activityDate: new Date('2026-01-06') },
+        { id: 5, userId: 1, activityDate: new Date('2026-01-05') },
+        { id: 4, userId: 1, activityDate: new Date('2026-01-04') },
+        { id: 3, userId: 1, activityDate: new Date('2026-01-03') },
+        { id: 2, userId: 1, activityDate: new Date('2026-01-02') },
+        { id: 1, userId: 1, activityDate: new Date('2026-01-01') },
+      ];
+      mockStreaksRepository.find.mockResolvedValue(mockData);
+
+      const result = await service.getSequencyDailyCount(1);
+
+      expect(result).toEqual({ sequencyDailyCount: 7 });
+    });
+
+    it('오늘이 2026.01.08일 때 01.01~01.08까지 스트릭을 갱신했다면 8을 리턴한다', async () => {
+      const mockData = [
+        { id: 8, userId: 1, activityDate: new Date('2026-01-08') },
+        { id: 7, userId: 1, activityDate: new Date('2026-01-07') },
+        { id: 6, userId: 1, activityDate: new Date('2026-01-06') },
+        { id: 5, userId: 1, activityDate: new Date('2026-01-05') },
+        { id: 4, userId: 1, activityDate: new Date('2026-01-04') },
+        { id: 3, userId: 1, activityDate: new Date('2026-01-03') },
+        { id: 2, userId: 1, activityDate: new Date('2026-01-02') },
+        { id: 1, userId: 1, activityDate: new Date('2026-01-01') },
+      ];
+      mockStreaksRepository.find.mockResolvedValue(mockData);
+
+      const result = await service.getSequencyDailyCount(1);
+
+      expect(result).toEqual({ sequencyDailyCount: 8 });
+    });
+
+    it('오늘이 2026.01.08일 때 01.01~01.06까지 스트릭을 갱신했다면 0을 리턴한다', async () => {
+      const mockData = [
+        { id: 6, userId: 1, activityDate: new Date('2026-01-06') },
+        { id: 5, userId: 1, activityDate: new Date('2026-01-05') },
+        { id: 4, userId: 1, activityDate: new Date('2026-01-04') },
+        { id: 3, userId: 1, activityDate: new Date('2026-01-03') },
+        { id: 2, userId: 1, activityDate: new Date('2026-01-02') },
+        { id: 1, userId: 1, activityDate: new Date('2026-01-01') },
+      ];
+      mockStreaksRepository.find.mockResolvedValue(mockData);
+
+      const result = await service.getSequencyDailyCount(1);
+
+      expect(result).toEqual({ sequencyDailyCount: 0 });
+    });
+
+    it('스트릭 데이터가 없다면 0을 리턴한다', async () => {
+      mockStreaksRepository.find.mockResolvedValue([]);
+
+      const result = await service.getSequencyDailyCount(1);
+
+      expect(result).toEqual({ sequencyDailyCount: 0 });
+    });
+
+    it('오늘이 2026.01.08일 때 01.06이 없고 01.07~01.08만 있으면 2를 리턴한다', async () => {
+      const mockData = [
+        { id: 2, userId: 1, activityDate: new Date('2026-01-08') },
+        { id: 1, userId: 1, activityDate: new Date('2026-01-07') },
+      ];
+      mockStreaksRepository.find.mockResolvedValue(mockData);
+
+      const result = await service.getSequencyDailyCount(1);
+
+      expect(result).toEqual({ sequencyDailyCount: 2 });
+    });
+
+    it('오늘이 2026.01.08일 때 오늘(01.08)만 있으면 1을 리턴한다', async () => {
+      const mockData = [
+        { id: 1, userId: 1, activityDate: new Date('2026-01-08') },
+      ];
+      mockStreaksRepository.find.mockResolvedValue(mockData);
+
+      const result = await service.getSequencyDailyCount(1);
+
+      expect(result).toEqual({ sequencyDailyCount: 1 });
+    });
+
+    it('오늘이 2026.01.08일 때 어제(01.07)만 있으면 1을 리턴한다', async () => {
+      const mockData = [
+        { id: 1, userId: 1, activityDate: new Date('2026-01-07') },
+      ];
+      mockStreaksRepository.find.mockResolvedValue(mockData);
+
+      const result = await service.getSequencyDailyCount(1);
+
+      expect(result).toEqual({ sequencyDailyCount: 1 });
+    });
+  });
+
+  describe('recordDailyActivity', () => {
+    it('submittedAt이 2026.01.08일 때 스트릭 데이터가 조회되지 않으면 데이터를 추가하고 true를 리턴한다', async () => {
+      const submittedAt = new Date('2026-01-08');
+      mockStreaksRepository.findOneBy.mockResolvedValue(null);
+      mockStreaksRepository.insert.mockResolvedValue({} as any);
+
+      const result = await service.recordDailyActivity(1, submittedAt);
+
+      expect(mockStreaksRepository.findOneBy).toHaveBeenCalledWith({
+        userId: 1,
+        activityDate: submittedAt,
+      });
+      expect(mockStreaksRepository.insert).toHaveBeenCalledWith({
+        userId: 1,
+        activityDate: submittedAt,
+      });
+      expect(result).toEqual({ success: true });
+    });
+
+    it('submittedAt이 2026.01.08일 때 스트릭 데이터가 조회된다면 데이터를 조작하지 않고 true를 리턴한다', async () => {
+      const submittedAt = new Date('2026-01-08');
+      const existingStreak = {
+        id: 1,
+        userId: 1,
+        activityDate: submittedAt,
+      };
+      mockStreaksRepository.findOneBy.mockResolvedValue(existingStreak);
+
+      const result = await service.recordDailyActivity(1, submittedAt);
+
+      expect(mockStreaksRepository.findOneBy).toHaveBeenCalledWith({
+        userId: 1,
+        activityDate: submittedAt,
+      });
+      expect(mockStreaksRepository.insert).not.toHaveBeenCalled();
+      expect(result).toEqual({ success: true });
+    });
+  });
+});

--- a/apps/api/src/streaks/streaks.service.spec.ts
+++ b/apps/api/src/streaks/streaks.service.spec.ts
@@ -7,7 +7,7 @@ describe('StreaksService', () => {
   let service: StreaksService;
 
   const mockStreaksRepository = {
-    findBy: jest.fn(),
+    count: jest.fn(),
     find: jest.fn(),
     findOneBy: jest.fn(),
     insert: jest.fn(),
@@ -34,7 +34,7 @@ describe('StreaksService', () => {
 
   describe('getYearlyActivityCount', () => {
     it('2026년 기준으로 데이터가 없으면 0이 리턴된다', async () => {
-      mockStreaksRepository.findBy.mockResolvedValue([]);
+      mockStreaksRepository.count.mockResolvedValue(0);
 
       const result = await service.getYearlyActivityCount(1, 2026);
 
@@ -42,14 +42,7 @@ describe('StreaksService', () => {
     });
 
     it('2026년 기준으로 데이터가 5개 있으면 5가 리턴된다', async () => {
-      const mockData = [
-        { id: 1, userId: 1, activityDate: new Date('2026-01-01') },
-        { id: 2, userId: 1, activityDate: new Date('2026-01-02') },
-        { id: 3, userId: 1, activityDate: new Date('2026-01-03') },
-        { id: 4, userId: 1, activityDate: new Date('2026-01-04') },
-        { id: 5, userId: 1, activityDate: new Date('2026-01-05') },
-      ];
-      mockStreaksRepository.findBy.mockResolvedValue(mockData);
+      mockStreaksRepository.count.mockResolvedValue(5);
 
       const result = await service.getYearlyActivityCount(1, 2026);
 
@@ -57,7 +50,7 @@ describe('StreaksService', () => {
     });
 
     it('2025년 기준으로 데이터가 없으면 0을 리턴한다', async () => {
-      mockStreaksRepository.findBy.mockResolvedValue([]);
+      mockStreaksRepository.count.mockResolvedValue(0);
 
       const result = await service.getYearlyActivityCount(1, 2025);
 
@@ -65,14 +58,7 @@ describe('StreaksService', () => {
     });
 
     it('2025년 기준으로 데이터가 5개 있으면 5를 리턴한다', async () => {
-      const mockData = [
-        { id: 1, userId: 1, activityDate: new Date('2025-01-01') },
-        { id: 2, userId: 1, activityDate: new Date('2025-01-02') },
-        { id: 3, userId: 1, activityDate: new Date('2025-01-03') },
-        { id: 4, userId: 1, activityDate: new Date('2025-01-04') },
-        { id: 5, userId: 1, activityDate: new Date('2025-01-05') },
-      ];
-      mockStreaksRepository.findBy.mockResolvedValue(mockData);
+      mockStreaksRepository.count.mockResolvedValue(5);
 
       const result = await service.getYearlyActivityCount(1, 2025);
 
@@ -80,17 +66,7 @@ describe('StreaksService', () => {
     });
 
     it('2025년 3개 + 2026년 5개 혼합 시 2026년 조회하면 5를 리턴한다', async () => {
-      const mockData = [
-        { id: 1, userId: 1, activityDate: new Date('2025-12-01') },
-        { id: 2, userId: 1, activityDate: new Date('2025-12-02') },
-        { id: 3, userId: 1, activityDate: new Date('2025-12-03') },
-        { id: 4, userId: 1, activityDate: new Date('2026-01-01') },
-        { id: 5, userId: 1, activityDate: new Date('2026-01-02') },
-        { id: 6, userId: 1, activityDate: new Date('2026-01-03') },
-        { id: 7, userId: 1, activityDate: new Date('2026-01-04') },
-        { id: 8, userId: 1, activityDate: new Date('2026-01-05') },
-      ];
-      mockStreaksRepository.findBy.mockResolvedValue(mockData);
+      mockStreaksRepository.count.mockResolvedValue(5);
 
       const result = await service.getYearlyActivityCount(1, 2026);
 
@@ -98,18 +74,11 @@ describe('StreaksService', () => {
     });
 
     it('userId별로 데이터를 구분하여 조회한다', async () => {
-      const mockDataForUser1 = [
-        { id: 1, userId: 1, activityDate: new Date('2026-01-01') },
-        { id: 2, userId: 1, activityDate: new Date('2026-01-02') },
-        { id: 3, userId: 1, activityDate: new Date('2026-01-03') },
-        { id: 4, userId: 1, activityDate: new Date('2026-01-04') },
-        { id: 5, userId: 1, activityDate: new Date('2026-01-05') },
-      ];
-      mockStreaksRepository.findBy.mockResolvedValue(mockDataForUser1);
+      mockStreaksRepository.count.mockResolvedValue(5);
 
       const result = await service.getYearlyActivityCount(1, 2026);
 
-      expect(mockStreaksRepository.findBy).toHaveBeenCalledWith({ userId: 1 });
+      expect(mockStreaksRepository.count).toHaveBeenCalled();
       expect(result).toEqual({ streakCount: 5 });
     });
   });

--- a/apps/api/src/streaks/streaks.service.spec.ts
+++ b/apps/api/src/streaks/streaks.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { StreaksService } from './streaks.service';
 import { Streaks } from './entities/streaks.entity';
+import { StreaksService } from './streaks.service';
 
 describe('StreaksService', () => {
   let service: StreaksService;
@@ -83,7 +83,7 @@ describe('StreaksService', () => {
     });
   });
 
-  describe('getSequencyDailyCount', () => {
+  describe('getConsecutiveDayCount', () => {
     beforeEach(() => {
       jest.useFakeTimers();
       jest.setSystemTime(new Date('2026-01-08T00:00:00.000Z'));
@@ -101,7 +101,7 @@ describe('StreaksService', () => {
       ];
       mockStreaksRepository.find.mockResolvedValue(mockData);
 
-      const result = await service.getSequencyDailyCount(1);
+      const result = await service.getConsecutiveDayCount(1);
 
       expect(result).toEqual({ sequencyDailyCount: 7 });
     });
@@ -119,7 +119,7 @@ describe('StreaksService', () => {
       ];
       mockStreaksRepository.find.mockResolvedValue(mockData);
 
-      const result = await service.getSequencyDailyCount(1);
+      const result = await service.getConsecutiveDayCount(1);
 
       expect(result).toEqual({ sequencyDailyCount: 8 });
     });
@@ -135,7 +135,7 @@ describe('StreaksService', () => {
       ];
       mockStreaksRepository.find.mockResolvedValue(mockData);
 
-      const result = await service.getSequencyDailyCount(1);
+      const result = await service.getConsecutiveDayCount(1);
 
       expect(result).toEqual({ sequencyDailyCount: 0 });
     });
@@ -143,7 +143,7 @@ describe('StreaksService', () => {
     it('스트릭 데이터가 없다면 0을 리턴한다', async () => {
       mockStreaksRepository.find.mockResolvedValue([]);
 
-      const result = await service.getSequencyDailyCount(1);
+      const result = await service.getConsecutiveDayCount(1);
 
       expect(result).toEqual({ sequencyDailyCount: 0 });
     });
@@ -155,7 +155,7 @@ describe('StreaksService', () => {
       ];
       mockStreaksRepository.find.mockResolvedValue(mockData);
 
-      const result = await service.getSequencyDailyCount(1);
+      const result = await service.getConsecutiveDayCount(1);
 
       expect(result).toEqual({ sequencyDailyCount: 2 });
     });
@@ -166,7 +166,7 @@ describe('StreaksService', () => {
       ];
       mockStreaksRepository.find.mockResolvedValue(mockData);
 
-      const result = await service.getSequencyDailyCount(1);
+      const result = await service.getConsecutiveDayCount(1);
 
       expect(result).toEqual({ sequencyDailyCount: 1 });
     });
@@ -177,7 +177,7 @@ describe('StreaksService', () => {
       ];
       mockStreaksRepository.find.mockResolvedValue(mockData);
 
-      const result = await service.getSequencyDailyCount(1);
+      const result = await service.getConsecutiveDayCount(1);
 
       expect(result).toEqual({ sequencyDailyCount: 1 });
     });

--- a/apps/api/src/streaks/streaks.service.ts
+++ b/apps/api/src/streaks/streaks.service.ts
@@ -10,14 +10,20 @@ export class StreaksService {
     private readonly streaksRepository: Repository<Streaks>,
   ) {}
 
-  async getYearlyActivityCount(userId: number, year: number): Promise<number> {
+  async getYearlyActivityCount(
+    userId: number,
+    year: number,
+  ): Promise<{ streakCount: number }> {
     const userStreak = await this.streaksRepository.findBy({ userId: userId });
-    return userStreak.filter((user) => {
+    const streakCount = userStreak.filter((user) => {
       return new Date(user.activityDate).getFullYear() === year;
     }).length;
+    return { streakCount };
   }
 
-  async getSequencyDailyCount(userId: number): Promise<number> {
+  async getSequencyDailyCount(
+    userId: number,
+  ): Promise<{ sequencyDailyCount: number }> {
     const today = new Date();
     today.setHours(0, 0, 0, 0); //시간으로 인해 이틀 뒤로 날짜가 밀리는것을 방지하기 위한 정규화
 
@@ -27,7 +33,7 @@ export class StreaksService {
     });
 
     if (!userStreaks.length) {
-      return 0;
+      return { sequencyDailyCount: 0 };
     }
 
     let count = 0;
@@ -45,21 +51,24 @@ export class StreaksService {
       count++;
       referenceDate.setDate(referenceDate.getDate() - 1);
     }
-    return count;
+    return { sequencyDailyCount: count };
   }
 
-  async recordDailyActivity(userId: number, submittedAt: Date) {
+  async recordDailyActivity(
+    userId: number,
+    submittedAt: Date,
+  ): Promise<{ success: boolean }> {
     const checkDay = await this.streaksRepository.findOneBy({
       userId: userId,
       activityDate: submittedAt,
     });
     if (checkDay) {
-      return true;
+      return { success: true };
     }
     await this.streaksRepository.insert({
       userId: userId,
       activityDate: submittedAt,
     });
-    return true;
+    return { success: true };
   }
 }

--- a/apps/api/src/streaks/streaks.service.ts
+++ b/apps/api/src/streaks/streaks.service.ts
@@ -17,6 +17,37 @@ export class StreaksService {
     }).length;
   }
 
+  async getSequencyDailyCount(userId: number): Promise<number> {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0); //시간으로 인해 이틀 뒤로 날짜가 밀리는것을 방지하기 위한 정규화
+
+    const userStreaks = await this.streaksRepository.find({
+      where: { userId },
+      order: { activityDate: 'DESC' },
+    });
+
+    if (!userStreaks.length) {
+      return 0;
+    }
+
+    let count = 0;
+
+    const streakDates = new Set(
+      userStreaks.map((streak) => {
+        const date = new Date(streak.activityDate);
+        date.setHours(0, 0, 0, 0);
+        return date.getTime();
+      }),
+    );
+
+    const referenceDate = new Date(today);
+    while (streakDates.has(referenceDate.getTime())) {
+      count++;
+      referenceDate.setDate(referenceDate.getDate() - 1);
+    }
+    return count;
+  }
+
   async recordDailyActivity(userId: number, submittedAt: Date) {
     const checkDay = await this.streaksRepository.findOneBy({
       userId: userId,

--- a/apps/api/src/streaks/streaks.service.ts
+++ b/apps/api/src/streaks/streaks.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Between, Repository } from 'typeorm';
 import { Streaks } from './entities/streaks.entity';
 
 @Injectable()
@@ -14,10 +14,16 @@ export class StreaksService {
     userId: number,
     year: number,
   ): Promise<{ streakCount: number }> {
-    const userStreak = await this.streaksRepository.findBy({ userId: userId });
-    const streakCount = userStreak.filter((user) => {
-      return new Date(user.activityDate).getFullYear() === year;
-    }).length;
+    const today = new Date();
+    const start = new Date(`${year}-01-01`);
+    const end =
+      today.getFullYear() < year ? new Date(`${year}-12-31`) : new Date();
+    const streakCount = await this.streaksRepository.count({
+      where: {
+        userId: userId,
+        activityDate: Between(start, end),
+      },
+    });
     return { streakCount };
   }
 

--- a/apps/api/src/streaks/streaks.service.ts
+++ b/apps/api/src/streaks/streaks.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Streaks } from './entities/streaks.entity';
+
+@Injectable()
+export class StreaksService {
+  constructor(
+    @InjectRepository(Streaks)
+    private readonly streaksRepository: Repository<Streaks>,
+  ) {}
+
+  async getYearlyActivityCount(userId: number, year: number): Promise<number> {
+    const userStreak = await this.streaksRepository.findBy({ userId: userId });
+    return userStreak.filter((user) => {
+      return new Date(user.activityDate).getFullYear() === year;
+    }).length;
+  }
+
+  async recordDailyActivity(userId: number, submittedAt: Date) {
+    const checkDay = await this.streaksRepository.findOneBy({
+      userId: userId,
+      activityDate: submittedAt,
+    });
+    if (checkDay) {
+      return true;
+    }
+    await this.streaksRepository.insert({
+      userId: userId,
+      activityDate: submittedAt,
+    });
+    return true;
+  }
+}

--- a/apps/api/src/streaks/streaks.service.ts
+++ b/apps/api/src/streaks/streaks.service.ts
@@ -47,9 +47,13 @@ export class StreaksService {
     );
 
     const referenceDate = new Date(today);
+    referenceDate.setDate(referenceDate.getDate() - 1);
     while (streakDates.has(referenceDate.getTime())) {
       count++;
       referenceDate.setDate(referenceDate.getDate() - 1);
+    }
+    if (streakDates.has(today.getTime())) {
+      count++;
     }
     return { sequencyDailyCount: count };
   }

--- a/apps/api/src/streaks/streaks.service.ts
+++ b/apps/api/src/streaks/streaks.service.ts
@@ -27,7 +27,7 @@ export class StreaksService {
     return { streakCount };
   }
 
-  async getSequencyDailyCount(
+  async getConsecutiveDayCount(
     userId: number,
   ): Promise<{ sequencyDailyCount: number }> {
     const today = new Date();


### PR DESCRIPTION
## 🔸 작업 내용
- #39 
- #65

## 🔸 고민 했던 부분

### streak/sequence를 어떻게 계산할 것인가
- 오늘 날짜 기준으로 어떻게 연속된 스트릭 일 수를 계산할 수 있을까에 대해 고민하였습니다.
- streak 테이블에 들어가있는 date에 시간 정규화를 하여 모두 동일한 시간을 가지도록 설정하고 while문을 통해 연속이 끊길때까지 계산하였습니다.
- 대부분의 streak 조회시 연속된 날짜를 선정할 때 당일에 스트릭을 갱신하지 않았더라도 연속된 날짜를 보여주는 점을 생각하여 오늘 진행하지 않았어도 count가 정상적으로 노출되도록 구현하였습니다.

## 🔸 참고

| Method | Endpoint | 설명 | 인증 필요 |
|--------|----------|------|----------|
| GET | `/streaks` | 1년 단위 스트릭 누적 횟수 조회 | X (쿠키 기반) |
| GET | `/streaks/sequence` | 오늘 날짜 기준으로 연속 몇 일인지 조회  | X (쿠키 기반) |
| POST | `/streaks` | 지정된 날짜 혹은 오늘 날짜 기준으로 스트릭 데이터 추가 | X (쿠키 기반) |

- /streaks 결과
<img width="408" height="144" alt="image" src="https://github.com/user-attachments/assets/0a276300-a59e-465a-95fa-18f9574ee8ee" />

- /streaks/sequence 결과 (01.05 ~ 01.08 연속)
<img width="536" height="144" alt="image" src="https://github.com/user-attachments/assets/7444f7d5-f9e2-4477-8f6c-b3ed813a5c7e" />

- POST /streak 결과
<img width="408" height="130" alt="image" src="https://github.com/user-attachments/assets/732cb94c-c946-4c14-b5d3-b0e2c1407880" />
