### PR TITLE
문제 리스트 풀이 상태에 따른 필터링 추가

### DIFF
--- a/apps/api/src/question/dtos/paginated-questions.dto.ts
+++ b/apps/api/src/question/dtos/paginated-questions.dto.ts
@@ -3,7 +3,7 @@ import { Question } from '../entities/question.entity';
 
 export class PaginatedQuestionsDto {
   @ApiProperty({ type: [Question], description: '질문 목록' })
-  questions: Question[];
+  questions: (Question & { score: number | null })[];
 
   @ApiProperty({ example: 100, description: '필터링된 전체 질문 수' })
   totalCount: number;

--- a/apps/api/src/question/dtos/question-filter.dto.ts
+++ b/apps/api/src/question/dtos/question-filter.dto.ts
@@ -1,5 +1,13 @@
-import { IsOptional, IsInt, Min, IsString, IsNumber } from 'class-validator';
 import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+import { SolvedStatus } from '../question.constants';
 
 export class QuestionFilterDto {
   @IsOptional()
@@ -17,6 +25,10 @@ export class QuestionFilterDto {
   @IsOptional()
   @IsString()
   search?: string; // 문제 제목 검색
+
+  @IsOptional()
+  @IsEnum(SolvedStatus)
+  solvedStatus?: SolvedStatus;
 
   @IsOptional()
   @Type(() => Number)

--- a/apps/api/src/question/question.constants.ts
+++ b/apps/api/src/question/question.constants.ts
@@ -1,0 +1,8 @@
+const SolvedStatus = {
+  SOLVED: 'SOLVED',
+  UNSOLVED: 'UNSOLVED',
+} as const;
+
+type SolvedStatus = (typeof SolvedStatus)[keyof typeof SolvedStatus];
+
+export { SolvedStatus };

--- a/apps/api/src/question/question.controller.ts
+++ b/apps/api/src/question/question.controller.ts
@@ -1,25 +1,27 @@
 import {
   Controller,
   Get,
+  NotFoundException,
   Param,
   Query,
-  NotFoundException,
   UseGuards,
 } from '@nestjs/common';
 import {
-  ApiTags,
+  ApiBearerAuth,
+  ApiNotFoundResponse,
   ApiOperation,
   ApiParam,
   ApiQuery,
   ApiResponse,
-  ApiNotFoundResponse,
+  ApiTags,
 } from '@nestjs/swagger';
-import { QuestionService } from './question.service';
-import { FindOneParams } from './dtos/find-one-params.dto';
-import { QuestionFilterDto } from './dtos/question-filter.dto';
-import { PaginatedQuestionsDto } from './dtos/paginated-questions.dto';
-import { Question } from './entities/question.entity';
+import { UserId } from 'src/auth/decorators/user-id.decorator';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { FindOneParams } from './dtos/find-one-params.dto';
+import { PaginatedQuestionsDto } from './dtos/paginated-questions.dto';
+import { QuestionFilterDto } from './dtos/question-filter.dto';
+import { Question } from './entities/question.entity';
+import { QuestionService } from './question.service';
 
 @ApiTags('questions')
 @Controller('questions')
@@ -60,6 +62,51 @@ export class QuestionController {
     @Query() filter: QuestionFilterDto,
   ): Promise<PaginatedQuestionsDto> {
     return await this.questionService.findPaginated(filter);
+  }
+
+  @Get('/auth')
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: '질문 목록 조회',
+    description:
+      '페이지네이션과 카테고리 필터를 적용하여 질문 목록을 조회합니다.',
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: '페이지 번호 (기본값: 1)',
+    example: 1,
+  })
+  @ApiQuery({
+    name: 'categoryId',
+    required: false,
+    type: Number,
+    description: '중분류 카테고리 ID',
+  })
+  @ApiQuery({
+    name: 'parentCategoryId',
+    required: false,
+    type: Number,
+    description: '대분류 카테고리 ID',
+  })
+  @ApiQuery({
+    name: 'solvedStatus',
+    required: false,
+    type: 'string',
+    description: 'SOLVED / UNSOLVED',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '질문 목록 조회 성공',
+    type: PaginatedQuestionsDto,
+  })
+  @UseGuards(JwtAuthGuard)
+  async getPaginatedWithAuth(
+    @Query() filter: QuestionFilterDto,
+    @UserId() userId: number,
+  ): Promise<PaginatedQuestionsDto> {
+    return await this.questionService.findPaginated(filter, userId);
   }
 
   @Get('category/:categoryId')

--- a/apps/api/src/question/question.module.ts
+++ b/apps/api/src/question/question.module.ts
@@ -1,13 +1,19 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Question } from './entities/question.entity';
+import { AnswerSubmissionModule } from 'src/answer-submission/answer-submission.module';
+import { AuthModule } from 'src/auth/auth.module';
 import { CategoryModule } from '../category/category.module';
