### PR TITLE
문제–키워드 관계 저장 로직 구현

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,7 @@
     "openapi:validate": "pnpm run openapi:generate && node -e \"const spec = require('./openapi-spec.json'); if (!spec.paths || Object.keys(spec.paths).length === 0) { console.error('OpenAPI 스펙에 경로가 없습니다.'); process.exit(1); } console.log('OpenAPI 스펙 검증 성공');\"",
     "seed": "cross-env NODE_ENV=development ts-node -r tsconfig-paths/register src/seeds/seed.runner.ts",
     "seed:prod": "cross-env NODE_ENV=production ts-node -r tsconfig-paths/register src/seeds/seed.runner.ts",
+    "seed:question": "cross-env NODE_ENV=development ts-node -r tsconfig-paths/register src/seeds/seed.runner.ts CategorySeed,QuestionSeed,QuestionSolutionSeed",
     "migration:create": "pnpm -s exec -- bash -lc \"NAME=${NAME:-ManualMigration} && typeorm-ts-node-commonjs -d src/datasource-cli.ts migration:create migrations/$NAME\"",
     "migration:generate": "cross-env NODE_OPTIONS='-r tsconfig-paths/register' typeorm-ts-node-commonjs -d src/datasource-cli.ts migration:generate migrations/AutoMigration",
     "migration:run": "cross-env NODE_OPTIONS='-r tsconfig-paths/register' typeorm-ts-node-commonjs -d src/datasource-cli.ts migration:run"

--- a/apps/api/src/answer-evaluation/answer-evaluation.module.ts
+++ b/apps/api/src/answer-evaluation/answer-evaluation.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule } from '@nestjs/config';
 import { LlmModule } from '../llm/llm.module';
+import { GraphModule } from '../graph/graph.module';
 import { AnswerEvaluationService } from './answer-evaluation.service';
 import { AnswerEvaluationController } from './answer-evaluation.controller';
 import { AnswerEvaluation } from './entities/answer-evaluation.entity';
@@ -19,6 +20,7 @@ import { QuestionSolution } from 'src/question-solution/entities/question-soluti
     ]),
     ConfigModule,
     LlmModule,
+    GraphModule,
   ],
   controllers: [AnswerEvaluationController],
   providers: [AnswerEvaluationService],

--- a/apps/api/src/answer-evaluation/answer-evaluation.service.spec.ts
+++ b/apps/api/src/answer-evaluation/answer-evaluation.service.spec.ts
@@ -4,6 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { DataSource, EntityManager } from 'typeorm';
 import { AnswerEvaluationService } from './answer-evaluation.service';
 import { LlmService } from '../llm/llm.service';
