### PR TITLE
fix: WAV 헤더 추가를 스트림 기반으로 변경하여 메모리 효율 개선

### DIFF
--- a/apps/api/src/audio-stream/audio-stream.service.spec.ts
+++ b/apps/api/src/audio-stream/audio-stream.service.spec.ts
@@ -1,14 +1,16 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 
 jest.mock('fs', () => {
-  // ✅ 원본 fs는 유지(= fs.native 유지)하면서 createWriteStream만 mock
+  // ✅ 원본 fs는 유지(= fs.native 유지)하면서 createWriteStream, createReadStream만 mock
   const actual = jest.requireActual<typeof import('fs')>('fs');
   return {
     ...actual,
     createWriteStream: jest.fn(),
+    createReadStream: jest.fn(),
   };
 });
 
@@ -27,7 +29,8 @@ import { AudioSessionStatus } from './audio-stream.constants';
 
 import { randomUUID } from 'crypto';
 import * as fs from 'fs';
-import { createWriteStream } from 'fs';
+import { createWriteStream, createReadStream } from 'fs';
+import { EventEmitter } from 'events';
 
 describe('AudioStreamService - Unit Tests (TestingModule, fs partial mock)', () => {
   let moduleRef: TestingModule;
@@ -46,10 +49,14 @@ describe('AudioStreamService - Unit Tests (TestingModule, fs partial mock)', () 
 
   const eventEmitterMock = { emit: jest.fn() };
 
-  const writeStreamMock = {
-    write: jest.fn((_: any, cb: (err?: Error | null) => void) => cb(null)),
-    end: jest.fn((cb: (err?: Error | null) => void) => cb(null)),
-  } as any;
+  const createWriteStreamMock = () => {
+    const emitter = new EventEmitter();
+    return Object.assign(emitter, {
+      write: jest.fn((_: any, cb: (err?: Error | null) => void) => cb(null)),
+      end: jest.fn((cb: (err?: Error | null) => void) => cb(null)),
+    });
+  };
+  let writeStreamMock: ReturnType<typeof createWriteStreamMock>;
 
   const FIXED_SESSION_ID = 'session-uuid-1';
   const USER_ID = 7;
@@ -59,16 +66,31 @@ describe('AudioStreamService - Unit Tests (TestingModule, fs partial mock)', () 
   let readFileSpy: jest.SpyInstance;
   let writeFileSpy: jest.SpyInstance;
   let unlinkSpy: jest.SpyInstance;
+  let renameSpy: jest.SpyInstance;
 
   beforeEach(async () => {
     jest.clearAllMocks();
 
     (randomUUID as unknown as jest.Mock).mockReturnValue(FIXED_SESSION_ID);
 
+    // ✅ writeStreamMock 초기화
+    writeStreamMock = createWriteStreamMock();
+
     // ✅ createWriteStream은 spyOn 대신 jest.mock('fs')로 만든 mock 함수에 직접 주입
     (createWriteStream as unknown as jest.Mock).mockReturnValue(
       writeStreamMock,
     );
+
+    // ✅ createReadStream mock - pipe를 위한 EventEmitter 기반 mock
+    const readStreamMock = new EventEmitter() as EventEmitter & {
+      pipe: jest.Mock;
+    };
+    readStreamMock.pipe = jest.fn().mockImplementation((dest) => {
+      // pipe 호출 시 바로 finish 이벤트 발생
+      setImmediate(() => dest.emit('finish'));
+      return dest;
+    });
+    (createReadStream as unknown as jest.Mock).mockReturnValue(readStreamMock);
 
     // ✅ fs.promises는 원본을 유지하므로 spyOn 가능
     mkdirSpy = jest
@@ -90,6 +112,10 @@ describe('AudioStreamService - Unit Tests (TestingModule, fs partial mock)', () 
 
     unlinkSpy = jest
       .spyOn(fs.promises, 'unlink')
+      .mockResolvedValue(undefined as any);
+
+    renameSpy = jest
+      .spyOn(fs.promises, 'rename')
       .mockResolvedValue(undefined as any);
 
     repoMock.create.mockImplementation((dto: any) => dto);
@@ -236,9 +262,10 @@ describe('AudioStreamService - Unit Tests (TestingModule, fs partial mock)', () 
 
       expect(writeStreamMock.end).toHaveBeenCalledTimes(1);
 
-      expect(statSpy).toHaveBeenCalledTimes(2);
-      expect(readFileSpy).toHaveBeenCalledTimes(1);
-      expect(writeFileSpy).toHaveBeenCalledTimes(1);
+      // 스트림 기반 WAV 헤더 추가
+      expect(statSpy).toHaveBeenCalledTimes(1); // pcmDataSize 확인
+      expect(renameSpy).toHaveBeenCalledTimes(1); // PCM 파일 임시 이동
+      expect(unlinkSpy).toHaveBeenCalledTimes(1); // 임시 PCM 파일 삭제
 
       expect(repoMock.create).toHaveBeenCalledTimes(1);
       expect(repoMock.save).toHaveBeenCalledTimes(1);

--- a/apps/api/src/audio-stream/audio-stream.service.ts
+++ b/apps/api/src/audio-stream/audio-stream.service.ts
@@ -196,26 +196,66 @@ export class AudioStreamService {
     const tempPcmPath = `${session.filePath}.pcm`;
     await fs.rename(session.filePath, tempPcmPath);
 
-    await new Promise<void>((resolve, reject) => {
-      const writeStream = createWriteStream(session.filePath);
-      const readStream = createReadStream(tempPcmPath);
+    let streamingSucceeded = false;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const writeStream = createWriteStream(session.filePath);
+        const readStream = createReadStream(tempPcmPath);
 
-      writeStream.write(wavHeader, (err) => {
-        if (err) {
-          reject(err);
-          return;
-        }
+        writeStream.write(wavHeader, (err) => {
+          if (err) {
+            reject(err);
+            return;
+          }
 
-        readStream.pipe(writeStream);
+          readStream.pipe(writeStream);
 
-        writeStream.on('finish', resolve);
-        writeStream.on('error', reject);
-        readStream.on('error', reject);
+          writeStream.on('finish', resolve);
+          writeStream.on('error', reject);
+          readStream.on('error', reject);
+        });
       });
-    });
+      streamingSucceeded = true;
+    } catch (streamError) {
+      this.logger.error(
+        `Failed to create WAV file for session ${session.sessionId}`,
+        streamError,
+      );
 
-    // 임시 PCM 파일 삭제
-    await fs.unlink(tempPcmPath);
+      // 스트리밍 실패 시 원본 PCM 파일 복구 시도
+      try {
+        await fs.rename(tempPcmPath, session.filePath);
+        this.logger.log(
+          `Restored original PCM file for session ${session.sessionId}`,
+        );
+      } catch (restoreError) {
+        this.logger.error(
+          `Failed to restore PCM file for session ${session.sessionId}`,
+          restoreError,
+        );
+      }
+
+      throw streamError;
+    } finally {
+      // 스트리밍 성공 시에만 임시 파일 삭제 (실패 시 위에서 복구됨)
+      if (streamingSucceeded) {
+        try {
+          await fs.unlink(tempPcmPath);
+        } catch (unlinkError) {
+          // ENOENT는 무시 (이미 삭제된 경우)
+          const isEnoent =
+            unlinkError instanceof Error &&
+            'code' in unlinkError &&
+            (unlinkError as NodeJS.ErrnoException).code === 'ENOENT';
+          if (!isEnoent) {
+            this.logger.warn(
+              `Failed to delete temp PCM file: ${tempPcmPath}`,
+              unlinkError,
+            );
+          }
+        }
+      }
+    }
 
     // 최종 파일 크기 확인
     const byteSize = pcmDataSize + wavHeader.length;

--- a/apps/api/src/audio-stream/audio-stream.service.ts
+++ b/apps/api/src/audio-stream/audio-stream.service.ts
@@ -202,17 +202,34 @@ export class AudioStreamService {
         const writeStream = createWriteStream(session.filePath);
         const readStream = createReadStream(tempPcmPath);
 
-        writeStream.write(wavHeader, (err) => {
+        let resolved = false;
+        const cleanup = (err?: Error) => {
+          if (resolved) return;
+          resolved = true;
+          readStream.destroy();
+          writeStream.destroy();
           if (err) {
             reject(err);
+          }
+        };
+
+        // 스트림 생성 직후 에러 리스너 등록 (파일 열기 실패 등 조기 에러 포착)
+        writeStream.on('error', (err) => cleanup(err));
+        readStream.on('error', (err) => cleanup(err));
+        writeStream.on('finish', () => {
+          if (!resolved) {
+            resolved = true;
+            resolve();
+          }
+        });
+
+        // WAV 헤더 쓰기 후 PCM 데이터 pipe
+        writeStream.write(wavHeader, (err) => {
+          if (err) {
+            cleanup(err);
             return;
           }
-
           readStream.pipe(writeStream);
-
-          writeStream.on('finish', resolve);
-          writeStream.on('error', reject);
-          readStream.on('error', reject);
         });
       });
       streamingSucceeded = true;

--- a/apps/api/src/audio-stream/audio-stream.service.ts
+++ b/apps/api/src/audio-stream/audio-stream.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { randomUUID } from 'crypto';
-import { createWriteStream, WriteStream } from 'fs';
+import { createWriteStream, createReadStream, WriteStream } from 'fs';
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import { AudioAsset, AudioUploadStatus } from './entities/audio-asset.entity';
@@ -192,15 +192,33 @@ export class AudioStreamService {
       pcmDataSize,
     );
 
-    // 임시 파일로 PCM 데이터 읽기
-    const pcmData = await fs.readFile(session.filePath);
+    // 스트림 기반으로 WAV 헤더 추가 (메모리 효율적)
+    const tempPcmPath = `${session.filePath}.pcm`;
+    await fs.rename(session.filePath, tempPcmPath);
 
-    // WAV 헤더 + PCM 데이터로 최종 파일 작성
-    await fs.writeFile(session.filePath, Buffer.concat([wavHeader, pcmData]));
+    await new Promise<void>((resolve, reject) => {
+      const writeStream = createWriteStream(session.filePath);
+      const readStream = createReadStream(tempPcmPath);
+
+      writeStream.write(wavHeader, (err) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+
+        readStream.pipe(writeStream);
+
+        writeStream.on('finish', resolve);
+        writeStream.on('error', reject);
+        readStream.on('error', reject);
+      });
+    });
+
+    // 임시 PCM 파일 삭제
+    await fs.unlink(tempPcmPath);
 
     // 최종 파일 크기 확인
-    const finalStats = await fs.stat(session.filePath);
-    const byteSize = finalStats.size;
+    const byteSize = pcmDataSize + wavHeader.length;
 
     const fileName = path.basename(session.filePath);
 


### PR DESCRIPTION
## 🔸 작업 내용

- fs.readFile/writeFile 대신 createReadStream/createWriteStream 사용
- 동시 finalize 시 메모리 사용량 대폭 감소 (200명 기준 ~3.8GB → ~13MB)
- 대용량 파일 처리 시 OOM 위험 제거

## 🔸 고민 했던 부분

- 기존에 stream을 사용안하고 바로 `fs.readFile()`을 사용해서 동시에 제출을 누르면 OOM이 터질 수 있는 문제가 있었습니다.
- 따라서 한번에 파일을 읽는 것이 아니라 스트림으로 읽는 방식으로 변경했습니다.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 오디오 처리 방식을 메모리 기반에서 스트리밍 기반으로 전환하여 메모리 사용과 대용량 파일 처리 개선
  * 임시 파일 이름 변경 및 스트리밍 기반 조립으로 실패 시 복구 로직과 정리(cleanup) 강화
  * WAV 헤더 처리 및 최종 크기 계산 방식 개선

* **테스트**
  * 스트리밍 흐름을 반영하도록 단위 테스트와 모킹이 강화됨

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->