+import { Question } from './entities/question.entity';
 import { QuestionController } from './question.controller';
 import { QuestionService } from './question.service';
-import { AuthModule } from 'src/auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Question]), CategoryModule, AuthModule],
+  imports: [
+    TypeOrmModule.forFeature([Question]),
+    CategoryModule,
+    AuthModule,
+    AnswerSubmissionModule,
+  ],
   providers: [QuestionService],
   controllers: [QuestionController],
 })

--- a/apps/api/src/question/question.service.spec.ts
+++ b/apps/api/src/question/question.service.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { AnswerSubmission } from 'src/answer-submission/entities/answer-submission.entity';
 import { Question } from './entities/question.entity';
+import { SolvedStatus } from './question.constants';
 import { QuestionService } from './question.service';
 
 describe('QuestionService', () => {
@@ -16,10 +18,23 @@ describe('QuestionService', () => {
     getManyAndCount: jest.fn(),
   };
 
+  const mockSubmissionQueryBuilder = {
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn(),
+  };
+
   const mockQuestionRepository = {
     find: jest.fn(),
     findOne: jest.fn(),
     createQueryBuilder: jest.fn(() => mockQueryBuilder),
+  };
+
+  const mockAnswerSubmissionRepository = {
+    createQueryBuilder: jest.fn(() => mockSubmissionQueryBuilder),
   };
 
   beforeEach(async () => {
@@ -29,6 +44,10 @@ describe('QuestionService', () => {
         {
           provide: getRepositoryToken(Question),
           useValue: mockQuestionRepository,
+        },
+        {
+          provide: getRepositoryToken(AnswerSubmission),
+          useValue: mockAnswerSubmissionRepository,
         },
       ],
     }).compile();
@@ -131,7 +150,10 @@ describe('QuestionService', () => {
         const result = await service.findPaginated({});
 
         expect(result).toEqual({
-          questions: mockQuestionsWithCategory,
+          questions: mockQuestionsWithCategory.map((q) => ({
+            ...q,
+            score: null,
+          })),
           totalCount: 30,
           pageSize: 15,
           currentPage: 1,
@@ -218,6 +240,88 @@ describe('QuestionService', () => {
         await service.findPaginated({});
 
         expect(mockQueryBuilder.andWhere).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('userId가 있을 때 score 매핑', () => {
+      it('userId가 있으면 해당 사용자의 제출 점수를 조회하여 매핑한다', async () => {
+        setupMockReturn(mockQuestionsWithCategory, 2);
+        mockSubmissionQueryBuilder.getRawMany.mockResolvedValue([
+          { questionId: 1, maxScore: 85 },
+        ]);
+
+        const result = await service.findPaginated({}, 1);
+
+        expect(
+          mockAnswerSubmissionRepository.createQueryBuilder,
+        ).toHaveBeenCalledWith('submission');
+        expect(result.questions[0].score).toBe(85);
+        expect(result.questions[1].score).toBeNull();
+      });
+
+      it('userId가 없으면 모든 질문의 score가 null이다', async () => {
+        setupMockReturn(mockQuestionsWithCategory, 2);
+
+        const result = await service.findPaginated({});
+
+        expect(
+          mockAnswerSubmissionRepository.createQueryBuilder,
+        ).not.toHaveBeenCalled();
+        expect(result.questions.every((q) => q.score === null)).toBe(true);
+      });
+
+      it('질문 목록이 비어있으면 submission 쿼리를 실행하지 않는다', async () => {
+        setupMockReturn([], 0);
+
+        await service.findPaginated({}, 1);
+
+        expect(
+          mockAnswerSubmissionRepository.createQueryBuilder,
+        ).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('solvedStatus 필터', () => {
+      it('solvedStatus가 SOLVED이면 score가 있는 질문만 반환한다', async () => {
+        setupMockReturn(mockQuestionsWithCategory, 2);
+        mockSubmissionQueryBuilder.getRawMany.mockResolvedValue([
+          { questionId: 1, maxScore: 85 },
+        ]);
+
+        const result = await service.findPaginated(
+          { solvedStatus: SolvedStatus.SOLVED },
+          1,
+        );
+
+        expect(result.questions).toHaveLength(1);
+        expect(result.questions[0].id).toBe(1);
+        expect(result.questions[0].score).toBe(85);
+      });
+
+      it('solvedStatus가 UNSOLVED이면 score가 null인 질문만 반환한다', async () => {
+        setupMockReturn(mockQuestionsWithCategory, 2);
+        mockSubmissionQueryBuilder.getRawMany.mockResolvedValue([
+          { questionId: 1, maxScore: 85 },
+        ]);
+
+        const result = await service.findPaginated(
+          { solvedStatus: SolvedStatus.UNSOLVED },
+          1,
+        );
+
+        expect(result.questions).toHaveLength(1);
+        expect(result.questions[0].id).toBe(2);
+        expect(result.questions[0].score).toBeNull();
+      });
+
+      it('userId가 없으면 solvedStatus 필터가 적용되지 않는다', async () => {
+        setupMockReturn(mockQuestionsWithCategory, 2);
+
+        const result = await service.findPaginated({
+          solvedStatus: SolvedStatus.SOLVED,
+        });
+
+        expect(result.questions).toHaveLength(2);
       });
     });
   });

--- a/apps/api/src/question/question.service.ts
+++ b/apps/api/src/question/question.service.ts
@@ -78,8 +78,7 @@ export class QuestionService {
     let questionsWithScore: (Question & { score: number | null })[] =
       questions.map((q) => ({ ...q, score: null }));
 
-    if (userId && filter.solvedStatus) {
-      console.log(userId);
+    if (userId) {
       const questionsIds = questions.map((question) => question.id);
       const submissions = await this.answerSubmissionRepository
         .createQueryBuilder('submission')

--- a/apps/api/src/question/question.service.ts
+++ b/apps/api/src/question/question.service.ts
@@ -77,9 +77,8 @@ export class QuestionService {
     // userId가 있으면 해당 사용자의 점수를 조회하여 매핑
     let questionsWithScore: (Question & { score: number | null })[] =
       questions.map((q) => ({ ...q, score: null }));
-
-    if (userId) {
-      const questionsIds = questions.map((question) => question.id);
+    const questionsIds = questions.map((question) => question.id);
+    if (userId && questionsIds.length > 0) {
       const submissions = await this.answerSubmissionRepository
         .createQueryBuilder('submission')
         .select('submission.questionId', 'questionId')

--- a/apps/api/src/question/question.service.ts
+++ b/apps/api/src/question/question.service.ts
@@ -1,9 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { AnswerSubmission } from 'src/answer-submission/entities/answer-submission.entity';
 import { Repository } from 'typeorm';
-import { Question } from './entities/question.entity';
-import { QuestionFilterDto } from './dtos/question-filter.dto';
 import { PaginatedQuestionsDto } from './dtos/paginated-questions.dto';
+import { QuestionFilterDto } from './dtos/question-filter.dto';
+import { Question } from './entities/question.entity';
+import { SolvedStatus } from './question.constants';
 
 @Injectable()
 export class QuestionService {
@@ -12,6 +14,8 @@ export class QuestionService {
   constructor(
     @InjectRepository(Question)
     private questionRepository: Repository<Question>,
+    @InjectRepository(AnswerSubmission)
+    private answerSubmissionRepository: Repository<AnswerSubmission>,
   ) {}
 
   async findByCategory(categoryId: number) {
@@ -30,6 +34,7 @@ export class QuestionService {
 
   async findPaginated(
     filter: QuestionFilterDto,
+    userId?: number,
   ): Promise<PaginatedQuestionsDto> {
     const page = filter.page ?? 1;
     const skip = (page - 1) * this.pageSize;
@@ -69,8 +74,45 @@ export class QuestionService {
     const [questions, totalCount] = await queryBuilder.getManyAndCount();
     const totalPages = Math.ceil(totalCount / this.pageSize);
 
+    // userId가 있으면 해당 사용자의 점수를 조회하여 매핑
+    let questionsWithScore: (Question & { score: number | null })[] =
+      questions.map((q) => ({ ...q, score: null }));
+
+    if (userId && filter.solvedStatus) {
+      console.log(userId);
+      const questionsIds = questions.map((question) => question.id);
+      const submissions = await this.answerSubmissionRepository
+        .createQueryBuilder('submission')
+        .select('submission.questionId', 'questionId')
+        .addSelect('MAX(submission.score)', 'maxScore')
+        .where('submission.userId = :userId', { userId })
+        .andWhere('submission.questionId IN (:...questionIds)', {
+          questionIds: questionsIds,
+        })
+        .groupBy('submission.questionId')
+        .getRawMany<{ questionId: number; maxScore: number }>();
+
+      const scoreMap = new Map(
+        submissions.map((submission) => [
+          submission.questionId,
+          submission.maxScore,
+        ]),
+      );
+
+      questionsWithScore = questions.map((question) => ({
+        ...question,
+        score: scoreMap.get(question.id) ?? null,
+      }));
+
+      if (filter.solvedStatus === SolvedStatus.SOLVED) {
+        questionsWithScore = questionsWithScore.filter((q) => q.score !== null);
+      } else if (filter.solvedStatus === SolvedStatus.UNSOLVED) {
+        questionsWithScore = questionsWithScore.filter((q) => q.score === null);
+      }
+    }
+
     return {
-      questions,
+      questions: questionsWithScore,
       totalCount,
       pageSize: this.pageSize,
       currentPage: page,

--- a/apps/web/src/app/daily/questions/_components/question-filters.tsx
+++ b/apps/web/src/app/daily/questions/_components/question-filters.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import * as React from "react";
-import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/button/button";
 import {
   InputGroup,
@@ -9,9 +7,11 @@ import {
   InputGroupInput,
 } from "@/components/input-group/input-group";
 import { SegmentedControl } from "@/components/segmented-control/segmented-control";
-import { Search } from "lucide-react";
-import { Category } from "../_types/types";
 import { cn } from "@/lib/cn";
+import { Search } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import * as React from "react";
+import { Category } from "../_types/types";
 
 interface QuestionFiltersProps {
   categories: Category[];
@@ -19,6 +19,7 @@ interface QuestionFiltersProps {
   selectedCategoryId: number | null;
   selectedSubCategoryId: number | null;
   searchQuery: string;
+  selectedSolvedStatus: string | null;
   selectedMinImportance: number | null;
 }
 
@@ -28,11 +29,11 @@ function QuestionFilters({
   selectedCategoryId,
   selectedSubCategoryId,
   searchQuery,
+  selectedSolvedStatus,
   selectedMinImportance,
 }: QuestionFiltersProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [solveStatus, setSolveStatus] = React.useState("");
   const [searchInput, setSearchInput] = React.useState(searchQuery);
 
   const updateSearchParams = React.useCallback(
@@ -154,11 +155,15 @@ function QuestionFilters({
           <SegmentedControl
             options={[
               { label: "전체", value: "" },
-              { label: "푼 문제", value: "solved" },
-              { label: "안 푼 문제", value: "unsolved" },
+              { label: "푼 문제", value: "SOLVED" },
+              { label: "안 푼 문제", value: "UNSOLVED" },
             ]}
-            value={solveStatus}
-            onChange={setSolveStatus}
+            value={selectedSolvedStatus ?? ""}
+            onChange={(value) =>
+              updateSearchParams({
+                solvedStatus: value || null,
+              })
+            }
           />
         </div>
         <div className="flex gap-3 items-center">

--- a/apps/web/src/app/daily/questions/_lib/fetch-questions.ts
+++ b/apps/web/src/app/daily/questions/_lib/fetch-questions.ts
@@ -1,4 +1,5 @@
 import { apiGet, checkAuthUser } from "@/lib/api-client";
+import { ApiError } from "@/lib/api-error";
 import { PaginatedQuestionsDTO } from "../_types/types";
 
 interface FetchQuestionsParams {
@@ -13,11 +14,6 @@ interface FetchQuestionsParams {
 async function fetchQuestions(
   params: FetchQuestionsParams = {},
 ): Promise<PaginatedQuestionsDTO> {
-  const baseUrl = process.env.API_URL;
-  if (!baseUrl) {
-    throw new Error("API_URL environment variable is not defined");
-  }
-
   const searchParams = new URLSearchParams();
   if (params.page) {
     searchParams.set("page", params.page.toString());
@@ -43,7 +39,15 @@ async function fetchQuestions(
   const endpoint = userStatus ? `/questions/auth` : `/questions`;
   const url = `${endpoint}${queryString ? `?${queryString}` : ""}`;
 
-  return apiGet<PaginatedQuestionsDTO>(url);
+  try {
+    return await apiGet<PaginatedQuestionsDTO>(url);
+  } catch (err) {
+    if (userStatus && err instanceof ApiError && err.status === 401) {
+      const fallbackUrl = `/questions${queryString ? `?${queryString}` : ""}`;
+      return apiGet<PaginatedQuestionsDTO>(fallbackUrl);
+    }
+    throw err;
+  }
 }
 
 export { fetchQuestions };

--- a/apps/web/src/app/daily/questions/_lib/fetch-questions.ts
+++ b/apps/web/src/app/daily/questions/_lib/fetch-questions.ts
@@ -1,3 +1,4 @@
+import { apiGet, checkAuthUser } from "@/lib/api-client";
 import { PaginatedQuestionsDTO } from "../_types/types";
 
 interface FetchQuestionsParams {
@@ -5,14 +6,15 @@ interface FetchQuestionsParams {
   categoryId?: number;
   parentCategoryId?: number;
   search?: string;
+  solvedStatus?: string;
   minImportance?: number;
 }
 
 async function fetchQuestions(
   params: FetchQuestionsParams = {},
 ): Promise<PaginatedQuestionsDTO> {
-  const apiUrl = process.env.API_URL;
-  if (!apiUrl) {
+  const baseUrl = process.env.API_URL;
+  if (!baseUrl) {
     throw new Error("API_URL environment variable is not defined");
   }
 
@@ -29,22 +31,19 @@ async function fetchQuestions(
   if (params.search) {
     searchParams.set("search", params.search);
   }
+  if (params.solvedStatus) {
+    searchParams.set("solvedStatus", params.solvedStatus.toUpperCase());
+  }
   if (params.minImportance !== undefined) {
     searchParams.set("minImportance", params.minImportance.toString());
   }
 
   const queryString = searchParams.toString();
-  const url = `${apiUrl}/questions${queryString ? `?${queryString}` : ""}`;
+  const userStatus = await checkAuthUser();
+  const endpoint = userStatus ? `/questions/auth` : `/questions`;
+  const url = `${endpoint}${queryString ? `?${queryString}` : ""}`;
 
-  const response = await fetch(url, {
-    cache: "no-store",
-  });
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch questions: ${response.statusText}`);
-  }
-
-  return await response.json();
+  return apiGet<PaginatedQuestionsDTO>(url);
 }
 
 export { fetchQuestions };

--- a/apps/web/src/app/daily/questions/_types/types.ts
+++ b/apps/web/src/app/daily/questions/_types/types.ts
@@ -16,6 +16,7 @@ export interface Question {
   avgImportance: number;
   categoryId: number;
   category?: Category;
+  score: number | null;
 }
 
 export interface PaginatedQuestionsDTO {

--- a/apps/web/src/app/daily/questions/page.tsx
+++ b/apps/web/src/app/daily/questions/page.tsx
@@ -158,7 +158,7 @@ async function QuestionListPage({ searchParams }: QuestionListPageProps) {
                 </TableCell>
                 <TableCell className="text-center">
                   {question.score !== null ? (
-                    <span className="text-teal-600 font-medium text-sm bg-teal-50 px-2 py-1 rounded-lg">
+                    <span className="text-teal-600 font-medium text-sm bg-teal-50 px-2 py-1 rounded-sm">
                       {question.score}점
                     </span>
                   ) : (

--- a/apps/web/src/app/daily/questions/page.tsx
+++ b/apps/web/src/app/daily/questions/page.tsx
@@ -1,4 +1,11 @@
 import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/pagination/pagination";
+import {
   Table,
   TableBody,
   TableCell,
@@ -7,20 +14,13 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/table/table";
-import {
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/pagination/pagination";
-import { fetchQuestions } from "./_lib/fetch-questions";
-import {
-  fetchRootCategories,
-  fetchCategoryTree,
-} from "./_lib/fetch-categories";
 import QuestionFilters from "./_components/question-filters";
 import { QuestionLinkButton } from "./_components/question-link-button";
+import {
+  fetchCategoryTree,
+  fetchRootCategories,
+} from "./_lib/fetch-categories";
+import { fetchQuestions } from "./_lib/fetch-questions";
 
 interface QuestionListPageProps {
   searchParams: Promise<{
@@ -28,13 +28,20 @@ interface QuestionListPageProps {
     categoryId?: string;
     subCategoryId?: string;
     search?: string;
+    solvedStatus?: string;
     minImportance?: string;
   }>;
 }
 
 async function QuestionListPage({ searchParams }: QuestionListPageProps) {
-  const { page, categoryId, subCategoryId, search, minImportance } =
-    await searchParams;
+  const {
+    page,
+    categoryId,
+    subCategoryId,
+    search,
+    solvedStatus,
+    minImportance,
+  } = await searchParams;
 
   const parseIntOrNull = (value: string | undefined): number | null => {
     if (!value) return null;
@@ -53,6 +60,7 @@ async function QuestionListPage({ searchParams }: QuestionListPageProps) {
   const selectedCategoryId = parseIntOrNull(categoryId);
   const selectedSubCategoryId = parseIntOrNull(subCategoryId);
   const searchQuery = search ?? "";
+  const selectedSolvedStatus = solvedStatus ?? null;
   const selectedMinImportance = parseFloatOrNull(minImportance);
 
   const rootCategoriesPromise = fetchRootCategories();
@@ -64,6 +72,7 @@ async function QuestionListPage({ searchParams }: QuestionListPageProps) {
     parentCategoryId: selectedCategoryId ?? undefined,
     categoryId: selectedSubCategoryId ?? undefined,
     search: searchQuery || undefined,
+    solvedStatus: selectedSolvedStatus ?? undefined,
     minImportance: selectedMinImportance ?? undefined,
   });
 
@@ -87,6 +96,7 @@ async function QuestionListPage({ searchParams }: QuestionListPageProps) {
     if (categoryId) params.set("categoryId", categoryId);
     if (subCategoryId) params.set("subCategoryId", subCategoryId);
     if (searchQuery) params.set("search", searchQuery);
+    if (solvedStatus) params.set("solvedStatus", solvedStatus);
     if (minImportance) params.set("minImportance", minImportance);
     return `/daily/questions?${params.toString()}`;
   };
@@ -106,6 +116,7 @@ async function QuestionListPage({ searchParams }: QuestionListPageProps) {
         selectedCategoryId={selectedCategoryId}
         selectedSubCategoryId={selectedSubCategoryId}
         searchQuery={searchQuery}
+        selectedSolvedStatus={selectedSolvedStatus}
         selectedMinImportance={selectedMinImportance}
       />
       <Table>
@@ -115,6 +126,7 @@ async function QuestionListPage({ searchParams }: QuestionListPageProps) {
             <TableHead className="w-32">중분류</TableHead>
             <TableHead>문제 제목</TableHead>
             <TableHead className="w-20 text-center">중요도</TableHead>
+            <TableHead className="w-20 text-center">내 점수</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -144,6 +156,15 @@ async function QuestionListPage({ searchParams }: QuestionListPageProps) {
                 <TableCell className="text-center">
                   {(question.avgImportance ?? 0).toFixed(1)}
                 </TableCell>
+                <TableCell className="text-center">
+                  {question.score !== null ? (
+                    <span className="text-teal-600 font-medium text-sm bg-teal-50 px-2 py-1 rounded-lg">
+                      {question.score}점
+                    </span>
+                  ) : (
+                    ""
+                  )}
+                </TableCell>
               </TableRow>
             ))
           )}
@@ -155,7 +176,7 @@ async function QuestionListPage({ searchParams }: QuestionListPageProps) {
                 {startIndex} - {endIndex} / 총 {totalCount}개
               </span>
             </TableCell>
-            <TableCell colSpan={2} className="text-right">
+            <TableCell colSpan={3} className="text-right">
               <Pagination className="justify-end">
                 <PaginationContent>
                   <PaginationItem>

--- a/apps/web/src/app/reports/[questionId]/_components/feedback/feedback-section.stories.tsx
+++ b/apps/web/src/app/reports/[questionId]/_components/feedback/feedback-section.stories.tsx
@@ -1,7 +1,7 @@
-import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import FeedbackSection from "./feedback-section";
-import { ReportDetail } from "../../_types/report-detail";
 import { Question } from "@/app/daily/questions/_types/types";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ReportDetail } from "../../_types/report-detail";
+import FeedbackSection from "./feedback-section";
 
 const MOCK_QUESTION: Question = {
   id: 1,
@@ -12,6 +12,7 @@ const MOCK_QUESTION: Question = {
   avgScore: 85,
   avgImportance: 4,
   categoryId: 101,
+  score: null,
 };
 
 const meta = {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -118,3 +118,12 @@ export async function apiDelete<T>(endpoint: string): Promise<T> {
 
   return response.json();
 }
+
+/**
+ * BFF 요청시 인증된 유저인지 확인하는 헬퍼
+ */
+export async function checkAuthUser(): Promise<boolean> {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("accessToken")?.value;
+  return !!accessToken;
+}


### PR DESCRIPTION
## 🔸 작업 내용
- #228
- #229 
- #230 

## 🔸 고민 했던 부분

### 로그인 / 비로그인 구분 관리
- 문제 풀이 리스트에서는 로그인한 사용자와 로그인하지 않은 사용자가 모두 접속해야하는 상황입니다.
- 로그인 상태에서 자신이 풀은 점수를 제공해야하기 때문에 accessToken을 통해 userId를 받아와야합니다.
- userId를 받아오기 위해서는 decorator를 사용해야하고, decorator에는 guard -> authService가 강하게 결합되어있습니다.
- guard와 authService에서 로그인을 하지 않으면 반드시 401에러를 리턴하기 때문에 코드를 대폭 수정해야합니다.
- 라우터 하나에 선택적으로 guard를 넣는 것은 불가하기 때문에 라우팅을 새로 만들지 기존 코드를 수정할지에 대한 고민을 하였습니다.
- 동일한 기능을 하지만 인증 상태에 따라 사용하는 API를 두 개 만드는 것이 후자의 경우보다 코드 복잡성이 적다고 생각하고 전자의 생각으로 진행하였습니다.
- 프론트엔드에서 서버로 요청을 보내기 전 인증된 유저인지 확인하는 헬퍼함수를 도입하고 이를 사용해서 로그인했을 때와 로그인하지 않았을 때의 요청 URL을 다르게 설정하여 문제를 해결하였습니다.

- **프론트엔드 요청 시퀀스**
```mermaid
sequenceDiagram
    participant Client
    participant fetchQuestions
    participant checkAuthUser
    participant apiGet
    participant API Server

    Client->>fetchQuestions: 호출(params)
    fetchQuestions->>fetchQuestions: URLSearchParams 구성
    fetchQuestions->>checkAuthUser: 인증 상태 확인

    alt 로그인 상태
        checkAuthUser-->>fetchQuestions: true
        fetchQuestions->>apiGet: /questions/auth?{queryString}
        apiGet->>API Server: GET /questions/auth
        API Server-->>apiGet: PaginatedQuestionsDTO (풀이 상태 포함)
    else 비로그인 상태
        checkAuthUser-->>fetchQuestions: false
        fetchQuestions->>apiGet: /questions?{queryString}
        apiGet->>API Server: GET /questions
        API Server-->>apiGet: PaginatedQuestionsDTO
    end

    apiGet-->>fetchQuestions: response
    fetchQuestions-->>Client: PaginatedQuestionsDTO
```

### 문제 리스트와 답변 제출 리스트 매핑
- 문제 리스트를 가져올 때 기존의 쿼리 빌더에 answer-submissions를 left join하는 쿼리와 answer-submissions를 불러와서 합치는 로직 중 어떤 것을 선택해야하나 고민하였습니다.
- 성능상 left join을 통해 쿼리 한 번에 처리하는 것이 좋다고 생각했으나 userId에 따른 필터링 + Query Parameter에 따른 필터링 이중 필터링이 들어가기 때문에 기존 쿼리 빌더에서 작업하는 경우 많이 복잡해질 것이라 생각하였습니다.
- 따라서 각각의 쿼리를 호출하여 점수를 매핑하는 식으로 문제를 해결하였습니다.

## 🔸 참고

https://github.com/user-attachments/assets/d7bc0fcd-9bb5-43bb-8e80-161d3f423c35

<img width="1463" height="133" alt="image" src="https://github.com/user-attachments/assets/5577b200-d591-445a-be4b-7a6056d3da28" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 문제 목록에서 SOLVED/UNSOLVED 필터 지원
  * 테이블에 사용자별 점수(내 점수) 열 추가
  * 인증된 사용자는 개인 점수 정보가 포함된 맞춤형 문제 목록 확인 가능
  * 인증 상태 확인 유틸리티 추가

* **리팩토링**
  * 문제 조회에 제출 데이터 연동해 사용자별 점수 매핑 및 solvedStatus 필터 적용

* **테스트**
  * 점수 매핑 및 solvedStatus 필터 관련 테스트 확장

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->