### PR TITLE
마이페이지 문제 목록 조회 API 추가

### DIFF
--- a/apps/api/src/user/dtos/response/solved-problem.dto.ts
+++ b/apps/api/src/user/dtos/response/solved-problem.dto.ts
@@ -33,4 +33,10 @@ export class SolvedProblemDto {
     example: 123,
   })
   reportId: number;
+
+  @ApiProperty({
+    description: '문제 풀이 점수 (0~100)',
+    example: 85,
+  })
+  score: number;
 }

--- a/apps/api/src/user/dtos/response/solved-problem.dto.ts
+++ b/apps/api/src/user/dtos/response/solved-problem.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * 푼 문제 단건 응답 DTO
+ */
+export class SolvedProblemDto {
+  @ApiProperty({
+    description: '문제 ID',
+    example: 1,
+  })
+  questionId: number;
+
+  @ApiProperty({
+    description: '문제 제목',
+    example: 'React란 무엇인가요?',
+  })
+  title: string;
+
+  @ApiProperty({
+    description: '문제 분류(카테고리)',
+    example: '프론트엔드',
+  })
+  category: string;
+
+  @ApiProperty({
+    description: '풀이 완료 시각 (ISO-8601 포맷)',
+    example: '2026-01-21T10:30:00.000Z',
+  })
+  completedAt: string;
+
+  @ApiProperty({
+    description: '리포트 ID (제출 ID)',
+    example: 123,
+  })
+  reportId: number;
+}

--- a/apps/api/src/user/dtos/response/solved-problems-list-response.dto.ts
+++ b/apps/api/src/user/dtos/response/solved-problems-list-response.dto.ts
@@ -16,16 +16,4 @@ export class SolvedProblemsListResponseDto {
     example: 15,
   })
   totalCount: number;
-
-  @ApiProperty({
-    description: '총 점수',
-    example: 100,
-  })
-  totalScore: number;
-
-  @ApiProperty({
-    description: '총 포인트',
-    example: 100,
-  })
-  totalPoint: number;
 }

--- a/apps/api/src/user/dtos/response/solved-problems-list-response.dto.ts
+++ b/apps/api/src/user/dtos/response/solved-problems-list-response.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SolvedProblemDto } from './solved-problem.dto';
+
+/**
+ * 푼 문제 목록 리스트 응답 래퍼 DTO
+ */
+export class SolvedProblemsListResponseDto {
+  @ApiProperty({
+    description: '푼 문제 목록',
+    type: [SolvedProblemDto],
+  })
+  problems: SolvedProblemDto[];
+
+  @ApiProperty({
+    description: '푼 문제 갯수',
+    example: 15,
+  })
+  totalCount: number;
+}

--- a/apps/api/src/user/dtos/response/solved-problems-list-response.dto.ts
+++ b/apps/api/src/user/dtos/response/solved-problems-list-response.dto.ts
@@ -16,4 +16,16 @@ export class SolvedProblemsListResponseDto {
     example: 15,
   })
   totalCount: number;
+
+  @ApiProperty({
+    description: '총 점수',
+    example: 100,
+  })
+  totalScore: number;
+
+  @ApiProperty({
+    description: '총 포인트',
+    example: 100,
+  })
+  totalPoint: number;
 }

--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -26,6 +26,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { UserId } from '../auth/decorators/user-id.decorator';
 import { CreateUserRequestDto } from './dtos/request/create-user.request.dto';
 import { UserPublicResponseDto } from './dtos/response/user.public.response.dto';
