### PR TITLE
헤더, 푸터, 랜딩 페이지 구현

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,7 +1,9 @@
+import Footer from "@/components/footer/footer";
+import Header from "@/components/header/header";
+import { cn } from "@/lib/cn";
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
-import { cn } from "@/lib/cn";
 
 const pretendard = localFont({
   src: "../assets/fonts/PretendardVariable.woff2",
@@ -19,8 +21,15 @@ interface RootLayoutProps {
 function RootLayout({ children }: Readonly<RootLayoutProps>) {
   return (
     <html lang="ko">
-      <body className={cn(pretendard.className, "antialiased bg-slate-50")}>
+      <body
+        className={cn(
+          pretendard.className,
+          "antialiased bg-slate-50 w-screen flex flex-col items-center",
+        )}
+      >
+        <Header />
         {children}
+        <Footer />
       </body>
     </html>
   );

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -24,7 +24,7 @@ function RootLayout({ children }: Readonly<RootLayoutProps>) {
       <body
         className={cn(
           pretendard.className,
-          "antialiased bg-slate-50 w-screen flex flex-col items-center",
+          "antialiased bg-slate-50 w-full flex flex-col items-center",
         )}
       >
         <Header />

--- a/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
+++ b/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
@@ -124,7 +124,7 @@ function GraphView({
     // onMouseUp: 드래그 종료
     // onMouseLeave: 캔버스 밖으로 나갈 때 드래그 종료 (마우스 업과 동일한 처리)
     <canvas
-      className="w-full h-full rounded-md border border-gray-300 "
+      className="w-full h-full  "
       ref={canvasRef}
       onMouseDown={handleMouseDown}
       onMouseMove={handleMouseMove}

--- a/apps/web/src/app/mypage/_contents/graph-content.tsx
+++ b/apps/web/src/app/mypage/_contents/graph-content.tsx
@@ -51,7 +51,9 @@ function GraphContent({ graphData }: { graphData: GraphData }) {
           </p>
         </div>
       ) : (
-        <GraphView graphData={graphData} changeNodeMap={changeNodeMap} />
+        <div className="border border-slate-200 rounded-md">
+          <GraphView graphData={graphData} changeNodeMap={changeNodeMap} />
+        </div>
       )}
       {openModalStatus && (
         <div

--- a/apps/web/src/app/mypage/page.tsx
+++ b/apps/web/src/app/mypage/page.tsx
@@ -5,6 +5,8 @@ import {
   TabsTrigger,
 } from "@/components/tabs/tabs";
 import { BookText, Brush, CircleCheckBig } from "lucide-react";
+import { redirect } from "next/navigation";
+import { getCurrentUser } from "../(auth)/_utils/auth";
 import UserStatsCard from "./_components/user-stats-card/user-stats-card";
 import { mockGraphData } from "./_constants/graph-mock";
 import GraphContent from "./_contents/graph-content";
@@ -15,6 +17,10 @@ import { fetchStreaks } from "./_lib/fetch/fetch-streaks";
 import { fetchUserInfo } from "./_lib/fetch/fetch-user-info";
 
 async function MyPage() {
+  const user = await getCurrentUser();
+  if (!user) {
+    redirect("/login");
+  }
   const [userData, _graphData, streakData] = await Promise.all([
     fetchUserInfo(),
     fetchGraph(),

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -11,7 +11,7 @@ async function Home() {
   return (
     <main className="w-full h-full flex flex-col bg-white overflow-x-hidden">
       <section className="w-full relative py-16 px-8 flex justify-center overflow-hidden">
-        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col justify-center items-center z-10 gap-6 lg:gap-10 w-full px-4 lg:px-0 py-40 xl:pt-0 pointer-events-none">
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col justify-center items-center z-10 gap-6 lg:gap-10 w-full px-4 lg:px-0 py-40 xl:pt-0">
           <span className="bg-white border border-teal-100 rounded-[50px] px-4 py-2 text-teal-500 font-bold text-xs ">
             AI 지식 구조화 서비스
           </span>
@@ -27,7 +27,7 @@ async function Home() {
             <br />
             말만해가 당신의 머릿속 지식을 체계적으로 구조화해 드립니다.
           </p>
-          <div className="flex flex-col lg:flex-row gap-4 pointer-events-auto">
+          <div className="flex flex-col lg:flex-row gap-4">
             <Link
               href={!user ? "/login" : "/mypage"}
               className="flex gap-1 text-white bg-teal-400 rounded-[50px] px-6 py-3 lg:px-9 lg:py-4 text-base lg:text-lg font-bold items-center justify-center"
@@ -45,7 +45,11 @@ async function Home() {
           </div>
         </div>
         <div className="opacity-30 w-full lg:w-4/5">
-          <GraphView graphData={mockData} textRenderScale={1.2} />
+          <GraphView
+            graphData={mockData}
+            textRenderScale={1.2}
+            clickEventDisabled={true}
+          />
         </div>
       </section>
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,88 +1,91 @@
 import { Activity, ArrowRight, Mic, Share2 } from "lucide-react";
 import Link from "next/link";
+import { getCurrentUser } from "./(auth)/_utils/auth";
 import GraphView from "./mypage/_components/graph-view/graph-view";
 import { mockGraphData } from "./mypage/_constants/graph-mock";
 
 async function Home() {
   const mockData = mockGraphData;
+  const user = await getCurrentUser();
+
   return (
-    <main className="w-full h-full flex flex-col bg-white">
-      <section className="w-full relative py-16 px-48 flex justify-center">
-        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col justify-center items-center z-10 gap-10">
+    <main className="w-full h-full flex flex-col bg-white overflow-x-hidden">
+      <section className="w-full relative py-16 px-8 flex justify-center overflow-hidden">
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col justify-center items-center z-10 gap-6 lg:gap-10 w-full px-4 lg:px-0 py-40 xl:pt-0 pointer-events-none">
           <span className="bg-white border border-teal-100 rounded-[50px] px-4 py-2 text-teal-500 font-bold text-xs ">
             AI 지식 구조화 서비스
           </span>
-          <span className="font-bold text-6xl text-center">
+          <span className="font-bold text-4xl lg:text-6xl text-center">
             말로 설명하며 완성하는
             <br />
-            <span className="font-extrabold text-[64px] bg-linear-to-r from-[#039484] via-[#2CD1BF] to-[#039484] bg-clip-text text-transparent">
+            <span className="font-extrabold text-4xl lg:text-[64px] bg-linear-to-r from-[#039484] via-[#2CD1BF] to-[#039484] bg-clip-text text-transparent">
               나만의 지식 지도
             </span>
           </span>
-          <p className="text-slate-500 text-center font-medium text-xl">
+          <p className="text-slate-500 text-center font-medium text-base lg:text-xl">
             단편적인 CS지식, 이제는 연결하세요.
             <br />
             말만해가 당신의 머릿속 지식을 체계적으로 구조화해 드립니다.
           </p>
-          <div className="flex gap-4 ">
+          <div className="flex flex-col lg:flex-row gap-4 pointer-events-auto">
             <Link
-              href="/questions"
-              className="flex gap-1 text-white bg-teal-400 rounded-[50px] px-9 py-4 text-lg font-bold items-center"
+              href={!user ? "/login" : "/mypage"}
+              className="flex gap-1 text-white bg-teal-400 rounded-[50px] px-6 py-3 lg:px-9 lg:py-4 text-base lg:text-lg font-bold items-center justify-center"
             >
               지금 무료로 시작하기
               <ArrowRight className="w-4 h-4" />
             </Link>
             <Link
-              href="/guide"
-              className="flex bg-white border border-slate-300 py-4 px-9 gap-1 rounded-[50px] items-center font-bold text-slate-600 text-lg"
+              href="/"
+              className="flex bg-white border border-slate-300 py-3 px-6 lg:py-4 lg:px-9 gap-1 rounded-[50px] items-center justify-center font-bold text-slate-600 text-base lg:text-lg cursor-not-allowed"
             >
               <ArrowRight className="w-4 h-4" stroke="#475569" />
               사용 가이드
             </Link>
           </div>
         </div>
-        <div className="opacity-40 w-4/5">
+        <div className="opacity-30 w-full lg:w-4/5">
           <GraphView graphData={mockData} textRenderScale={1.2} />
         </div>
       </section>
 
-      <section className="flex flex-col items-center px-48 py-16  border-slate-200 mb-34">
-        <span className="text-slate-900 font-bold text-[32px]">
+      <section className="flex flex-col items-center px-8 lg:px-48 py-16 border-slate-200 mb-34">
+        <span className="text-slate-900 font-bold text-2xl lg:text-[32px]">
           학습의 새로운 패러다임
         </span>
-        <div className="text-slate-500 font-medium text-lg pt-6 text-center">
+        <div className="text-slate-500 font-medium text-base lg:text-lg pt-6 text-center">
           단순한 암기가 아닙니다.{" "}
           <span className="text-teal-600 font-bold">말만해</span>는 당신이 아는
           것을 구조적으로 연결하고, <br />
           실제로 설명할 수 있는 살아있는 지식으로 만듭니다.
         </div>
-        <div className="w-full flex gap-7 pt-16 justify-center items-center">
-          <article className="max-w-83 flex-1 bg-teal-50 flex flex-col py-9 px-10 justify-center items-center gap-4 rounded-xl">
+        <div className="w-full flex flex-col xl:flex-row gap-4 lg:gap-7 pt-16 justify-center items-center lg:items-stretch">
+          <article className="w-full  bg-teal-50 flex flex-col py-6 px-4 lg:py-9 lg:px-10 justify-center items-center gap-4 rounded-xl">
             <Mic stroke="#475569" className="w-6 h-6" />
-            <span className="text-teal-700 font-bold text-xl">
+            <span className="text-teal-700 font-bold text-base lg:text-xl">
               음성 인출 연습
             </span>
-            <span className="text-slate-600 font-medium text-base text-pretty text-center">
+            <span className="text-slate-600 font-medium text-sm lg:text-base text-balance text-center">
               눈으로 읽는 공부는 그만. 실제 면접처럼 말로 설명하며 내가 무엇을
               모르는지 메타인지를 높입니다.
             </span>
           </article>
-          <article className=" max-w-83 flex-1 bg-teal-50 flex flex-col py-9 px-10 justify-center items-center gap-4 rounded-xl">
+          <article className="w-full  bg-teal-50 flex flex-col py-6 px-4 lg:py-9 lg:px-10 justify-center items-center gap-4 rounded-xl">
             <Activity stroke="#475569" className="w-6 h-6" />
-            <span className="text-teal-700 font-bold text-xl">
+            <span className="text-teal-700 font-bold text-base lg:text-xl">
               5가지 지표 분석
             </span>
-            <span className="text-slate-600 font-medium text-base text-pretty text-center">
+            <span className="text-slate-600 font-medium text-sm lg:text-base text-balance text-center">
               정확성, 논리성, 심층성, 완성도, 실무 활용도. AI가 다각도로 분석한
               리포트를 매일 받아보세요.
             </span>
           </article>
-          <article className="max-w-83 flex-1 bg-teal-50 flex flex-col py-9 px-10 justify-center items-center gap-4 rounded-xl">
+          <article className="w-full  bg-teal-50 flex flex-col py-6 px-4 lg:py-9 lg:px-10 justify-center items-center gap-4 rounded-xl">
             <Share2 stroke="#475569" className="w-6 h-6" />
-            <span className="text-teal-700 font-bold text-xl">
+            <span className="text-teal-700 font-bold text-base lg:text-xl">
               지식 그래프 연결
             </span>
-            <span className="text-slate-600 font-medium text-base text-pretty text-center">
+            <span className="text-slate-600 font-medium text-sm lg:text-base text-balance text-center">
               파편화된 개념들을 연결하여 나만의 지식 지도를 만듭니다. 꼬리에
               꼬리를 무는 질문에 대비하세요.
             </span>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,23 +1,95 @@
-import Header from "@/components/header";
+import { Activity, ArrowRight, Mic, Share2 } from "lucide-react";
+import Link from "next/link";
 import GraphView from "./mypage/_components/graph-view/graph-view";
 import { mockGraphData } from "./mypage/_constants/graph-mock";
 
-function Home() {
+async function Home() {
   const mockData = mockGraphData;
   return (
-    <div className="flex min-h-screen flex-col bg-zinc-50 dark:bg-black">
-      <Header />
-      <div className="w-full h-full relative">
-        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col justify-center items-center z-10">
-          <div className="text-5xl w-full font-bold">
-            말로 설명하며 완성하는 나만의 지식 지도
+    <main className="w-full h-full flex flex-col bg-white">
+      <section className="w-full relative py-16 px-48 flex justify-center">
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col justify-center items-center z-10 gap-10">
+          <span className="bg-white border border-teal-100 rounded-[50px] px-4 py-2 text-teal-500 font-bold text-xs ">
+            AI 지식 구조화 서비스
+          </span>
+          <span className="font-bold text-6xl text-center">
+            말로 설명하며 완성하는
+            <br />
+            <span className="font-extrabold text-[64px] bg-linear-to-r from-[#039484] via-[#2CD1BF] to-[#039484] bg-clip-text text-transparent">
+              나만의 지식 지도
+            </span>
+          </span>
+          <p className="text-slate-500 text-center font-medium text-xl">
+            단편적인 CS지식, 이제는 연결하세요.
+            <br />
+            말만해가 당신의 머릿속 지식을 체계적으로 구조화해 드립니다.
+          </p>
+          <div className="flex gap-4 ">
+            <Link
+              href="/questions"
+              className="flex gap-1 text-white bg-teal-400 rounded-[50px] px-9 py-4 text-lg font-bold items-center"
+            >
+              지금 무료로 시작하기
+              <ArrowRight className="w-4 h-4" />
+            </Link>
+            <Link
+              href="/guide"
+              className="flex bg-white border border-slate-300 py-4 px-9 gap-1 rounded-[50px] items-center font-bold text-slate-600 text-lg"
+            >
+              <ArrowRight className="w-4 h-4" stroke="#475569" />
+              사용 가이드
+            </Link>
           </div>
         </div>
-        <div className="opacity-20">
+        <div className="opacity-40 w-4/5">
           <GraphView graphData={mockData} textRenderScale={1.2} />
         </div>
-      </div>
-    </div>
+      </section>
+
+      <section className="flex flex-col items-center px-48 py-16  border-slate-200 mb-34">
+        <span className="text-slate-900 font-bold text-[32px]">
+          학습의 새로운 패러다임
+        </span>
+        <div className="text-slate-500 font-medium text-lg pt-6 text-center">
+          단순한 암기가 아닙니다.{" "}
+          <span className="text-teal-600 font-bold">말만해</span>는 당신이 아는
+          것을 구조적으로 연결하고, <br />
+          실제로 설명할 수 있는 살아있는 지식으로 만듭니다.
+        </div>
+        <div className="w-full flex gap-7 pt-16 justify-center items-center">
+          <article className="max-w-83 flex-1 bg-teal-50 flex flex-col py-9 px-10 justify-center items-center gap-4 rounded-xl">
+            <Mic stroke="#475569" className="w-6 h-6" />
+            <span className="text-teal-700 font-bold text-xl">
+              음성 인출 연습
+            </span>
+            <span className="text-slate-600 font-medium text-base text-pretty text-center">
+              눈으로 읽는 공부는 그만. 실제 면접처럼 말로 설명하며 내가 무엇을
+              모르는지 메타인지를 높입니다.
+            </span>
+          </article>
+          <article className=" max-w-83 flex-1 bg-teal-50 flex flex-col py-9 px-10 justify-center items-center gap-4 rounded-xl">
+            <Activity stroke="#475569" className="w-6 h-6" />
+            <span className="text-teal-700 font-bold text-xl">
+              5가지 지표 분석
+            </span>
+            <span className="text-slate-600 font-medium text-base text-pretty text-center">
+              정확성, 논리성, 심층성, 완성도, 실무 활용도. AI가 다각도로 분석한
+              리포트를 매일 받아보세요.
+            </span>
+          </article>
+          <article className="max-w-83 flex-1 bg-teal-50 flex flex-col py-9 px-10 justify-center items-center gap-4 rounded-xl">
+            <Share2 stroke="#475569" className="w-6 h-6" />
+            <span className="text-teal-700 font-bold text-xl">
+              지식 그래프 연결
+            </span>
+            <span className="text-slate-600 font-medium text-base text-pretty text-center">
+              파편화된 개념들을 연결하여 나만의 지식 지도를 만듭니다. 꼬리에
+              꼬리를 무는 질문에 대비하세요.
+            </span>
+          </article>
+        </div>
+      </section>
+    </main>
   );
 }
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -53,7 +53,7 @@ async function Home() {
         </div>
       </section>
 
-      <section className="flex flex-col items-center px-8 lg:px-48 py-16 border-slate-200 mb-34">
+      <section className="flex flex-col items-center px-8 lg:px-48 py-16 border-slate-200 mb-32">
         <span className="text-slate-900 font-bold text-2xl lg:text-[32px]">
           학습의 새로운 패러다임
         </span>

--- a/apps/web/src/components/footer/footer.tsx
+++ b/apps/web/src/components/footer/footer.tsx
@@ -1,0 +1,20 @@
+import Image from "next/image";
+
+async function Footer() {
+  return (
+    <div className="w-full bg-white flex flex-col justify-center items-center py-16 gap-6 border-t border-slate-200">
+      <div className="flex flex-col">
+        <div className="flex gap-2 items-center">
+          <Image width={32} height={32} src={"/mmh-logo.svg"} alt="logo" />
+          <div className="font-bold text-xl text-slate-700">말만해</div>
+        </div>
+      </div>
+      <div className="flex flex-col gap-3 text-slate-400 text-center">
+        <span>© 2026 Malmanhae. All rights reserved.</span>
+        <span>AI 기반 CS 지식 구조화 플랫폼</span>
+      </div>
+    </div>
+  );
+}
+
+export default Footer;

--- a/apps/web/src/components/header/header.tsx
+++ b/apps/web/src/components/header/header.tsx
@@ -1,0 +1,47 @@
+import { getCurrentUser } from "@/app/(auth)/_utils/auth";
+import { User } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+
+async function Header() {
+  const user = await getCurrentUser();
+
+  return (
+    <div className="sticky top-0 z-40 w-full flex justify-center items-center bg-white  border-slate-200 border-b ">
+      <div className="w-full max-w-5xl px-8 h-16 flex justify-between items-center ">
+        <Link href={"/"} className="flex gap-2 items-center">
+          <Image width={32} height={32} src={"/mmh-logo.svg"} alt="logo" />
+          <div className="font-bold text-xl text-slate-700">말만해</div>
+        </Link>
+        <section className="flex gap-2.5 items-center">
+          <Link
+            className="py-2 px-3.5 font-medium text-base rounded-xl text-slate-500 hover:bg-teal-50 hover:text-teal-500 hover:font-semibold"
+            href={"/daily/questions"}
+          >
+            문제 리스트
+          </Link>
+          <Link
+            className="py-2 px-3.5 font-medium text-base rounded-xl text-slate-500 hover:bg-teal-50 hover:text-teal-500 hover:font-semibold"
+            href={"/mypage"}
+          >
+            마이페이지
+          </Link>
+          {!user ? (
+            <Link
+              href="/login"
+              className="text-white bg-teal-400 px-3.5 py-2 rounded-xl font-semibold text-base"
+            >
+              로그인
+            </Link>
+          ) : (
+            <div className="flex justify-center items-center rounded-full bg-teal-50 w-8 h-8">
+              <User stroke="#14B8A6" className="w-6 h-6" />
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}
+
+export default Header;


### PR DESCRIPTION
## 🔸 작업 내용
- #214 
- 헤더 컴포넌트 구현
- 푸터 컴포넌트 구현
- root의 layout.tsx에 header, footer 컴포넌트 적용
- 랜딩페이지 구현

## 🔸 고민 했던 부분

### 랜딩페이지 반응형을 어디까지 신경써야할까
- 저희 서비스 특성상 모바일환경에서 접속하지 않고 PC환경에서만 접근할 것으로 생각했습니다.
- 작은 모니터를 사용하면서 화면을 1/2로 나누고 진행하면 랜딩페이지의 레이아웃이 이상해지는 문제가 있는 것을 확인하였습니다.
- 1024px을 기준으로 레이아웃을 적용하여 반응형 문제 간단하게 처리하였습니다.

## 🔸 참고

https://github.com/user-attachments/assets/ece3a11e-b5f6-452c-8341-e45403d1b65d


https://github.com/user-attachments/assets/5faa15d3-97c9-4f7d-a20e-3494438b7d34




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 모든 페이지에 헤더 및 푸터 추가
  * 홈에 새로운 히어로 섹션과 3개 기능 카드(음성 연습, 5지표 분석, 지식 그래프) 추가
  * 로그인 상태에 따라 CTA 대상이 동적으로 변경

* **버그 수정**
  * 마이페이지 접근 시 인증 검사 추가로 미인증 사용자 리다이렉트 적용

* **스타일/UI**
  * 홈 그래프 상호작용 비활성화 및 그래프 주변 레이아웃/캔버스 스타일 조정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->