### PR TITLE
그래프 줌 레벨에 따라서 edge의 width가 변하지 않도록 수정함

### DIFF
--- a/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
+++ b/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
@@ -124,7 +124,7 @@ function GraphView({
     // onMouseUp: 드래그 종료
     // onMouseLeave: 캔버스 밖으로 나갈 때 드래그 종료 (마우스 업과 동일한 처리)
     <canvas
-      className="w-full h-full  "
+      className="w-full h-full"
       ref={canvasRef}
       onMouseDown={handleMouseDown}
       onMouseMove={handleMouseMove}

--- a/apps/web/src/app/mypage/_constants/graph-view-constant.ts
+++ b/apps/web/src/app/mypage/_constants/graph-view-constant.ts
@@ -4,14 +4,17 @@ export const GRAPH_NUMBER_CONSTANT = {
   MAX_SCALE: 2.3,
   EDGE_DISTANCE: 100,
   VELOCITY_THRESHOLD: 0.05, // 기존 0.01에서 수렴 속도 빠르게 조정하기 위해 0.05 높임
+  EDGE_STROKE_WIDTH: 2,
+  MIN_EDGE_STROKE_WIDTH: 2, // 줌 아웃 시 최소 시각적 굵기 (픽셀 단위)
+  MAX_EDGE_STROKE_WIDTH: 2, // 줌 인 시 최대 시각적 굵기 (픽셀 단위)
 } as const;
 
 export const GRAPH_COLOR_CONSTANT = {
-  QUESTION_NODE: "#0d9488", // teal-600
-  KEYWORD_NODE: "#334155", // slate-700
-  EDGE: "#94a3b8", // slate-400
+  QUESTION_NODE: "#00b39e", // teal-600
+  KEYWORD_NODE: "#525252", // slate-700
+  EDGE: "#e1e1e1", // slate-400
   HOVERED: "#2dd4bf", // teal-400
-  LABEL: "#333333",
+  LABEL: "#393939",
   NOT_HOVERED_ALPHA: 0.2,
 };
 

--- a/apps/web/src/app/mypage/_contents/graph-content.tsx
+++ b/apps/web/src/app/mypage/_contents/graph-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { BarChart3, ExpandIcon } from "lucide-react";
+import { BarChart3, Expand } from "lucide-react";
 import GraphView from "../_components/graph-view/graph-view";
 import NodeMap from "../_components/graph-view/node-map";
 import { GraphData } from "../_types/graph-view";
@@ -40,8 +40,9 @@ function GraphContent({ graphData }: { graphData: GraphData }) {
             size="icon"
             variant="outline"
             className="absolute right-0 top-8"
+            aria-label="그래프 확대"
           >
-            <ExpandIcon className="text-muted-foreground" />
+            <Expand className="text-muted-foreground" />
           </Button>
           <GraphView graphData={graphData} changeNodeMap={changeNodeMap} />
         </div>

--- a/apps/web/src/app/mypage/_contents/graph-content.tsx
+++ b/apps/web/src/app/mypage/_contents/graph-content.tsx
@@ -1,17 +1,18 @@
 "use client";
 
 import * as React from "react";
-import { BarChart3 } from "lucide-react";
+import { BarChart3, ExpandIcon } from "lucide-react";
 import GraphView from "../_components/graph-view/graph-view";
 import NodeMap from "../_components/graph-view/node-map";
 import { GraphData } from "../_types/graph-view";
+import { Button } from "@/components/button/button";
 
 function GraphContent({ graphData }: { graphData: GraphData }) {
   const [openModalStatus, setOpenModalStatus] = React.useState(false);
   const [nodeMap, setNodeMap] = React.useState<NodeMap>();
 
-  const handleModalClose = React.useCallback(() => {
-    setOpenModalStatus(false);
+  const handleModalToggle = React.useCallback(() => {
+    setOpenModalStatus((prev) => !prev);
   }, []);
 
   const changeNodeMap = React.useCallback((map: NodeMap) => {
@@ -33,13 +34,21 @@ function GraphContent({ graphData }: { graphData: GraphData }) {
           </p>
         </div>
       ) : (
-        <div className="w-full h-200">
+        <div className="relative w-full aspect-square">
+          <Button
+            onClick={handleModalToggle}
+            size="icon"
+            variant="outline"
+            className="absolute right-0 top-8"
+          >
+            <ExpandIcon className="text-muted-foreground" />
+          </Button>
           <GraphView graphData={graphData} changeNodeMap={changeNodeMap} />
         </div>
       )}
       {openModalStatus && (
         <div
-          onClick={handleModalClose}
+          onClick={handleModalToggle}
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-in fade-in duration-200"
         >
           <div

--- a/apps/web/src/app/mypage/_contents/graph-content.tsx
+++ b/apps/web/src/app/mypage/_contents/graph-content.tsx
@@ -1,6 +1,7 @@
 "use client";
-import { BarChart3, Maximize2 } from "lucide-react";
+
 import * as React from "react";
+import { BarChart3 } from "lucide-react";
 import GraphView from "../_components/graph-view/graph-view";
 import NodeMap from "../_components/graph-view/node-map";
 import { GraphData } from "../_types/graph-view";
@@ -8,10 +9,6 @@ import { GraphData } from "../_types/graph-view";
 function GraphContent({ graphData }: { graphData: GraphData }) {
   const [openModalStatus, setOpenModalStatus] = React.useState(false);
   const [nodeMap, setNodeMap] = React.useState<NodeMap>();
-
-  const handleModalOpen = React.useCallback(() => {
-    setOpenModalStatus(true);
-  }, []);
 
   const handleModalClose = React.useCallback(() => {
     setOpenModalStatus(false);
@@ -23,21 +20,6 @@ function GraphContent({ graphData }: { graphData: GraphData }) {
 
   return (
     <>
-      <div className="flex py-8 justify-between items-center">
-        <div className="flex flex-col justify-start gap-2">
-          <span className="text-lg font-bold text-slate-900">지식 그래프</span>
-          <span className="text-sm font-medium text-slate-500">
-            개념 간의 연결 고리를 시각화합니다.
-          </span>
-        </div>
-        <button
-          onClick={handleModalOpen}
-          disabled={graphData.nodes.length === 0}
-          className="flex justify-center items-center w-10 h-10 border border-slate-200 bg-white rounded-xl disabled:cursor-not-allowed"
-        >
-          <Maximize2 className="w-5 h-5" stroke="#94A3B8" />
-        </button>
-      </div>
       {graphData.nodes.length === 0 ? (
         <div className="flex flex-col h-full w-full items-center justify-center py-12 text-center">
           <div className="w-16 h-16 mb-4 rounded-full bg-gray-100 flex items-center justify-center">
@@ -51,7 +33,7 @@ function GraphContent({ graphData }: { graphData: GraphData }) {
           </p>
         </div>
       ) : (
-        <div className="border border-slate-200 rounded-md">
+        <div className="w-full h-200">
           <GraphView graphData={graphData} changeNodeMap={changeNodeMap} />
         </div>
       )}
@@ -64,7 +46,7 @@ function GraphContent({ graphData }: { graphData: GraphData }) {
             onClick={(e) => e.stopPropagation()}
             className="bg-white rounded-2xl w-full h-full max-w-5xl max-h-5/6 shadow-xl overflow-hidden relative"
           >
-            <div className="w-full h-full ">
+            <div className="w-full h-full">
               <GraphView graphData={graphData} nodeMap={nodeMap} />
             </div>
           </div>

--- a/apps/web/src/app/mypage/_lib/graph-view/draw-graph-view.ts
+++ b/apps/web/src/app/mypage/_lib/graph-view/draw-graph-view.ts
@@ -26,7 +26,16 @@ function drawGraphView(
 
   const hoveredSet = new Set<number>();
 
-  ctx.lineWidth = 1;
+  // 줌 레벨에 따라 시각적 굵기를 min/max 범위 내로 유지
+  const minVisualWidth = GRAPH_NUMBER_CONSTANT.MIN_EDGE_STROKE_WIDTH;
+  const maxVisualWidth = GRAPH_NUMBER_CONSTANT.MAX_EDGE_STROKE_WIDTH;
+  const baseWidth = GRAPH_NUMBER_CONSTANT.EDGE_STROKE_WIDTH;
+  const clampedVisualWidth = Math.max(
+    minVisualWidth,
+    Math.min(baseWidth * scale, maxVisualWidth),
+  );
+  ctx.lineWidth = clampedVisualWidth / scale;
+
   edges.forEach((edge) => {
     const source = nodes.get(edge.sourceId);
     const target = nodes.get(edge.targetId);
@@ -54,7 +63,7 @@ function drawGraphView(
     ctx.stroke();
   });
 
-  ctx.font = "12px sans-serif";
+  ctx.font = "8px sans-serif";
   ctx.textAlign = "center";
   nodes.forEach((node) => {
     const isHovered = node.id === hoveredNode;


### PR DESCRIPTION
## 🔸 작업 내용

- 그래프 edge의 색상을 전체적으로 더 연하게 조정했습니다. 기존에는 색이 다소 짙어 시각적으로 복잡해 보이는 문제가 있었습니다.
- edge 색상이 옅어지면서 줌 아웃 시 선이 지나치게 가늘어져 식별이 어려운 문제가 발생해, edge의 최소·최대 너비를 고정하여 줌 레벨과 관계없이 명확하게 보이도록 개선했습니다.

## 🔸 고민 했던 부분

**문제 상황:**

* 그래프를 줌 아웃할수록 edge의 실제 렌더링 두께가 지나치게 얇아져 식별이 어려워짐
* 반대로 줌 인 시에는 edge가 과도하게 두꺼워져 시각적 균형이 무너질 수 있음
* 캔버스의 `lineWidth`가 줌 스케일에 직접적으로 영향을 받아, 화면에서 인지되는 두께를 일관되게 유지하기 어려움

**해결 방법:**

* 줌 레벨과 무관하게 유지되어야 하는 **시각적 두께(visual width)** 개념을 기준으로 접근함
* `baseWidth * scale` 값을 기준으로 최소·최대 시각적 두께 범위를 설정하고 clamp 처리함
* 어떤 줌 레벨에서도 edge가 너무 얇거나 두껍지 않도록 시각적 가독성을 보장함
* clamp된 시각적 두께를 `scale`로 나누어 `ctx.lineWidth`에 적용해 실제 렌더링 두께를 보정함

## 🔸 참고

그래프 edge 고정 너비 적용 전:


https://github.com/user-attachments/assets/9a1cf583-46c1-4833-bdfe-e5532c2dbffc


그래프 edge 고정 너비 적용 후:



https://github.com/user-attachments/assets/a0cc9383-3d77-4ad9-bbaf-227c49697e0c






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 그래프 뷰 레이아웃 간소화 및 전체화면 토글 버튼 추가로 사용성 향상
  * 색상 팔레트 업데이트로 시각적 일관성 향상
  * 줌 레벨에 따라 엣지 두께를 자동 보정해 시각적 일관성 유지
  * 노드 라벨 폰트 크기 조정으로 가독성 개선

* **스타일**
  * 소소한 UI 포맷팅 및 버튼 위치/표시 방식 조정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->