+import { SolvedProblemsListResponseDto } from './dtos/response/solved-problems-list-response.dto';
 
 const USER_CONTROLLER_VALIDATION_PIPE = new ValidationPipe({
   transform: true,
@@ -158,5 +159,25 @@ export class UserController {
       totalScore: user.totalScore ?? 0,
       createdAt: user.createdAt.toISOString(),
     };
+  }
+
+  @Get('solved-problems')
+  @ApiOperation({ summary: '내가 푼 문제 목록 조회' })
+  @ApiBearerAuth('JWT-auth')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiResponse({
+    status: 200,
+    description: '푼 문제 목록 조회 성공',
+    type: SolvedProblemsListResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: '로그인이 필요합니다',
+  })
+  async getSolvedProblems(
+    @UserId() userId: number,
+  ): Promise<SolvedProblemsListResponseDto> {
+    return await this.userService.getSolvedProblems(userId);
   }
 }

--- a/apps/api/src/user/user.module.ts
+++ b/apps/api/src/user/user.module.ts
@@ -5,9 +5,14 @@ import { UserRepository } from './user.repository';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { AuthModule } from '../auth/auth.module';
+import { AnswerSubmission } from '../answer-submission/entities/answer-submission.entity';
+import { Question } from '../question/entities/question.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), AuthModule],
+  imports: [
+    TypeOrmModule.forFeature([User, AnswerSubmission, Question]),
+    AuthModule,
+  ],
   controllers: [UserController],
   providers: [UserRepository, UserService],
   exports: [UserService],

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -4,6 +4,8 @@ import {
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
 import { UserRole } from './entities/user-role.enum';
 import { UserRepository } from './user.repository';
@@ -13,10 +15,18 @@ import {
   verifyPassword,
 } from './utils/password.util';
 import { QueryFailedError } from 'typeorm';
+import { AnswerSubmission } from '../answer-submission/entities/answer-submission.entity';
+import { EvaluationStatus } from '../answer-evaluation/answer-evaluation.constants';
+import { SolvedProblemDto } from './dtos/response/solved-problem.dto';
+import { SolvedProblemsListResponseDto } from './dtos/response/solved-problems-list-response.dto';
 
 @Injectable()
 export class UserService {
-  constructor(private readonly userRepository: UserRepository) {}
+  constructor(
+    private readonly userRepository: UserRepository,
+    @InjectRepository(AnswerSubmission)
+    private readonly answerSubmissionRepository: Repository<AnswerSubmission>,
+  ) {}
 
   async findOneById(id: number): Promise<User | null> {
     return this.userRepository.findOneById(id);
@@ -100,5 +110,80 @@ export class UserService {
       throw new NotFoundException('사용자를 찾을 수 없습니다.');
     }
     return user;
+  }
+
+  /**
+   * 채점 및 AI 피드백이 완료된 문제 목록 조회
+   * @param userId 사용자 ID
+   * @returns 푼 문제 목록 및 총 갯수
+   */
+  async getSolvedProblems(
+    userId: number,
+  ): Promise<SolvedProblemsListResponseDto> {
+    // 채점 및 피드백이 완료된 제출 내역 조회
+    const submissions = await this.answerSubmissionRepository
+      .createQueryBuilder('submission')
+      .innerJoin(
+        'answer_evaluations',
+        'evaluation',
+        'evaluation.submission_id = submission.id',
+      )
+      .innerJoinAndSelect('submission.question', 'question')
+      .leftJoinAndSelect('question.category', 'category')
+      .where('submission.user_id = :userId', { userId })
+      .andWhere('submission.evaluation_status = :status', {
+        status: EvaluationStatus.COMPLETED,
+      })
+      .andWhere('evaluation.feedback_message IS NOT NULL')
+      .orderBy('submission.submitted_at', 'DESC')
+      .getMany();
+
+    // 문제별로 가장 최근 제출 내역만 선택
+    const problemMap = new Map<
+      number,
+      {
+        submissionId: number;
+        questionId: number;
+        title: string;
+        category: string;
+        completedAt: Date;
+      }
+    >();
+
+    submissions.forEach((submission) => {
+      const questionId = submission.questionId;
+      const existing = problemMap.get(questionId);
+
+      if (!existing || submission.submittedAt > existing.completedAt) {
+        const categoryName = submission.question?.category?.name ?? '미분류';
+
+        problemMap.set(questionId, {
+          submissionId: submission.id,
+          questionId,
+          title: submission.question?.title ?? '',
+          category: categoryName,
+          completedAt: submission.submittedAt,
+        });
+      }
+    });
+
+    // DTO 변환 및 정렬
+    const problems: SolvedProblemDto[] = Array.from(problemMap.values())
+      .map((data) => ({
+        questionId: data.questionId,
+        title: data.title,
+        category: data.category,
+        completedAt: data.completedAt.toISOString(),
+        reportId: data.submissionId,
+      }))
+      .sort(
+        (a, b) =>
+          new Date(b.completedAt).getTime() - new Date(a.completedAt).getTime(),
+      );
+
+    return {
+      problems,
+      totalCount: problems.length,
+    };
   }
 }

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -115,11 +115,17 @@ export class UserService {
   /**
    * 채점 및 AI 피드백이 완료된 문제 목록 조회
    * @param userId 사용자 ID
-   * @returns 푼 문제 목록 및 총 갯수
+   * @returns 푼 문제 목록 및 총 갯수, 총 점수, 총 포인트
    */
   async getSolvedProblems(
     userId: number,
   ): Promise<SolvedProblemsListResponseDto> {
+    // 사용자 정보 조회 (totalScore, totalPoint를 위해)
+    const user = await this.userRepository.findOneById(userId);
+    if (!user) {
+      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    }
+
     // 채점 및 피드백이 완료된 제출 내역 조회
     const submissions = await this.answerSubmissionRepository
       .createQueryBuilder('submission')
@@ -184,6 +190,8 @@ export class UserService {
     return {
       problems,
       totalCount: problems.length,
+      totalScore: user.totalScore ?? 0,
+      totalPoint: user.totalPoint ?? 0,
     };
   }
 }

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -147,6 +147,7 @@ export class UserService {
         title: string;
         category: string;
         completedAt: Date;
+        score: number;
       }
     >();
 
@@ -163,6 +164,7 @@ export class UserService {
           title: submission.question?.title ?? '',
           category: categoryName,
           completedAt: submission.submittedAt,
+          score: submission.score,
         });
       }
     });
