### PR TITLE
뷰포트 변경으로 canvas 크기 변화시 nodeMap 인스턴스 새로 만들지 않도록 수정

### DIFF
--- a/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
+++ b/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
@@ -9,11 +9,15 @@ interface GraphViewProps {
   graphData: GraphData;
   textRenderScale?: number;
   clickEventDisabled?: boolean;
+  nodeMap?: NodeMap;
+  changeNodeMap?: (map: NodeMap) => void;
 }
 function GraphView({
   graphData,
   textRenderScale,
   clickEventDisabled,
+  nodeMap,
+  changeNodeMap,
 }: GraphViewProps) {
   // canvasRef: Canvas DOM 참조
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
@@ -21,13 +25,16 @@ function GraphView({
   const { ctx, width, height } = useCanvas2D(canvasRef);
 
   // nodeMapRef: NodeMap 인스턴스를 관리하는 ref
-  const nodeMapRef = React.useRef<NodeMap | null>(null);
+  const nodeMapRef = React.useRef<NodeMap | null>(nodeMap || null);
 
-  // NodeMap 초기화 (캔버스 크기나 노드 데이터가 변경될 때만 재생성)
+  // NodeMap 초기화
   React.useEffect(() => {
     if (width === 0 || height === 0) return;
+    // nodeMap을 props로 받았았을 때 초기화 안되게
+    // nodeMap이 존재할 때 width, height이 변경되도 초기화안되게
+    if (nodeMap || nodeMapRef.current) return;
     nodeMapRef.current = new NodeMap(graphData.nodes, width, height);
-  }, [width, height, graphData.nodes]);
+  }, [width, height, graphData.nodes, nodeMap]);
 
   // 캔버스 인터랙션 훅에서 반환된 값들
   // offset: 캔버스 이동 오프셋, scale: 줌 레벨
@@ -79,6 +86,10 @@ function GraphView({
         textRenderScale,
       );
 
+      if (changeNodeMap) {
+        changeNodeMap(nodeMapRef.current);
+      }
+
       // 3. 애니메이션 지속 조건 확인
       // 모든 노드의 속도가 0이면 수렴한 것으로 판단
       const isStable = nodeMapRef.current.checkStable();
@@ -103,6 +114,7 @@ function GraphView({
     activeInteraction,
     hoveredNodeId,
     textRenderScale,
+    changeNodeMap,
   ]);
 
   return (

--- a/apps/web/src/app/mypage/_components/graph-view/use-graph-interaction.ts
+++ b/apps/web/src/app/mypage/_components/graph-view/use-graph-interaction.ts
@@ -63,7 +63,7 @@ function useGraphInteraction(
       const y = (screenY - rect.top - offset.current.y) / scale.current;
       return { x, y };
     },
-    [canvasRef, offset, scale],
+    [canvasRef],
   );
 
   // 캔버스 내의 좌표에서 해당하는 노드가 있는지 확인하고, 있으면 해당 node 리턴

--- a/apps/web/src/app/mypage/_contents/graph-content.tsx
+++ b/apps/web/src/app/mypage/_contents/graph-content.tsx
@@ -2,18 +2,25 @@
 import { BarChart3, Maximize2 } from "lucide-react";
 import * as React from "react";
 import GraphView from "../_components/graph-view/graph-view";
+import NodeMap from "../_components/graph-view/node-map";
 import { GraphData } from "../_types/graph-view";
 
 function GraphContent({ graphData }: { graphData: GraphData }) {
   const [openModalStatus, setOpenModalStatus] = React.useState(false);
+  const [nodeMap, setNodeMap] = React.useState<NodeMap>();
 
-  const handleModalOpen = () => {
+  const handleModalOpen = React.useCallback(() => {
     setOpenModalStatus(true);
-  };
+  }, []);
 
-  const handleModalClose = () => {
+  const handleModalClose = React.useCallback(() => {
     setOpenModalStatus(false);
-  };
+  }, []);
+
+  const changeNodeMap = React.useCallback((map: NodeMap) => {
+    setNodeMap(map);
+  }, []);
+
   return (
     <>
       <div className="flex py-8 justify-between items-center">
@@ -44,7 +51,7 @@ function GraphContent({ graphData }: { graphData: GraphData }) {
           </p>
         </div>
       ) : (
-        <GraphView graphData={graphData} />
+        <GraphView graphData={graphData} changeNodeMap={changeNodeMap} />
       )}
       {openModalStatus && (
         <div
@@ -56,7 +63,7 @@ function GraphContent({ graphData }: { graphData: GraphData }) {
             className="bg-white rounded-2xl w-full h-full max-w-5xl max-h-5/6 shadow-xl overflow-hidden relative"
           >
             <div className="w-full h-full ">
-              <GraphView graphData={graphData} />
+              <GraphView graphData={graphData} nodeMap={nodeMap} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 🔸 작업 내용

- 뷰포트 변경으로 canvas 크기 변화시 노드맵 인스턴스가 재생성되는 문제를 해결하였습니다.
- 마이페이지에서 모달로 그래프뷰 확대시 새롭게 인스턴스가 생성되고 조정되는 것이 아닌 기존에 있던 인스턴스를 활용하고, 중앙으로만 배치될 수 있도록 수정하였습니다.

## 🔸 참고


https://github.com/user-attachments/assets/830c2a42-8b22-4507-9ad3-29cdc37b336e


https://github.com/user-attachments/assets/995334ef-d823-4b15-8068-b37cde6a8823



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 그래프 렌더링 및 상태 관리 최적화로 애니메이션 성능 향상
  * 불필요한 콜백 재생성을 방지하여 렌더링 효율성 개선

* **리팩토링**
  * 그래프 뷰 컴포넌트의 내부 상태 관리 구조 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->