### PR TITLE
중요도 평가 후 alert 제거 및 Toast 추가

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,6 +29,7 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-hot-toast": "^2.6.0",
     "skmeans": "^0.11.3",
     "socket.io-client": "^4.8.3",
     "tailwind-merge": "^3.4.0",

--- a/apps/web/src/app/daily/questions/[questionId]/_components/importance-rating.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/_components/importance-rating.tsx
@@ -7,6 +7,7 @@ import {
   updateImportanceAction,
   type ActionState,
 } from "../_lib/submit-importance-action";
+import toast from "react-hot-toast";
 
 interface ImportanceRatingProps {
   open?: boolean;
@@ -30,10 +31,36 @@ function ImportanceRating({
     if (!state) return;
 
     if (state.success) {
-      alert(state.message);
-      if (onSuccess) onSuccess();
+      toast.success(state.message, {
+        duration: 1500,
+        style: {
+          background: "rgba(45, 212, 191, 0.9)",
+          backdropFilter: "blur(10px)",
+          WebkitBackdropFilter: "blur(10px)",
+          color: "#fff",
+          fontWeight: "600",
+          padding: "16px 24px",
+          borderRadius: "16px",
+          fontSize: "16px",
+          border: "1px solid rgba(255, 255, 255, 0.2)",
+          boxShadow:
+            "0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1)",
+          minWidth: "280px",
+        },
+        iconTheme: {
+          primary: "#fff",
+          secondary: "#2dd4bf",
+        },
+      });
+      if (onSuccess) {
+        const timer = setTimeout(() => {
+          onSuccess();
+          setScore(0);
+        }, 1500);
+        return () => clearTimeout(timer);
+      }
     } else {
-      alert(state.message);
+      toast.error(state.message);
     }
   }, [state, onSuccess]);
 

--- a/apps/web/src/app/daily/questions/[questionId]/_components/importance-rating.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/_components/importance-rating.tsx
@@ -27,8 +27,17 @@ function ImportanceRating({
     FormData
   >(updateImportanceAction, null);
 
+  const onSuccessRef = React.useRef(onSuccess);
   React.useEffect(() => {
-    if (!state) return;
+    onSuccessRef.current = onSuccess;
+  }, [onSuccess]);
+
+  const lastProcessedStateRef = React.useRef<ActionState | null>(null);
+
+  React.useEffect(() => {
+    if (!state || state === lastProcessedStateRef.current) return;
+
+    lastProcessedStateRef.current = state;
 
     if (state.success) {
       toast.success(state.message, {
@@ -40,17 +49,17 @@ function ImportanceRating({
           secondary: "#2dd4bf",
         },
       });
-      if (onSuccess) {
-        const timer = setTimeout(() => {
-          onSuccess();
-          setScore(0);
-        }, 1500);
-        return () => clearTimeout(timer);
-      }
+
+      const timer = setTimeout(() => {
+        onSuccessRef.current?.();
+        setScore(0);
+      }, 1500);
+
+      return () => clearTimeout(timer);
     } else {
       toast.error(state.message);
     }
-  }, [state, onSuccess]);
+  }, [state]);
 
   if (!open) return null;
 

--- a/apps/web/src/app/daily/questions/[questionId]/_components/importance-rating.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/_components/importance-rating.tsx
@@ -33,20 +33,8 @@ function ImportanceRating({
     if (state.success) {
       toast.success(state.message, {
         duration: 1500,
-        style: {
-          background: "rgba(45, 212, 191, 0.9)",
-          backdropFilter: "blur(10px)",
-          WebkitBackdropFilter: "blur(10px)",
-          color: "#fff",
-          fontWeight: "600",
-          padding: "16px 24px",
-          borderRadius: "16px",
-          fontSize: "16px",
-          border: "1px solid rgba(255, 255, 255, 0.2)",
-          boxShadow:
-            "0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1)",
-          minWidth: "280px",
-        },
+        className:
+          "bg-[#2dd4bf]/90 backdrop-blur-md text-white font-semibold py-4 px-6 rounded-[16px] text-base border border-white/20 shadow-xl min-w-[280px]",
         iconTheme: {
           primary: "#fff",
           secondary: "#2dd4bf",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/cn";
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
+import { Toaster } from "react-hot-toast";
 
 const pretendard = localFont({
   src: "../assets/fonts/PretendardVariable.woff2",
@@ -29,6 +30,15 @@ function RootLayout({ children }: Readonly<RootLayoutProps>) {
       >
         <Header />
         {children}
+        <Toaster
+          position="top-center"
+          toastOptions={{
+            style: {
+              marginTop: "15vh",
+            },
+          }}
+          reverseOrder={false}
+        />
         <Footer />
       </body>
     </html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      react-hot-toast:
+        specifier: ^2.6.0
+        version: 2.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       skmeans:
         specifier: ^0.11.3
         version: 0.11.3
@@ -4803,6 +4806,11 @@ packages:
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
+  goober@2.1.18:
+    resolution: {integrity: sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==}
+    peerDependencies:
+      csstype: ^3.0.10
+
   google-auth-library@10.5.0:
     resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
     engines: {node: '>=18'}
@@ -6073,6 +6081,13 @@ packages:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
       react: ^19.2.3
+
+  react-hot-toast@2.6.0:
+    resolution: {integrity: sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -11929,8 +11944,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1(jiti@2.6.1))
@@ -11956,7 +11971,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11967,21 +11982,21 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11992,7 +12007,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -12520,6 +12535,10 @@ snapshots:
       gopd: 1.2.0
 
   globrex@0.1.2: {}
+
+  goober@2.1.18(csstype@3.1.3):
+    dependencies:
+      csstype: 3.1.3
 
   google-auth-library@10.5.0:
     dependencies:
@@ -13999,6 +14018,13 @@ snapshots:
     dependencies:
       react: 19.2.3
       scheduler: 0.27.0
+
+  react-hot-toast@2.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      csstype: 3.1.3
+      goober: 2.1.18(csstype@3.1.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   react-is@16.13.1: {}
 


### PR DESCRIPTION
## 🔸 작업 내용

fix #234 

- alert 제거
- react-hot-toast 라이브러리 설치
- Toast 스타일링 추가
- Toast 호출 (1.5초간 유지 후 사라짐, 동시에 결과 화면으로 넘어감)

## 🔸 고민 했던 부분

### 라이브러리로 Toast 사용하는 것이 맞는가? 
-> 커스텀이 크게 요구되지 않고, 함수호출만으로 사용이 가능함

만약 라이브러리로 이용하는 점이 걸린다면, 댓글로 남겨주세요. 
toast에 큰 공수를 들일 필요가 있는지? 고민이 되었습니다. 


## 🔸 참고

https://github.com/user-attachments/assets/72ed15cb-0ab6-4d31-b1c7-b72ce66dbc37

디자인은 간단하게 색상에 맞춰보았습니다. 변경 원하시면 코멘트 달아주세요. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 전역 토스트 알림 기능 추가로 즉시 피드백 제공

* **개선 사항**
  * 성공·실패에 따른 스타일된 성공/오류 토스트 표시
  * 성공 시 확장된 노출 시간과 아이콘, 이후 자동 동작(지연 후 상태 초기화)으로 UX 개선
  * 앱 전체에서 일관된 위치에 토스트가 표시되도록 통합 설정 반영

* **잡무(Chore)**
  * 런타임 의존성으로 react-hot-toast가 추가됨

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->