### PR TITLE
그래프 노드 정보를 반환할 때 questionId를 포함하도록 수정

### DIFF
--- a/apps/api/src/graph/dtos/graph-response.dto.ts
+++ b/apps/api/src/graph/dtos/graph-response.dto.ts
@@ -23,6 +23,13 @@ export class GraphNodeDto {
     example: 'React란 무엇인가요?',
   })
   label: string;
+
+  @ApiProperty({
+    description: '질문 ID (QUESTION 타입일 때만 존재, KEYWORD 타입은 null)',
+    example: 1,
+    nullable: true,
+  })
+  questionId: number | null;
 }
 
 /**
@@ -60,11 +67,13 @@ export class GraphResponseDto {
         id: 1,
         type: 'QUESTION',
         label: 'React란 무엇인가요?',
+        questionId: 1,
       },
       {
         id: 2,
         type: 'KEYWORD',
         label: 'React',
+        questionId: null,
       },
     ],
   })

--- a/apps/api/src/graph/graph.service.ts
+++ b/apps/api/src/graph/graph.service.ts
@@ -92,6 +92,7 @@ export class GraphService {
       id: node.id,
       type: node.type,
       label: node.label,
+      questionId: node.questionId,
     }));
 
     const edgeDtos: GraphEdgeDto[] = edges.map((edge) => ({


### PR DESCRIPTION
## 🔸 작업 내용

- #176 

- 그래프 뷰에서 노드를 클릭하면 바로 리포트 뷰로 전환될 수 있도록 응답 DTO에 질문 ID가 함께 반환되게 수정하였습니다.
  - **엔티티 쪽**: graph-node.entity.ts 에 이미 questionId 컬럼 존재
  - **응답 DTO에 필드 추가/보완**: GraphNodeDto 에 questionId 필드를 nullable 로 정의하고 Swagger 메타 보완
  - **노드 → DTO 변환 시 questionId 포함**: GraphService 에서 DTO로 변환할 때 questionId 를 함께 내려주도록 수정

- 이제 그래프 노드 정보를 반환할 때 각 노드 응답에 questionId(QUESTION 노드면 실제 ID, KEYWORD 노드면 null)가 포함돼서 내려가게 됩니다!

## 🔸 참고

### Swagger 응답 테스트

<img width="647" height="334" alt="스크린샷 2026-01-19 18 46 06" src="https://github.com/user-attachments/assets/593cf47b-cb5c-4ab7-bf59-16ca50782824" />

- 질문이 잘 포함된 것을 볼 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 그래프 응답에 질문 ID 정보가 추가되었습니다. 각 노드는 이제 연관된 질문 ID를 포함하여 더 자세한 데이터를 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->