@@ -175,6 +177,7 @@ export class UserService {
         category: data.category,
         completedAt: data.completedAt.toISOString(),
         reportId: data.submissionId,
+        score: data.score,
       }))
       .sort(
         (a, b) =>

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -115,17 +115,11 @@ export class UserService {
   /**
    * 채점 및 AI 피드백이 완료된 문제 목록 조회
    * @param userId 사용자 ID
-   * @returns 푼 문제 목록 및 총 갯수, 총 점수, 총 포인트
+   * @returns 푼 문제 목록 및 총 갯수
    */
   async getSolvedProblems(
     userId: number,
   ): Promise<SolvedProblemsListResponseDto> {
-    // 사용자 정보 조회 (totalScore, totalPoint를 위해)
-    const user = await this.userRepository.findOneById(userId);
-    if (!user) {
-      throw new NotFoundException('사용자를 찾을 수 없습니다.');
-    }
-
     // 채점 및 피드백이 완료된 제출 내역 조회
     const submissions = await this.answerSubmissionRepository
       .createQueryBuilder('submission')
@@ -190,8 +184,6 @@ export class UserService {
     return {
       problems,
       totalCount: problems.length,
-      totalScore: user.totalScore ?? 0,
-      totalPoint: user.totalPoint ?? 0,
     };
   }
 }


### PR DESCRIPTION
## 🔸 작업 내용

- #231 
- #232 

### 주요 변경사항

1. **DTO 생성**
   - `SolvedProblemDto`: 푼 문제 단건 응답 DTO (문제 ID, 제목, 카테고리, 풀이 완료 시각, 리포트 ID)
   - `SolvedProblemsListResponseDto`: 푼 문제 목록 리스트 응답 래퍼 DTO

2. **API 엔드포인트 추가**
   - `GET /api/users/solved-problems`: 채점 및 AI 피드백이 완료된 문제 목록 조회
   - JWT 인증 필수, 본인 데이터만 조회 가능

3. **비즈니스 로직 구현**
   - `UserService.getSolvedProblems()`: 채점 완료(`evaluation_status = COMPLETED`) 및 피드백 존재(`feedback_message IS NOT NULL`) 조건으로 필터링
   - 문제별 가장 최근 제출 내역만 반환
   - 풀이 완료 시각 기준 내림차순 정렬

4. **모듈 구조**
   - `UserModule`에 `AnswerSubmission`, `Question` 엔티티 의존성 추가
   - Swagger 문서화 완료

## 🔸 고민 했던 부분

### 모듈 구조: 별도 모듈 vs User 모듈 통합

**고민 배경:**
- 현재 프로젝트는 도메인별로 모듈이 분리되어 있음 (user, question, answer-submission 등)
- 마이페이지 기능은 사용자 관련이지만, 실제로는 `answer-submission`과 `answer-evaluation` 데이터를 조회하는 기능

**고려했던 옵션:**
1. **별도 `MypageModule` 생성**
   - 장점
     - 마이페이지 기능 확장 시 독립적 관리 가능, 책임 분리 명확
     - `user` 모듈과 다른 의존성 구조 (answer-submission, answer-evaluation에 의존)
   - 단점
     - 사용자 관련 기능이 분산될 수 있음

2. **`UserModule`에 통합** (최종 선택)
   - 장점
     - 사용자 관련 기능을 한 곳에 모아 응집도 향상
     - API 경로가 `/api/users/*`로 일관성 유지
   - 단점
     - `UserModule`이 `AnswerSubmission`, `Question` 엔티티에 의존하게 됨

**결정 근거:**
- 마이페이지는 사용자 관점의 기능이므로 `UserModule`에 포함하는 것이 자연스럽다고 판단
- API 경로 일관성 (`/api/users/me`, `/api/users/solved-problems`)
- 향후 마이페이지 기능 확장 시에도 사용자 데이터 조회가 주 목적이라면 `UserModule` 내부에서 관리하는 것이 적절하다고 생각됨

**향후 고려사항:**
- 마이페이지 기능이 복잡해지고 독립적인 도메인으로 성장한다면 별도 모듈 분리 검토
- 현재는 사용자 관련 기능의 확장으로 보아 `UserModule`에 통합하는 것이 적절하다고 판단

## 🔸 참고

- Swagger 문서: `/api-docs`에서 `users` 태그 하위에 `GET /api/users/solved-problems` 엔드포인트 확인 가능
- 응답 예시:

```json
{
  "problems": [
    {
      "questionId": 8,
      "title": "작업 실행 단위의 이해",
      "category": "Operating System",
      "completedAt": "2026-01-22T09:08:01.083Z",
      "reportId": 10
    },
    {
      "questionId": 9,
      "title": "웹 페이지 로딩의 여정",
      "category": "Browser Rendering",
      "completedAt": "2026-01-22T09:08:01.083Z",
      "reportId": 11
    }
  ],
  "totalCount": 2
}
```

<img width="819" height="493" alt="스크린샷 2026-01-22 18 39 52" src="https://github.com/user-attachments/assets/c138cd57-3945-4427-8156-ca854b5512dd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 완료한 문제 목록 조회 API 추가
  * 인증된 사용자가 문제별 상세(문제 ID, 제목, 분류, 풀이 완료 시각, 제출/리포트 ID)를 확인 가능
  * 각 완료 문제에 0~100 범위의 점수(score) 포함
  * 응답에 문제 목록과 전체 완료 문제 개수(totalCount) 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->