+import { GraphService } from '../graph/graph.service';
 import {
   AccuracyEval,
   LogicEval,
@@ -41,6 +42,10 @@ describe('AnswerEvaluationService', () => {
     get: jest.fn().mockReturnValue('gemini-2.5-flash-lite-preview-09-2025'),
   };
 
+  const mockGraphService = {
+    createGraphFromEvaluation: jest.fn().mockResolvedValue(undefined),
+  };
+
   const mockEntityManager = {
     update: jest.fn(),
     save: jest.fn(),
@@ -67,6 +72,10 @@ describe('AnswerEvaluationService', () => {
         {
           provide: ConfigService,
           useValue: mockConfigService,
+        },
+        {
+          provide: GraphService,
+          useValue: mockGraphService,
         },
         {
           provide: getRepositoryToken(AnswerEvaluation),
@@ -190,10 +199,15 @@ describe('AnswerEvaluationService', () => {
     it('LLM 호출 후 점수를 계산하고 엔티티를 업데이트해야 한다', async () => {
       const mockSubmission = {
         id: 1,
+        userId: 1,
         questionId: 10,
         rawAnswer: 'User Answer',
       } as AnswerSubmission;
-      const mockQuestion = { content: 'Question Content' };
+      const mockQuestion = {
+        id: 10,
+        title: 'Test Question',
+        content: 'Question Content',
+      };
       const mockSolution = {
         standardDefinition: 'def',
         technicalMechanism: {},
@@ -246,6 +260,14 @@ describe('AnswerEvaluationService', () => {
         expect.objectContaining({
           evaluationStatus: EvaluationStatus.COMPLETED,
         }),
+      );
+
+      // 그래프 생성이 호출되었는지 확인
+      expect(mockGraphService.createGraphFromEvaluation).toHaveBeenCalledWith(
+        1, // userId
+        10, // questionId
+        'Test Question', // questionTitle
+        ['React', 'Hook'], // keywords
       );
     });
 

--- a/apps/api/src/answer-evaluation/answer-evaluation.service.ts
+++ b/apps/api/src/answer-evaluation/answer-evaluation.service.ts
@@ -23,6 +23,7 @@ import { AnswerEvaluation } from './entities/answer-evaluation.entity';
 import { AnswerSubmission } from '../answer-submission/entities/answer-submission.entity';
 import { Question } from '../question/entities/question.entity';
 import { QuestionSolution } from '../question-solution/entities/question-solution.entity';
+import { GraphService } from '../graph/graph.service';
 
 interface AiEvaluationRawResponse {
   accuracy_level: AccuracyEval;
@@ -52,6 +53,7 @@ export class AnswerEvaluationService {
     @InjectRepository(QuestionSolution)
     private readonly questionSolutionRepository: Repository<QuestionSolution>,
     private readonly dataSource: DataSource,
+    private readonly graphService: GraphService,
   ) {
     this.evaluationModel =
       this.configService.get<string>('GEMINI_EVALUATION_MODEL') ||
@@ -240,6 +242,24 @@ export class AnswerEvaluationService {
           score: totalScore,
         });
       });
+
+      // 그래프 데이터 생성 (평가 완료 후 비동기로 처리)
+      // 그래프 생성 실패는 평가 프로세스에 영향을 주지 않도록 별도로 처리
+      if (result.extractedKeywords && result.extractedKeywords.length > 0) {
+        void this.graphService
+          .createGraphFromEvaluation(
+            submission.userId,
+            submission.questionId,
+            questionEntity.title,
+            result.extractedKeywords,
+          )
+          .catch((error) => {
+            this.logger.error(
+              `userId: ${submission.userId}, questionId: ${submission.questionId}에 대한 그래프 데이터 생성에 실패했습니다.`,
+              error,
+            );
+          });
+      }
     } catch (error) {
       this.logger.error(error);
       await this.answerSubmissionRepository.update(submission.id, {

--- a/apps/api/src/graph/entities/graph-edge.entity.ts
+++ b/apps/api/src/graph/entities/graph-edge.entity.ts
@@ -12,12 +12,19 @@ import { GraphNode } from './graph-node.entity';
  * 그래프 엣지 Entity
  * 노드 간 방향 없는 연결 관계를 표현한다
  * (실제 저장은 sourceId/targetId로 하지만, 조회 시 양방향으로 처리 가능)
+ * 사용자별로 독립적인 그래프 구조를 관리한다
  */
 @Entity('graph_edges')
-@Index(['sourceId', 'targetId'], { unique: true })
+@Index(['userId', 'sourceId', 'targetId'], { unique: true })
 export class GraphEdge {
   @PrimaryGeneratedColumn()
   id: number;
+
+  /**
+   * 엣지를 소유한 사용자 ID
+   */
+  @Column({ name: 'user_id', type: 'int' })
+  userId: number;
 
   /**
    * 출발 노드 ID

--- a/apps/api/src/graph/entities/graph-node.entity.ts
+++ b/apps/api/src/graph/entities/graph-node.entity.ts
@@ -12,12 +12,26 @@ import { Question } from '../../question/entities/question.entity';
 /**
  * 그래프 노드 Entity
  * QUESTION 또는 KEYWORD 타입의 노드를 표현한다
+ * 사용자별로 독립적인 그래프 구조를 관리한다
  */
 @Entity('graph_nodes')
-@Index(['type', 'label'], { unique: true, where: `type = 'KEYWORD'` })
+@Index(['userId', 'type', 'label'], {
+  unique: true,
+  where: `type = 'KEYWORD'`,
+})
+@Index(['userId', 'type', 'questionId'], {
+  unique: true,
+  where: `type = 'QUESTION'`,
+})
 export class GraphNode {
   @PrimaryGeneratedColumn()
   id: number;
+
+  /**
+   * 노드를 소유한 사용자 ID
+   */
+  @Column({ name: 'user_id', type: 'int' })
+  userId: number;
 
   /**
    * 노드 타입 (QUESTION 또는 KEYWORD)
@@ -28,7 +42,7 @@ export class GraphNode {
   /**
    * 노드 라벨 (표시용 텍스트)
    * QUESTION 타입: 문제 제목
-   * KEYWORD 타입: 키워드 텍스트 (유니크)
+   * KEYWORD 타입: 키워드 텍스트 (사용자별로 유니크)
    */
   @Column({ type: 'varchar', length: 255 })
   label: string;

--- a/apps/api/src/graph/graph.module.ts
+++ b/apps/api/src/graph/graph.module.ts
@@ -10,6 +10,6 @@ import { AuthModule } from '../auth/auth.module';
   imports: [TypeOrmModule.forFeature([GraphNode, GraphEdge]), AuthModule],
   controllers: [GraphController],
   providers: [GraphService],
-  exports: [TypeOrmModule],
+  exports: [GraphService, TypeOrmModule],
 })
 export class GraphModule {}

--- a/apps/api/src/graph/graph.service.ts
+++ b/apps/api/src/graph/graph.service.ts
@@ -167,8 +167,8 @@ export class GraphService {
         const normalizedKeywords = Array.from(
           new Set(
             keywords
-              .map((k) => k.trim())
-              .filter((k): k is string => !!k && k.length > 0),
+              .filter((k): k is string => typeof k === 'string' && k.length > 0)
+              .map((k) => k.trim()),
           ),
         );
 

--- a/apps/api/src/graph/graph.service.ts
+++ b/apps/api/src/graph/graph.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
-import { Repository, In } from 'typeorm';
+import { Repository } from 'typeorm';
 import { GraphNode } from './entities/graph-node.entity';
 import { GraphEdge } from './entities/graph-edge.entity';
 import {
@@ -13,6 +13,8 @@ import { NodeType } from './graph.constants';
 
 @Injectable()
 export class GraphService {
+  private readonly logger = new Logger(GraphService.name);
+
   constructor(
     @InjectRepository(GraphNode)
     private graphNodeRepository: Repository<GraphNode>,
@@ -26,68 +28,37 @@ export class GraphService {
    * 특정 유저가 학습한 그래프 데이터를 조회한다
    *
    * 조회 로직:
-   * 1. answer_submissions에서 userId로 question_id 목록 조회
-   * 2. 해당 question_id에 연결된 GraphNode (QUESTION 타입) 조회
-   * 3. 해당 노드들과 연결된 GraphEdge 조회
-   * 4. 엣지의 sourceId, targetId를 통해 연결된 모든 노드 조회 (KEYWORD 포함)
-   * 5. nodes와 edges를 반환
+   * 1. 해당 userId의 모든 GraphNode 조회 (QUESTION + KEYWORD)
+   * 2. 해당 userId의 모든 GraphEdge 조회
+   * 3. nodes와 edges를 반환
    *
    * @param userId - 조회할 유저 ID
    * @returns 그래프 데이터 (nodes, edges)
    */
   async getGraphByUserId(userId: number): Promise<GraphResponseDto> {
-    // 1. userId로 학습한 question_id 목록 조회
-    const questionIds = await this.getQuestionIdsByUserId(userId);
-
-    // 학습한 문제가 없으면 빈 그래프 반환
-    if (questionIds.length === 0) {
-      return {
-        nodes: [],
-        edges: [],
-      };
-    }
-
-    // 2. 해당 question_id에 연결된 QUESTION 노드 조회
-    const questionNodes = await this.graphNodeRepository.find({
-      where: {
-        type: NodeType.QUESTION,
-        questionId: In(questionIds),
-      },
-    });
-
-    // QUESTION 노드가 없으면 빈 그래프 반환
-    if (questionNodes.length === 0) {
-      return {
-        nodes: [],
-        edges: [],
-      };
-    }
-
-    const questionNodeIds = questionNodes.map((node) => node.id);
-
-    // 3. 해당 노드들과 연결된 엣지 조회 (sourceId 또는 targetId가 questionNodeIds에 포함)
-    const edges = await this.graphEdgeRepository
-      .createQueryBuilder('edge')
-      .where('edge.sourceId IN (:...nodeIds)', { nodeIds: questionNodeIds })
-      .orWhere('edge.targetId IN (:...nodeIds)', { nodeIds: questionNodeIds })
-      .getMany();
-
-    // 4. 엣지에 연결된 모든 노드 ID 수집 (QUESTION + KEYWORD)
-    const connectedNodeIds = new Set<number>();
-    questionNodeIds.forEach((id) => connectedNodeIds.add(id));
-    edges.forEach((edge) => {
-      connectedNodeIds.add(edge.sourceId);
-      connectedNodeIds.add(edge.targetId);
-    });
-
-    // 5. 연결된 모든 노드 조회 (QUESTION + KEYWORD)
+    // 1. 해당 사용자의 모든 노드 조회 (QUESTION + KEYWORD)
     const allNodes = await this.graphNodeRepository.find({
       where: {
-        id: In(Array.from(connectedNodeIds)),
+        userId: userId,
       },
     });
 
-    // 6. DTO 형태로 변환
+    // 노드가 없으면 빈 그래프 반환
+    if (allNodes.length === 0) {
+      return {
+        nodes: [],
+        edges: [],
+      };
+    }
+
+    // 2. 해당 사용자의 모든 엣지 조회
+    const edges = await this.graphEdgeRepository.find({
+      where: {
+        userId: userId,
+      },
+    });
+
+    // 3. DTO 형태로 변환
     const nodeDtos: GraphNodeDto[] = allNodes.map((node) => ({
       id: node.id,
       type: node.type,
@@ -125,5 +96,120 @@ export class GraphService {
     );
 
     return result.map((row: QuestionIdRow): number => row.question_id);
+  }
+
+  /**
+   * AI 평가 결과로부터 그래프 데이터를 생성한다
+   *
+   * 로직:
+   * 1. 문제 노드 생성 또는 재사용 (userId, questionId로 기존 노드 확인)
+   * 2. 각 키워드에 대해 키워드 노드 생성 또는 재사용 (userId, label로 유니크 제약 활용)
+   * 3. 문제-키워드 간 엣지 생성 (중복 방지)
+   *
+   * @param userId - 사용자 ID
+   * @param questionId - 문제 ID
+   * @param questionTitle - 문제 제목
+   * @param keywords - 추출된 키워드 배열
+   */
+  async createGraphFromEvaluation(
+    userId: number,
+    questionId: number,
+    questionTitle: string,
+    keywords: string[],
+  ): Promise<void> {
+    // 키워드가 없으면 그래프 생성하지 않음
+    if (!keywords || keywords.length === 0) {
+      this.logger.debug(
+        `userId: ${userId}, questionId: ${questionId}에 대해 생성할 키워드가 존재하지 않습니다.`,
+      );
+      return;
+    }
+
+    try {
+      await this.dataSource.transaction(async (manager) => {
+        // 1. 문제 노드 생성 또는 재사용 (사용자별로 독립적)
+        let questionNode = await manager.findOne(GraphNode, {
+          where: {
+            userId: userId,
+            type: NodeType.QUESTION,
+            questionId: questionId,
+          },
+        });
+
+        if (!questionNode) {
+          questionNode = manager.create(GraphNode, {
+            userId: userId,
+            type: NodeType.QUESTION,
+            label: questionTitle,
+            questionId: questionId,
+          });
+          questionNode = await manager.save(GraphNode, questionNode);
+        }
+
+        // 2. 각 키워드에 대해 키워드 노드 생성 또는 재사용 (사용자별로 독립적)
+        const keywordNodes: GraphNode[] = [];
+
+        for (const keyword of keywords) {
+          // 빈 문자열이나 공백만 있는 키워드는 제외
+          if (!keyword || keyword.trim().length === 0) {
+            continue;
+          }
+
+          const trimmedKeyword = keyword.trim();
+
+          // 사용자별 유니크 제약을 활용하여 기존 노드 확인
+          let keywordNode = await manager.findOne(GraphNode, {
+            where: {
+              userId: userId,
+              type: NodeType.KEYWORD,
+              label: trimmedKeyword,
+            },
+          });
+
+          if (!keywordNode) {
+            keywordNode = manager.create(GraphNode, {
+              userId: userId,
+              type: NodeType.KEYWORD,
+              label: trimmedKeyword,
+              questionId: null,
+            });
+            keywordNode = await manager.save(GraphNode, keywordNode);
+          }
+
+          keywordNodes.push(keywordNode);
+        }
+
+        // 3. 문제-키워드 간 엣지 생성 (중복 방지, 사용자별로 독립적)
+        for (const keywordNode of keywordNodes) {
+          // sourceId와 targetId의 순서를 일관되게 유지 (sourceId < targetId)
+          const sourceId = Math.min(questionNode.id, keywordNode.id);
+          const targetId = Math.max(questionNode.id, keywordNode.id);
+
+          // 이미 존재하는 엣지인지 확인 (사용자별로)
+          const existingEdge = await manager.findOne(GraphEdge, {
+            where: {
+              userId: userId,
+              sourceId: sourceId,
+              targetId: targetId,
+            },
+          });
+
+          if (!existingEdge) {
+            const edge = manager.create(GraphEdge, {
+              userId: userId,
+              sourceId: sourceId,
+              targetId: targetId,
+            });
+            await manager.save(GraphEdge, edge);
+          }
+        }
+      });
+    } catch (error) {
+      this.logger.error(
+        `userId: ${userId}, questionId: ${questionId}에 대한 그래프 데이터 생성에 실패했습니다.`,
+        error,
+      );
+      // 그래프 생성 실패는 평가 프로세스를 중단하지 않도록 에러를 throw하지 않음
+    }
   }
 }

--- a/apps/api/src/graph/graph.service.ts
+++ b/apps/api/src/graph/graph.service.ts
@@ -154,7 +154,6 @@ export class GraphService {
             where: {
               userId: userId,
               type: NodeType.QUESTION,
-              label: questionTitle,
               questionId: questionId,
             },
           });

--- a/apps/api/src/graph/graph.service.ts
+++ b/apps/api/src/graph/graph.service.ts
@@ -137,26 +137,43 @@ export class GraphService {
         });
 
         if (!questionNode) {
-          questionNode = manager.create(GraphNode, {
-            userId: userId,
-            type: NodeType.QUESTION,
-            label: questionTitle,
-            questionId: questionId,
+          await manager
+            .createQueryBuilder()
+            .insert()
+            .into(GraphNode)
+            .values({
+              userId: userId,
+              type: NodeType.QUESTION,
+              label: questionTitle,
+              questionId: questionId,
+            })
+            .orIgnore()
+            .execute();
+
+          questionNode = await manager.findOne(GraphNode, {
+            where: {
+              userId: userId,
+              type: NodeType.QUESTION,
+              label: questionTitle,
+              questionId: questionId,
+            },
           });
-          questionNode = await manager.save(GraphNode, questionNode);
+          if (!questionNode) {
+            throw new Error('문제 노드 생성에 실패했습니다.');
+          }
         }
 
         // 2. 각 키워드에 대해 키워드 노드 생성 또는 재사용 (사용자별로 독립적)
         const keywordNodes: GraphNode[] = [];
+        const normalizedKeywords = Array.from(
+          new Set(
+            keywords
+              .map((k) => k.trim())
+              .filter((k): k is string => !!k && k.length > 0),
+          ),
+        );
 
-        for (const keyword of keywords) {
-          // 빈 문자열이나 공백만 있는 키워드는 제외
-          if (!keyword || keyword.trim().length === 0) {
-            continue;
-          }
-
-          const trimmedKeyword = keyword.trim();
-
+        for (const trimmedKeyword of normalizedKeywords) {
           // 사용자별 유니크 제약을 활용하여 기존 노드 확인
           let keywordNode = await manager.findOne(GraphNode, {
             where: {

--- a/apps/api/src/seeds/seed.runner.ts
+++ b/apps/api/src/seeds/seed.runner.ts
@@ -6,6 +6,12 @@ import { AppModule } from '../app.module';
 async function runSeeds() {
   console.log('🌱 Starting seed process...\n');
 
+  // 명령줄 인자 또는 환경 변수로 특정 시드 필터링
+  const seedFilter = process.argv[2] || process.env.SEED_FILTER;
+  const seedNames = seedFilter
+    ? seedFilter.split(',').map((name) => name.trim())
+    : null;
+
   // NestJS ApplicationContext 생성 (서버 띄우지 않음)
   const app = await NestFactory.createApplicationContext(AppModule, {
     logger: ['error', 'warn', 'log'],
@@ -27,7 +33,31 @@ async function runSeeds() {
     await queryRunner.connect();
     await queryRunner.startTransaction();
 
-    const seedsToRun = seeds.filter((seed) => seed.shouldRun());
+    let seedsToRun = seeds.filter((seed) => seed.shouldRun());
+
+    // 특정 시드만 필터링
+    if (seedNames && seedNames.length > 0) {
+      seedsToRun = seedsToRun.filter((seed) =>
+        seedNames.some(
+          (name) =>
+            seed.name.toLowerCase().includes(name.toLowerCase()) ||
+            name.toLowerCase() === 'all',
+        ),
+      );
+
+      if (seedsToRun.length === 0) {
+        console.warn(`⚠️  No seeds found matching: ${seedNames.join(', ')}\n`);
+        console.log('Available seeds:');
+        seeds.forEach((seed) => {
+          console.log(`  - ${seed.name}`);
+        });
+        return;
+      }
+
+      console.log(
+        `📌 Running filtered seeds: ${seedsToRun.map((s) => s.name).join(', ')}\n`,
+      );
+    }
 
     // Seed 순차 실행
     for (const seed of seedsToRun) {


### PR DESCRIPTION
## 🔸 작업 내용

- #5
- AI 평가 결과로 추출된 키워드를 기반으로 사용자 개인별 학습 그래프 모델 구축
- 문제 → 키워드 → 개념 노드로 확장 가능한 구조 설계 및 구현

### 주요 변경 사항

1. **그래프 엔티티 수정**
   - `GraphNode`와 `GraphEdge`에 `userId` 필드 추가
   - 사용자별로 독립적인 그래프 구조 관리
   - 유니크 제약 조건 수정: `(userId, type, label)` 조합으로 키워드 노드 관리
 
> graph_nodes에 user_id를 NOT NULL로 추가하려 하면 기존 데이터에 user_id 값이 없어 실패할 수 있습니다.  
> 먼저 nullable로 추가하고, 기존 데이터에 user_id를 설정한 뒤 NOT NULL 제약을 추가해야합니다!  
> 1) user_id를 nullable로 추가  
> 2) 기존 데이터에 user_id 값 설정  
> 3) NOT NULL 제약 조건 추가  

2. **그래프 생성 로직 구현**
   - `GraphService.createGraphFromEvaluation()` 메서드 추가
   - 문제 노드 생성/재사용 (사용자별로 독립적)
   - 키워드 노드 생성/재사용 (사용자별 유니크 제약 활용)
   - 문제-키워드 간 엣지 생성 (중복 방지)

3. **평가 완료 시 그래프 자동 생성**
   - `AnswerEvaluationService`에서 평가 완료 후 그래프 생성 로직 호출
   - 그래프 생성 실패가 평가 프로세스에 영향을 주지 않도록 에러 처리

4. **그래프 조회 로직 개선**
   - `getGraphByUserId()` 메서드 단순화
   - 사용자별로 직접 필터링하여 조회 성능 개선

5. **시드 실행 기능 추가**
   - 특정 시드만 실행할 수 있는 필터링 기능 추가
   - `pnpm seed:question` 명령어로 문제 관련 시드만 실행 가능

## 🔸 고민 했던 부분

### 1. 전역 그래프 vs 사용자별 그래프

**고민**: 초기에는 모든 사용자가 공유하는 전역 그래프 구조로 설계했습니다. 하지만 사용자마다 같은 문제에 대해 다른 키워드가 추출될 수 있다는 점을 고려해야 했습니다.

**결과**: 사용자별로 독립적인 그래프 구조로 변경했습니다. 이렇게 하면:
- 각 사용자의 학습 이력에 맞는 개인화된 그래프 제공
- 같은 문제에 대해 사용자별로 다른 키워드 추출 가능
- 사용자 간 데이터 혼선 방지

### 2. 그래프 생성 실패 처리

**고민**: 그래프 생성이 실패할 경우 평가 프로세스 전체가 실패하는 것을 방지해야 했습니다.

**결과**: 그래프 생성 로직을 비동기로 처리하고, 에러 발생 시 로깅만 하고 평가 프로세스는 정상적으로 완료되도록 구현했습니다.

### 3. 키워드 노드 재사용 전략

**고민**: 같은 사용자가 여러 문제에서 같은 키워드를 사용할 경우, 키워드 노드를 재사용해야 합니다.

**결과**: `(userId, type, label)` 조합으로 유니크 제약을 설정하여, 같은 사용자의 같은 키워드는 자동으로 재사용되도록 구현했습니다.

## 🔸 참고

### 테스트 방법

1. 문제 풀이 완료 후 그래프 데이터 생성 확인:
   ```bash
   # API 서버 실행 후 문제 풀이 완료
   # 평가 완료 시 자동으로 그래프 데이터 생성됨
   ```

2. 사용자별 그래프 조회:
   ```bash
   GET /graph
   Authorization: Bearer {token}
   ```

<img width="1124" height="563" alt="스크린샷 2026-01-22 23 26 43" src="https://github.com/user-attachments/assets/3baeb64c-d427-4140-9d88-581221196d3f" />

- Swagger 조회

<img width="564" height="138" alt="스크린샷 2026-01-22 23 26 26" src="https://github.com/user-attachments/assets/a2487f4f-39af-4ad0-aaaf-c511230716be" />

- DB 저장 테이블 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자별 지식 그래프 도입: 각 사용자는 독립적인 노드·엣지 집합을 가집니다.
  * 평가 결과로 사용자 그래프를 생성하는 비동기 흐름 추가.

* **개선**
  * 그래프 서비스가 모듈 외부로 제공되어 평가 흐름에서 사용 가능해짐.
  * 그래프 조회 로직 단순화 및 오류 비차단 처리.

* **테스트**
  * 평가 후 그래프 생성 흐름에 대한 단위 테스트 보강.

* **잡일**
  * 시드 로더에 필터링 옵션 및 실행 스크립트(seed:question) 추가.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->