### PR TITLE
CodeRabbit 설정 스키마 불일치 문제 수정

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,7 +13,3 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
-
-tools:
-  github-checks:
-    enabled: true


### PR DESCRIPTION
> 샤라웃 투 조엘

## 🔸 작업 내용

- 이미지에 보시는 것 처럼 PR 코멘트에 제일 먼저 추가되는 경고가 있었습니다. 

<img width="717" height="216" alt="스크린샷 2026-01-14 23 26 45" src="https://github.com/user-attachments/assets/9ca77dc1-06db-48c5-b2ba-17659fc4865f" />

- 이 경고는 .coderabbit.yaml 설정 파일에 CodeRabbit이 인식하지 못하는 키가 들어가 있기 때문에 발생한다고 합니다. 
- 찾아보니 핵심 원인은 메시지 그대로 tools라는 설정 항목이 CodeRabbit 스키마에 존재하지 않기 때문이라고 하네요.. ~예전엔 그대로 써도 안떴던거 같은데..기분 탓인가 봅니다.~
- 리뷰에는 큰 문제 없고 단지 코드래빗이 모르는 설정이라고 경고만 출력하는 것이라 다행입니다.

## 🔸 참고

- 처음 설정파일을 추가했을 때 조엘이 알려주셨지만..잘못된 지식을 퍼트린 것 같아 송구스럽습니다!!

<img width="225" height="225" alt="image" src="https://github.com/user-attachments/assets/b099546c-6b8e-4f0b-8887-e1a7ce09752f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 설정 파일 구조가 개선되었습니다. drafts 설정이 상위 수준으로 이동되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->