### PR TITLE
마이페이지 초기 구성 및 그래프뷰 초기 정적 렌더링 진행

### DIFF
--- a/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
+++ b/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
@@ -25,8 +25,10 @@ function GraphView({ mockData }: { mockData: GraphData }) {
   React.useEffect(() => {
     if (!ctx || width === 0 || height === 0) return;
 
-    ctx.clearRect(0, 0, width, height);
-    drawGraphView(ctx, initNodeMap, mockData.edges);
+    requestAnimationFrame(() => {
+      ctx.clearRect(0, 0, width, height);
+      drawGraphView(ctx, initNodeMap, mockData.edges);
+    });
   }, [ctx, width, height, initNodeMap, mockData.edges]);
 
   return (

--- a/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
+++ b/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
@@ -1,0 +1,37 @@
+"use client";
+import { useCanvas2D } from "@/hooks/use-canvas-2d";
+import * as React from "react";
+import { mockGraphData } from "../../_constants/graph-mock";
+import { GRAPH_NUMBER_CONSTANT } from "../../_constants/graph-view-constant";
+import drawGraphView from "../../_lib/graph-view/draw-graph-view";
+import generateInitialNodePosition from "../../_lib/graph-view/generate-initial-node-position";
+
+function GraphView() {
+  const canvasRef = React.useRef<HTMLCanvasElement>(null);
+  const { ctx, width, height } = useCanvas2D(canvasRef);
+
+  const mockData = mockGraphData; // 임시 목데이터
+
+  const initNodeMap = React.useMemo(
+    () =>
+      generateInitialNodePosition(
+        mockData.nodes,
+        width,
+        height,
+        GRAPH_NUMBER_CONSTANT.NODE_RADIUS,
+      ),
+    [mockData.nodes, width, height],
+  );
+
+  //초기 렌더링
+  React.useEffect(() => {
+    if (!ctx || width === 0 || height === 0) return;
+
+    ctx.clearRect(0, 0, width, height);
+    drawGraphView(ctx, initNodeMap, mockData.edges);
+  }, [ctx, width, height, initNodeMap, mockData.edges]);
+
+  return <canvas className="w-full h-full" ref={canvasRef}></canvas>;
+}
+
+export default GraphView;

--- a/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
+++ b/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
@@ -25,10 +25,16 @@ function GraphView({ mockData }: { mockData: GraphData }) {
   React.useEffect(() => {
     if (!ctx || width === 0 || height === 0) return;
 
-    requestAnimationFrame(() => {
+    const render = () => {
       ctx.clearRect(0, 0, width, height);
       drawGraphView(ctx, initNodeMap, mockData.edges);
-    });
+    };
+
+    const animationId = requestAnimationFrame(render);
+
+    return () => {
+      cancelAnimationFrame(animationId);
+    };
   }, [ctx, width, height, initNodeMap, mockData.edges]);
 
   return (

--- a/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
+++ b/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
@@ -1,16 +1,14 @@
 "use client";
 import { useCanvas2D } from "@/hooks/use-canvas-2d";
 import * as React from "react";
-import { mockGraphData } from "../../_constants/graph-mock";
 import { GRAPH_NUMBER_CONSTANT } from "../../_constants/graph-view-constant";
 import drawGraphView from "../../_lib/graph-view/draw-graph-view";
 import generateInitialNodePosition from "../../_lib/graph-view/generate-initial-node-position";
+import { GraphData } from "../../types/graph-view";
 
-function GraphView() {
+function GraphView({ mockData }: { mockData: GraphData }) {
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
   const { ctx, width, height } = useCanvas2D(canvasRef);
-
-  const mockData = mockGraphData; // 임시 목데이터
 
   const initNodeMap = React.useMemo(
     () =>
@@ -31,7 +29,12 @@ function GraphView() {
     drawGraphView(ctx, initNodeMap, mockData.edges);
   }, [ctx, width, height, initNodeMap, mockData.edges]);
 
-  return <canvas className="w-full h-full" ref={canvasRef}></canvas>;
+  return (
+    <canvas
+      className="w-full h-full rounded-md border border-gray-300"
+      ref={canvasRef}
+    ></canvas>
+  );
 }
 
 export default GraphView;

--- a/apps/web/src/app/mypage/_components/user-stats-card/user-stats-card.tsx
+++ b/apps/web/src/app/mypage/_components/user-stats-card/user-stats-card.tsx
@@ -1,0 +1,47 @@
+interface UserStatsCardProps {
+  nickname: string;
+  consecutiveDayCount: number;
+  totalPoint: number;
+  totalScore: number;
+}
+
+function UserStatsCard({
+  nickname,
+  consecutiveDayCount,
+  totalPoint,
+  totalScore,
+}: UserStatsCardProps) {
+  return (
+    <div className="flex items-center gap-6 p-6 bg-white rounded-lg border border-gray-200 shadow-sm">
+      <div className="flex-1">
+        <p className="text-sm text-gray-500 mb-1">닉네임</p>
+        <p className="text-2xl font-bold text-gray-900">{nickname}</p>
+      </div>
+
+      <div className="h-12 w-px bg-gray-200" />
+
+      <div className="flex-1">
+        <p className="text-sm text-gray-500 mb-1">연속 출석</p>
+        <p className="text-2xl font-bold text-blue-600">
+          {consecutiveDayCount}일
+        </p>
+      </div>
+
+      <div className="h-12 w-px bg-gray-200" />
+
+      <div className="flex-1">
+        <p className="text-sm text-gray-500 mb-1">총 포인트</p>
+        <p className="text-2xl font-bold text-green-600">{totalPoint}</p>
+      </div>
+
+      <div className="h-12 w-px bg-gray-200" />
+
+      <div className="flex-1">
+        <p className="text-sm text-gray-500 mb-1">총 점수</p>
+        <p className="text-2xl font-bold text-purple-600">{totalScore}</p>
+      </div>
+    </div>
+  );
+}
+
+export default UserStatsCard;

--- a/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.stories.tsx
+++ b/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.stories.tsx
@@ -9,14 +9,6 @@ const meta = {
   },
   tags: ["autodocs"],
   argTypes: {
-    width: {
-      control: { type: "number", min: 200, max: 1000, step: 50 },
-      description: "캔버스 너비",
-    },
-    height: {
-      control: { type: "number", min: 200, max: 800, step: 50 },
-      description: "캔버스 높이",
-    },
     imageSrc: {
       control: "text",
       description: "배경 이미지 URL",
@@ -27,11 +19,16 @@ const meta = {
     },
   },
   args: {
-    width: 600,
-    height: 400,
     imageSrc: "/starry-night.jpg",
     streakCount: 0,
   },
+  decorators: [
+    (Story) => (
+      <div className="w-150 h-100">
+        <Story />
+      </div>
+    ),
+  ],
 } satisfies Meta<typeof VoronoiStreak>;
 
 export default meta;

--- a/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.tsx
+++ b/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.tsx
@@ -109,7 +109,7 @@ function VoronoiStreak({ streakCount, imageSrc }: VoronoiStreakProps) {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    requestAnimationFrame(() => {
+    const render = () => {
       ctx.clearRect(0, 0, width, height);
 
       cellData.forEach((cell) => {
@@ -127,7 +127,13 @@ function VoronoiStreak({ streakCount, imageSrc }: VoronoiStreakProps) {
         ctx.lineWidth = 0.5;
         ctx.stroke(cell.path);
       });
-    });
+    };
+
+    const animationId = requestAnimationFrame(render);
+
+    return () => {
+      cancelAnimationFrame(animationId);
+    };
   }, [cellData, streakCount, width, height]);
   return <canvas className="w-full h-full" ref={canvasRef} />;
 }

--- a/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.tsx
+++ b/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCanvas2D } from "@/hooks/use-canvas-2d";
 import { Delaunay } from "d3-delaunay";
 import { randomLcg } from "d3-random";
 import * as React from "react";
@@ -13,8 +14,6 @@ import generateRandomPoint from "../../_lib/generate-random-point";
 import lloydRelaxation from "../../_lib/lloyd-relaxation";
 
 interface VoronoiStreakProps {
-  width: number;
-  height: number;
   streakCount: number;
   imageSrc: string;
 }
@@ -25,17 +24,13 @@ interface CellData {
   cluster: number;
 }
 
-function VoronoiStreak({
-  width,
-  height,
-  streakCount,
-  imageSrc,
-}: VoronoiStreakProps) {
+function VoronoiStreak({ streakCount, imageSrc }: VoronoiStreakProps) {
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
+  const { width, height } = useCanvas2D(canvasRef);
   const [cellData, setCellData] = React.useState<CellData[]>([]);
 
   React.useEffect(() => {
-    if (!imageSrc) return;
+    if (!imageSrc || width === 0 || height === 0) return;
 
     const image = new Image();
     image.src = imageSrc;
@@ -132,7 +127,7 @@ function VoronoiStreak({
       ctx.stroke(cell.path);
     });
   }, [cellData, streakCount, width, height]);
-  return <canvas ref={canvasRef} width={width} height={height} />;
+  return <canvas className="w-full h-full" ref={canvasRef} />;
 }
 
 export default VoronoiStreak;

--- a/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.tsx
+++ b/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.tsx
@@ -109,22 +109,24 @@ function VoronoiStreak({ streakCount, imageSrc }: VoronoiStreakProps) {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    ctx.clearRect(0, 0, width, height);
+    requestAnimationFrame(() => {
+      ctx.clearRect(0, 0, width, height);
 
-    cellData.forEach((cell) => {
-      ctx.beginPath();
+      cellData.forEach((cell) => {
+        ctx.beginPath();
 
-      if (cell.cluster < streakCount) {
-        ctx.fillStyle = cell.color;
-        ctx.strokeStyle = cell.color;
-      } else {
-        ctx.fillStyle = VORONOI_COLOR_CONSTANT.GRAY;
-        ctx.strokeStyle = VORONOI_COLOR_CONSTANT.WHITE;
-      }
+        if (cell.cluster < streakCount) {
+          ctx.fillStyle = cell.color;
+          ctx.strokeStyle = cell.color;
+        } else {
+          ctx.fillStyle = VORONOI_COLOR_CONSTANT.GRAY;
+          ctx.strokeStyle = VORONOI_COLOR_CONSTANT.WHITE;
+        }
 
-      ctx.fill(cell.path);
-      ctx.lineWidth = 0.5;
-      ctx.stroke(cell.path);
+        ctx.fill(cell.path);
+        ctx.lineWidth = 0.5;
+        ctx.stroke(cell.path);
+      });
     });
   }, [cellData, streakCount, width, height]);
   return <canvas className="w-full h-full" ref={canvasRef} />;

--- a/apps/web/src/app/mypage/_constants/graph-mock.ts
+++ b/apps/web/src/app/mypage/_constants/graph-mock.ts
@@ -1,0 +1,21 @@
+import { GraphData, NodeType } from "../types/graph-view";
+
+export const mockGraphData: GraphData = {
+  nodes: [
+    { id: 1, type: NodeType.QUESTION, label: "React란 무엇인가요?" },
+    { id: 2, type: NodeType.KEYWORD, label: "React" },
+    { id: 3, type: NodeType.KEYWORD, label: "Virtual DOM" },
+    { id: 4, type: NodeType.QUESTION, label: "Virtual DOM의 동작 원리는?" },
+    { id: 5, type: NodeType.KEYWORD, label: "컴포넌트" },
+    { id: 6, type: NodeType.QUESTION, label: "useState와 useEffect 차이점은?" },
+    { id: 7, type: NodeType.KEYWORD, label: "Hook" },
+  ],
+  edges: [
+    { id: 1, sourceId: 1, targetId: 2 },
+    { id: 2, sourceId: 1, targetId: 3 },
+    { id: 3, sourceId: 4, targetId: 3 },
+    { id: 4, sourceId: 1, targetId: 5 },
+    { id: 5, sourceId: 6, targetId: 7 },
+    { id: 6, sourceId: 6, targetId: 2 },
+  ],
+};

--- a/apps/web/src/app/mypage/_constants/graph-view-constant.ts
+++ b/apps/web/src/app/mypage/_constants/graph-view-constant.ts
@@ -1,0 +1,10 @@
+export const GRAPH_NUMBER_CONSTANT = {
+  NODE_RADIUS: 5,
+} as const;
+
+export const GRAPH_COLOR_CONSTANT = {
+  QUESTION_NODE: "#ff7043",
+  KEYWORD_NODE: "#282b2c",
+  EDGE: "#999",
+  LABEL: "#333",
+};

--- a/apps/web/src/app/mypage/_lib/graph-view/draw-graph-view.ts
+++ b/apps/web/src/app/mypage/_lib/graph-view/draw-graph-view.ts
@@ -1,4 +1,7 @@
-import { GRAPH_COLOR_CONSTANT } from "../../_constants/graph-view-constant";
+import {
+  GRAPH_COLOR_CONSTANT,
+  GRAPH_NUMBER_CONSTANT,
+} from "../../_constants/graph-view-constant";
 import {
   GraphEdge,
   GraphNode,
@@ -25,7 +28,7 @@ function drawGraphView(
   });
 
   nodes.forEach((node) => {
-    const radius = 10;
+    const radius = GRAPH_NUMBER_CONSTANT.NODE_RADIUS;
     ctx.beginPath();
     ctx.arc(node.x, node.y, radius, 0, Math.PI * 2);
     ctx.fillStyle =

--- a/apps/web/src/app/mypage/_lib/graph-view/draw-graph-view.ts
+++ b/apps/web/src/app/mypage/_lib/graph-view/draw-graph-view.ts
@@ -1,0 +1,44 @@
+import { GRAPH_COLOR_CONSTANT } from "../../_constants/graph-view-constant";
+import {
+  GraphEdge,
+  GraphNode,
+  NodePosition,
+  NodeType,
+} from "../../types/graph-view";
+
+function drawGraphView(
+  ctx: CanvasRenderingContext2D,
+  nodes: Map<number, GraphNode & NodePosition>,
+  edges: GraphEdge[],
+) {
+  edges.forEach((edge) => {
+    const source = nodes.get(edge.sourceId);
+    const target = nodes.get(edge.targetId);
+    if (!source || !target) return;
+
+    ctx.strokeStyle = GRAPH_COLOR_CONSTANT.EDGE;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(source.x, source.y);
+    ctx.lineTo(target.x, target.y);
+    ctx.stroke();
+  });
+
+  nodes.forEach((node) => {
+    const radius = 10;
+    ctx.beginPath();
+    ctx.arc(node.x, node.y, radius, 0, Math.PI * 2);
+    ctx.fillStyle =
+      node.type === NodeType.QUESTION
+        ? GRAPH_COLOR_CONSTANT.QUESTION_NODE
+        : GRAPH_COLOR_CONSTANT.KEYWORD_NODE;
+    ctx.fill();
+
+    ctx.fillStyle = GRAPH_COLOR_CONSTANT.LABEL;
+    ctx.font = "12px sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillText(node.label, node.x, node.y + radius + 14);
+  });
+}
+
+export default drawGraphView;

--- a/apps/web/src/app/mypage/_lib/graph-view/generate-initial-node-position.ts
+++ b/apps/web/src/app/mypage/_lib/graph-view/generate-initial-node-position.ts
@@ -1,0 +1,19 @@
+import { GraphNode, NodePosition } from "../../types/graph-view";
+
+function generateInitialNodePosition(
+  nodes: GraphNode[],
+  canvasWidth: number,
+  canvasHeight: number,
+  radius: number,
+) {
+  const initialNodes: (GraphNode & NodePosition)[] = nodes.map((node) => ({
+    id: node.id,
+    type: node.type,
+    label: node.label,
+    x: Math.random() * (canvasWidth - radius * 2) + radius,
+    y: Math.random() * (canvasHeight - radius * 2) + radius,
+  }));
+  return new Map(initialNodes.map((node) => [node.id, node]));
+}
+
+export default generateInitialNodePosition;

--- a/apps/web/src/app/mypage/page.tsx
+++ b/apps/web/src/app/mypage/page.tsx
@@ -1,0 +1,95 @@
+import GraphView from "./_components/graph-view/graph-view";
+import VoronoiStreak from "./_components/voronoi-streak/voronoi-streak";
+import { mockGraphData } from "./_constants/graph-mock";
+
+async function MyPage() {
+  //실제 api 연동시 여기에 데이터 패칭 로직
+  const userData = {
+    id: 1,
+    nickname: "김개발",
+    totalPoint: 200,
+    totalScore: 500,
+  };
+  const consecutiveDayCount = 15;
+  const mockData = mockGraphData;
+  const streakCount = 180;
+  const imageSrc = "/starry-night.jpg";
+  return (
+    <main className="max-w-4xl mx-auto p-8 space-y-8 min-h-screen  ">
+      <section className="space-y-4">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">
+            마이페이지
+          </h1>
+          <p className="text-muted-foreground">학습 통계를 확인하세요</p>
+        </div>
+
+        <div className="flex items-center gap-6 p-6 bg-white rounded-lg border border-gray-200 shadow-sm">
+          <div className="flex-1">
+            <p className="text-sm text-gray-500 mb-1">닉네임</p>
+            <p className="text-2xl font-bold text-gray-900">
+              {userData.nickname}
+            </p>
+          </div>
+
+          <div className="h-12 w-px bg-gray-200" />
+
+          <div className="flex-1">
+            <p className="text-sm text-gray-500 mb-1">연속 출석</p>
+            <p className="text-2xl font-bold text-blue-600">
+              {consecutiveDayCount}일
+            </p>
+          </div>
+
+          <div className="h-12 w-px bg-gray-200" />
+
+          <div className="flex-1">
+            <p className="text-sm text-gray-500 mb-1">총 포인트</p>
+            <p className="text-2xl font-bold text-green-600">
+              {userData.totalPoint}
+            </p>
+          </div>
+
+          <div className="h-12 w-px bg-gray-200" />
+
+          <div className="flex-1">
+            <p className="text-sm text-gray-500 mb-1">총 점수</p>
+            <p className="text-2xl font-bold text-purple-600">
+              {userData.totalScore}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="w-full flex flex-col gap-6">
+        <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6">
+          <h2 className="text-xl font-semibold text-gray-900 mb-4">
+            학습 그래프
+          </h2>
+          <div className="h-100">
+            <GraphView mockData={mockData} />
+          </div>
+        </div>
+
+        <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-xl font-semibold text-gray-900">학습 스트릭</h2>
+            <section className="flex gap-1">
+              <span className="text-sm font-medium text-blue-600 bg-blue-50 px-3 py-1 rounded-full">
+                {streakCount}일 달성
+              </span>
+              <span className="text-sm font-medium text-green-600 bg-blue-50 px-3 py-1 rounded-full">
+                {consecutiveDayCount}일 연속
+              </span>
+            </section>
+          </div>
+          <div className="h-100">
+            <VoronoiStreak streakCount={streakCount} imageSrc={imageSrc} />
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+export default MyPage;

--- a/apps/web/src/app/mypage/page.tsx
+++ b/apps/web/src/app/mypage/page.tsx
@@ -1,6 +1,7 @@
+import { BarChart3 } from "lucide-react";
 import GraphView from "./_components/graph-view/graph-view";
+import UserStatsCard from "./_components/user-stats-card/user-stats-card";
 import VoronoiStreak from "./_components/voronoi-streak/voronoi-streak";
-import { mockGraphData } from "./_constants/graph-mock";
 
 async function MyPage() {
   //실제 api 연동시 여기에 데이터 패칭 로직
@@ -10,9 +11,10 @@ async function MyPage() {
     totalPoint: 200,
     totalScore: 500,
   };
-  const consecutiveDayCount = 15;
-  const mockData = mockGraphData;
-  const streakCount = 180;
+  const consecutiveDayCount = 0;
+  // const mockData = mockGraphData;
+  const mockData = { nodes: [], edges: [] };
+  const streakCount = 0;
   const imageSrc = "/starry-night.jpg";
   return (
     <main className="max-w-4xl mx-auto p-8 space-y-8 min-h-screen  ">
@@ -24,41 +26,12 @@ async function MyPage() {
           <p className="text-muted-foreground">학습 통계를 확인하세요</p>
         </div>
 
-        <div className="flex items-center gap-6 p-6 bg-white rounded-lg border border-gray-200 shadow-sm">
-          <div className="flex-1">
-            <p className="text-sm text-gray-500 mb-1">닉네임</p>
-            <p className="text-2xl font-bold text-gray-900">
-              {userData.nickname}
-            </p>
-          </div>
-
-          <div className="h-12 w-px bg-gray-200" />
-
-          <div className="flex-1">
-            <p className="text-sm text-gray-500 mb-1">연속 출석</p>
-            <p className="text-2xl font-bold text-blue-600">
-              {consecutiveDayCount}일
-            </p>
-          </div>
-
-          <div className="h-12 w-px bg-gray-200" />
-
-          <div className="flex-1">
-            <p className="text-sm text-gray-500 mb-1">총 포인트</p>
-            <p className="text-2xl font-bold text-green-600">
-              {userData.totalPoint}
-            </p>
-          </div>
-
-          <div className="h-12 w-px bg-gray-200" />
-
-          <div className="flex-1">
-            <p className="text-sm text-gray-500 mb-1">총 점수</p>
-            <p className="text-2xl font-bold text-purple-600">
-              {userData.totalScore}
-            </p>
-          </div>
-        </div>
+        <UserStatsCard
+          nickname={userData.nickname}
+          consecutiveDayCount={consecutiveDayCount}
+          totalPoint={userData.totalPoint}
+          totalScore={userData.totalScore}
+        />
       </section>
 
       <section className="w-full flex flex-col gap-6">
@@ -67,7 +40,21 @@ async function MyPage() {
             학습 그래프
           </h2>
           <div className="h-100">
-            <GraphView mockData={mockData} />
+            {mockData.nodes.length === 0 && mockData.edges.length === 0 ? (
+              <div className="flex flex-col h-full w-full items-center justify-center py-12 text-center">
+                <div className="w-16 h-16 mb-4 rounded-full bg-gray-100 flex items-center justify-center">
+                  <BarChart3 className="w-8 h-8 text-gray-400" />
+                </div>
+                <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                  아직 학습 데이터가 없습니다
+                </h3>
+                <p className="text-sm text-gray-500">
+                  문제를 풀면 학습 그래프가 생성됩니다
+                </p>
+              </div>
+            ) : (
+              <GraphView mockData={mockData} />
+            )}
           </div>
         </div>
 

--- a/apps/web/src/app/mypage/types/graph-view.ts
+++ b/apps/web/src/app/mypage/types/graph-view.ts
@@ -1,0 +1,26 @@
+export enum NodeType {
+  "QUESTION",
+  "KEYWORD",
+}
+
+export interface GraphNode {
+  id: number;
+  type: NodeType;
+  label: string;
+}
+
+export interface GraphEdge {
+  id: number;
+  sourceId: number;
+  targetId: number;
+}
+
+export interface GraphData {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export interface NodePosition {
+  x: number;
+  y: number;
+}


### PR DESCRIPTION
## 🔸 작업 내용
- #3 
- #7 
- #8 
- voronoi streak 컴포넌트에서 canvas가 컴포넌트 전체 높이 & 넓이 차지하도록 useCanvas2D 훅 연결 부분 추가
- 마이페이지 최상단 유저 정보 보여주기 위한 컴포넌트 추가
- 물리 엔진 연결 및 캔버스 확대 이동은 다음 PR에 추가될 예정

## 🔸 고민 했던 부분
### 엣지가 많은 노드에 대한 노드 크기 변화 여부 결정
- 엣지가 많은 노드일 수록 해당 키워드 / 질문에 대한 가중치를 부여할지에 대한 고민이 있었습니다.
- 엣지가 많은 노드가 곧 중요한 노드는 아니기도 하고, 엣지 자체가 노드와 연결되어 있기 때문에 집중도가 높아질 것이라 생각하고 해당 부분은 제외하게 되었습니다.


## 🔸 참고
1. **문제를 하나도 풀지 않은 상태일 때 마이페이지**
<img width="902" height="1272" alt="image" src="https://github.com/user-attachments/assets/2cb4cf82-dd07-4024-8a91-b5ca3c7f33c1" />

2. **문제를 풀었을 때의 마이페이지**
<img width="900" height="1282" alt="image" src="https://github.com/user-attachments/assets/61423b0f-1768-474b-868b-c048b9cb25b8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MyPage dashboard page with header, user summary card (nickname, attendance, points, score), and streak panel.
  * Interactive canvas-based graph view rendering nodes and edges from mock graph data.
  * Visual streak component now auto-sizes to its container and accepts an image source with smoother canvas rendering.

* **Chores**
  * Added graph types, constants, initial-position logic, mock data, and updated Storybook wrapper for the streak component.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->