### PR TITLE
마이크 연결이 안됐을 때 에러 메시지 표현

### DIFF
--- a/apps/web/src/app/daily/questions/[questionId]/_components/voice-input.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/_components/voice-input.tsx
@@ -3,8 +3,15 @@
 import * as React from "react";
 import Waveform from "@/components/waveform/waveform";
 import { Button } from "@/components/button/button";
-import { CheckCircle2, LoaderCircle, RotateCcw } from "lucide-react";
-import useRecorder from "../_hooks/use-recorder";
+import {
+  CheckCircle2,
+  LoaderCircle,
+  RotateCcw,
+  MicOff,
+  ShieldAlert,
+  AlertCircle,
+} from "lucide-react";
+import useRecorder, { RecorderStatus } from "../_hooks/use-recorder";
 import RecordButton from "./record-button";
 import useWav from "@/hooks/use-wav";
 import {
@@ -35,6 +42,7 @@ function VoiceInput({
   disabled = false,
 }: VoiceInputProps) {
   const {
+    status,
     historyRef,
     isRecording,
     hasRecorded,
@@ -97,53 +105,109 @@ function VoiceInput({
     }
   };
 
+  const isStatusError =
+    status === "unsupported" ||
+    status === "permission_denied" ||
+    status === "no_device";
+
   return (
     <div className="bg-white border rounded-xl h-100 flex flex-col items-center justify-center">
-      <StatusMessage
-        state={recordingState}
-        elapsedSeconds={elapsedSeconds}
-        maxDurationSeconds={maxDurationSeconds}
-      />
-
-      <div className="max-w-lg">
-        <Waveform historyRef={historyRef} />
-      </div>
-
-      <div className="flex items-center justify-center h-24">
-        {recordingState !== "recorded" ? (
-          <RecordButton
-            isRecording={isRecording}
-            onClick={isRecording ? stopRecording : handleStartRecording}
-            disabled={isSubmitting || disabled}
+      {isStatusError ? (
+        <StatusError status={status} />
+      ) : (
+        <>
+          <StatusMessage
+            state={recordingState}
+            elapsedSeconds={elapsedSeconds}
+            maxDurationSeconds={maxDurationSeconds}
           />
-        ) : (
-          <div className="flex items-center gap-3 animate-in fade-in slide-in-from-bottom-2 duration-300">
-            <Button
-              size="lg"
-              type="button"
-              variant="outline"
-              onClick={retryRecording}
-              disabled={isSubmitting}
-            >
-              <RotateCcw className="w-4 h-4" /> 다시 시도
-            </Button>
-            <Button
-              type="button"
-              size="lg"
-              disabled={isSubmitting || disabled}
-              className="pl-6 pr-6 font-semibold"
-              onClick={handleSubmit}
-            >
-              답변 제출
-              {isSubmitting ? (
-                <LoaderCircle className="w-4 h-4 animate-spin" />
-              ) : (
-                <CheckCircle2 className="w-4 h-4" />
-              )}
-            </Button>
+
+          <div className="max-w-lg">
+            <Waveform historyRef={historyRef} />
           </div>
-        )}
+
+          <div className="flex items-center justify-center h-24">
+            {recordingState !== "recorded" ? (
+              <RecordButton
+                isRecording={isRecording}
+                onClick={isRecording ? stopRecording : handleStartRecording}
+                disabled={isSubmitting || disabled}
+              />
+            ) : (
+              <div className="flex items-center gap-3 animate-in fade-in slide-in-from-bottom-2 duration-300">
+                <Button
+                  size="lg"
+                  type="button"
+                  variant="outline"
+                  onClick={retryRecording}
+                  disabled={isSubmitting}
+                >
+                  <RotateCcw className="w-4 h-4" /> 다시 시도
+                </Button>
+                <Button
+                  type="button"
+                  size="lg"
+                  disabled={isSubmitting || disabled}
+                  className="pl-6 pr-6 font-semibold"
+                  onClick={handleSubmit}
+                >
+                  답변 제출
+                  {isSubmitting ? (
+                    <LoaderCircle className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <CheckCircle2 className="w-4 h-4" />
+                  )}
+                </Button>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+interface StatusErrorProps {
+  status: RecorderStatus;
+}
+
+function StatusError({ status }: StatusErrorProps) {
+  const config = {
+    unsupported: {
+      icon: AlertCircle,
+      title: "지원되지 않는 브라우저",
+      description:
+        "이 브라우저는 음성 녹음을 지원하지 않습니다. Chrome, Safari 등 최신 브라우저를 이용해주세요.",
+    },
+    permission_denied: {
+      icon: ShieldAlert,
+      title: "마이크 권한 필요",
+      description:
+        "음성 녹음을 위해 마이크 권한이 필요합니다. 브라우저 설정에서 마이크 권한을 허용해주세요.",
+    },
+    no_device: {
+      icon: MicOff,
+      title: "마이크를 찾을 수 없음",
+      description:
+        "연결된 마이크 장치가 없습니다. 마이크를 연결하고 다시 시도해주세요.",
+    },
+  } as const;
+
+  const current = config[status as keyof typeof config];
+
+  if (!current) return null;
+
+  const Icon = current.icon;
+
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-center px-6">
+      <div className="w-16 h-16 mb-4 rounded-full bg-red-50 flex items-center justify-center">
+        <Icon className="w-8 h-8 text-red-500" />
       </div>
+      <h3 className="text-lg font-semibold text-gray-900 mb-2">
+        {current.title}
+      </h3>
+      <p className="text-sm text-gray-500 max-w-sm">{current.description}</p>
     </div>
   );
 }

--- a/apps/web/src/app/daily/questions/[questionId]/_hooks/use-recorder.ts
+++ b/apps/web/src/app/daily/questions/[questionId]/_hooks/use-recorder.ts
@@ -6,13 +6,53 @@ import {
   WAVEFORM_CONFIG,
 } from "../_constants/audio-config-constant";
 
+export type RecorderStatus =
+  | "unsupported"
+  | "permission_denied"
+  | "permission_prompt"
+  | "no_device"
+  | "ready";
+
 interface UseRecorderOptions {
   maxDurationSeconds?: number;
+}
+
+function checkBrowserSupport(): boolean {
+  return !!(
+    typeof navigator !== "undefined" &&
+    navigator.mediaDevices &&
+    typeof navigator.mediaDevices.getUserMedia === "function"
+  );
+}
+
+async function checkMicrophoneDevice(): Promise<boolean> {
+  try {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    return devices.some((device) => device.kind === "audioinput");
+  } catch {
+    return false;
+  }
+}
+
+async function getPermissionState(): Promise<PermissionState | null> {
+  try {
+    if (navigator.permissions && navigator.permissions.query) {
+      const result = await navigator.permissions.query({
+        name: "microphone" as PermissionName,
+      });
+      return result.state;
+    }
+  } catch {
+    // Permissions API not supported or microphone permission query not allowed
+  }
+  return null;
 }
 
 function useRecorder(options: UseRecorderOptions = {}) {
   const { maxDurationSeconds = 300 } = options;
 
+  const [status, setStatus] =
+    React.useState<RecorderStatus>("permission_prompt");
   const [isRecording, setIsRecording] = React.useState(false);
   const [elapsedSeconds, setElapsedSeconds] = React.useState(0);
   const [hasRecorded, setHasRecorded] = React.useState(false);
@@ -36,6 +76,89 @@ function useRecorder(options: UseRecorderOptions = {}) {
     count: 0,
     nextFlushAt: 0,
   });
+
+  // 상태 체크 함수
+  const checkStatus = React.useCallback(async (): Promise<RecorderStatus> => {
+    // 1. 브라우저 지원 확인
+    if (!checkBrowserSupport()) {
+      return "unsupported";
+    }
+
+    // 2. 권한 상태 확인
+    const permissionState = await getPermissionState();
+
+    if (permissionState === "denied") {
+      return "permission_denied";
+    }
+
+    if (permissionState === "prompt") {
+      return "permission_prompt";
+    }
+
+    // 3. granted 상태이거나 Permissions API 미지원 시 디바이스 확인
+    if (permissionState === "granted") {
+      const hasDevice = await checkMicrophoneDevice();
+      if (!hasDevice) {
+        return "no_device";
+      }
+      return "ready";
+    }
+
+    // Permissions API 미지원 시 permission_prompt로 간주
+    return "permission_prompt";
+  }, []);
+
+  // 초기 상태 체크 및 권한 변경 리스너
+  React.useEffect(() => {
+    let permissionStatus: PermissionStatus | null = null;
+
+    const updateStatus = async () => {
+      const newStatus = await checkStatus();
+      setStatus(newStatus);
+    };
+
+    void updateStatus();
+
+    // 권한 변경 리스너 등록
+    const setupPermissionListener = async () => {
+      try {
+        if (navigator.permissions && navigator.permissions.query) {
+          permissionStatus = await navigator.permissions.query({
+            name: "microphone" as PermissionName,
+          });
+          permissionStatus.addEventListener("change", updateStatus);
+        }
+      } catch {
+        // Permissions API not supported
+      }
+    };
+
+    void setupPermissionListener();
+
+    // 디바이스 변경 리스너 등록
+    const handleDeviceChange = () => {
+      void updateStatus();
+    };
+
+    if (navigator.mediaDevices) {
+      navigator.mediaDevices.addEventListener(
+        "devicechange",
+        handleDeviceChange,
+      );
+    }
+
+    return () => {
+      if (permissionStatus) {
+        permissionStatus.removeEventListener("change", updateStatus);
+      }
+      if (navigator.mediaDevices) {
+        navigator.mediaDevices.removeEventListener(
+          "devicechange",
+          handleDeviceChange,
+        );
+      }
+    };
+  }, [checkStatus]);
 
   // AudioStreamer 초기화 (한 번만 실행)
   React.useEffect(() => {
@@ -111,10 +234,35 @@ function useRecorder(options: UseRecorderOptions = {}) {
       // 오디오 스트리머 시작
       await streamerRef.current?.start();
 
+      setStatus("ready");
       setIsRecording(true);
     } catch (error) {
       console.error("Failed to start recording:", error);
       setIsRecording(false);
+
+      // 에러 유형에 따라 상태 업데이트
+      if (error instanceof Error) {
+        const errorName = error.name;
+        const errorMessage = error.message.toLowerCase();
+
+        if (
+          errorName === "NotAllowedError" ||
+          errorMessage.includes("permission denied")
+        ) {
+          setStatus("permission_denied");
+        } else if (
+          errorName === "NotFoundError" ||
+          errorMessage.includes("no device") ||
+          errorMessage.includes("not found")
+        ) {
+          setStatus("no_device");
+        } else if (
+          errorName === "NotSupportedError" ||
+          errorMessage.includes("not supported")
+        ) {
+          setStatus("unsupported");
+        }
+      }
     }
   }, []);
 
@@ -185,7 +333,17 @@ function useRecorder(options: UseRecorderOptions = {}) {
     };
   }, [isRecording, maxDurationSeconds, stopRecording]);
 
+  // 상태 새로고침 함수 (수동 호출용)
+  const refreshStatus = React.useCallback(async () => {
+    const newStatus = await checkStatus();
+    setStatus(newStatus);
+    return newStatus;
+  }, [checkStatus]);
+
   return {
+    status,
+    refreshStatus,
+
     historyRef,
 
     isRecording,

--- a/apps/web/src/app/daily/questions/[questionId]/_hooks/use-recorder.ts
+++ b/apps/web/src/app/daily/questions/[questionId]/_hooks/use-recorder.ts
@@ -126,7 +126,9 @@ function useRecorder(options: UseRecorderOptions = {}) {
           permissionStatus = await navigator.permissions.query({
             name: "microphone" as PermissionName,
           });
-          permissionStatus.addEventListener("change", updateStatus);
+          if (typeof permissionStatus.addEventListener === "function") {
+            permissionStatus.addEventListener("change", updateStatus);
+          }
         }
       } catch {
         // Permissions API not supported
@@ -140,7 +142,10 @@ function useRecorder(options: UseRecorderOptions = {}) {
       void updateStatus();
     };
 
-    if (navigator.mediaDevices) {
+    if (
+      navigator.mediaDevices &&
+      typeof navigator.mediaDevices.addEventListener === "function"
+    ) {
       navigator.mediaDevices.addEventListener(
         "devicechange",
         handleDeviceChange,
@@ -148,10 +153,16 @@ function useRecorder(options: UseRecorderOptions = {}) {
     }
 
     return () => {
-      if (permissionStatus) {
+      if (
+        permissionStatus &&
+        typeof permissionStatus.removeEventListener === "function"
+      ) {
         permissionStatus.removeEventListener("change", updateStatus);
       }
-      if (navigator.mediaDevices) {
+      if (
+        navigator.mediaDevices &&
+        typeof navigator.mediaDevices.removeEventListener === "function"
+      ) {
         navigator.mediaDevices.removeEventListener(
           "devicechange",
           handleDeviceChange,


### PR DESCRIPTION
## 🔸 작업 내용

- use-recorder.tsx 훅에 마이크 상태를 반환하는 기능 추가
- 상태는 다음과 같이 정의함
  - 'unsupported': 브라우저가 관련 API를 지원하지 않음
  - 'permission_denied': 마이크 권한 거부
  - 'permission_prompt': 아직 권한 요청 전이거나 권한 요청이 필요한 상태
  - 'no_device': 권한은 있지만 마이크 장치가 없음(또는 OS/브라우저가 인식 못함)
  - 'ready': 권한 있고, 마이크 장치가 존재하며, (선택된 장치 기준으로) 스트림이 정상
 - 이 상태에 따라서 UI를 바꿔서 보여줌.

## 🔸 참고

마이크 권한은 브라우저에서 직접 다시 활성화할 수 없으며, 사용자가 브라우저 설정 화면에서 수동으로 권한을 변경해야 합니다. 이에 따라 다음과 같은 UI를 구성했습니다.

<img width="886" height="481" alt="Screenshot 2026-01-26 at 4 42 27 PM" src="https://github.com/user-attachments/assets/e0c2e9d3-b980-4a26-8bcd-bf62179e38fb" />
<img width="876" height="473" alt="Screenshot 2026-01-26 at 4 42 17 PM" src="https://github.com/user-attachments/assets/6cfb2062-4979-4f64-842a-b8c2deea904c" />
<img width="864" height="470" alt="Screenshot 2026-01-26 at 4 42 06 PM" src="https://github.com/user-attachments/assets/0bab6c0e-1ac3-4741-82db-34f3133e166c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 음성 입력 상태가 더 세분화되어 브라우저 미지원, 권한 거부, 권한 요청, 장치 미연결, 준비 완료 등을 감지하고 표시합니다.
  * 상태 재확인 기능이 추가되어 사용자가 상태를 수동으로 새로고침할 수 있습니다.

* **버그 수정**
  * 오류 발생 시 이전의 실패-재시도 UI를 대체하는 명확한 상태 안내 화면으로 개선되어 문제 원인을 쉽게 파악할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->