### PR TITLE
그래프뷰 수정

### DIFF
--- a/apps/web/src/app/mypage/_components/graph-view/use-graph-interaction.ts
+++ b/apps/web/src/app/mypage/_components/graph-view/use-graph-interaction.ts
@@ -74,8 +74,8 @@ function useGraphInteraction(
         const dx = graphX - node.x;
         const dy = graphY - node.y;
         const distance = Math.sqrt(dx * dx + dy * dy);
-        //노드 반지름 + 5해서 노드 보다 조금 넓은 범위 클릭하면 선택할 수 있게
-        if (distance <= GRAPH_NUMBER_CONSTANT.NODE_RADIUS + 5) {
+        //노드 반지름 +10해서 노드 보다 조금 넓은 범위 클릭하면 선택할 수 있게
+        if (distance <= GRAPH_NUMBER_CONSTANT.NODE_RADIUS + 10) {
           return node;
         }
       }

--- a/apps/web/src/app/mypage/_lib/graph-view/draw-graph-view.ts
+++ b/apps/web/src/app/mypage/_lib/graph-view/draw-graph-view.ts
@@ -63,15 +63,22 @@ function drawGraphView(
     ctx.stroke();
   });
 
-  ctx.font = "8px sans-serif";
+  const fontFamily = window.getComputedStyle(document.body).fontFamily;
+  ctx.font = `8px ${fontFamily}`;
   ctx.textAlign = "center";
+  const textAlpha = Math.min(
+    1,
+    Math.max(0, (scale - textRenderScale) / textRenderScale),
+  );
   nodes.forEach((node) => {
     const isHovered = node.id === hoveredNode;
     const isHighlighted = hoveredSet.has(node.id);
     const isDimmed = hoveredNode !== null && !isHovered && !isHighlighted;
-    const radius = isHovered
-      ? GRAPH_NUMBER_CONSTANT.NODE_RADIUS + 2
-      : GRAPH_NUMBER_CONSTANT.NODE_RADIUS;
+    const nodeRadius =
+      node.type === NodeType.QUESTION
+        ? GRAPH_NUMBER_CONSTANT.NODE_RADIUS + 5
+        : GRAPH_NUMBER_CONSTANT.NODE_RADIUS;
+    const radius = isHovered ? nodeRadius + 2 : nodeRadius;
 
     ctx.beginPath();
     ctx.arc(node.x, node.y, radius, 0, Math.PI * 2);
@@ -86,14 +93,13 @@ function drawGraphView(
     }
     ctx.fill();
 
-    ctx.fillStyle = isDimmed
-      ? hexToRgba(
-          GRAPH_COLOR_CONSTANT.LABEL,
-          GRAPH_COLOR_CONSTANT.NOT_HOVERED_ALPHA,
-        )
-      : GRAPH_COLOR_CONSTANT.LABEL;
-    if (scale > textRenderScale)
+    if (textAlpha > 0) {
+      const labelAlpha = isDimmed
+        ? GRAPH_COLOR_CONSTANT.NOT_HOVERED_ALPHA * textAlpha
+        : textAlpha;
+      ctx.fillStyle = hexToRgba(GRAPH_COLOR_CONSTANT.LABEL, labelAlpha);
       ctx.fillText(node.label, node.x, node.y + radius + 14);
+    }
   });
 
   ctx.restore();

--- a/apps/web/src/app/mypage/_lib/graph-view/draw-graph-view.ts
+++ b/apps/web/src/app/mypage/_lib/graph-view/draw-graph-view.ts
@@ -74,9 +74,10 @@ function drawGraphView(
     const isHovered = node.id === hoveredNode;
     const isHighlighted = hoveredSet.has(node.id);
     const isDimmed = hoveredNode !== null && !isHovered && !isHighlighted;
+    // 질문노드 -> 키워드 노드보다 반지름 +1px 정도 크게
     const nodeRadius =
       node.type === NodeType.QUESTION
-        ? GRAPH_NUMBER_CONSTANT.NODE_RADIUS + 5
+        ? GRAPH_NUMBER_CONSTANT.NODE_RADIUS + 1
         : GRAPH_NUMBER_CONSTANT.NODE_RADIUS;
     const radius = isHovered ? nodeRadius + 2 : nodeRadius;
 


### PR DESCRIPTION
## 🔸 작업 내용
- #270 
- 그래프뷰 질문노드 / 키워드 노드 크기 변동
- 줌인 / 줌아웃에서 라벨 투명도 조절
- 노드 클릭 범위 +5 -> +10으로 확대
- `document.body`의 font-family 속성을 가져와 canvas에 추가


## 🔸 참고
### 텍스트 투명도 인터렉션
![화면 기록 2026-01-27 오전 12 44 05](https://github.com/user-attachments/assets/1d0680b0-2190-45bf-8fa2-333444a152ef)

### 노드간 크기 차이
<img width="747" height="638" alt="image" src="https://github.com/user-attachments/assets/a4ff517e-0072-45d8-ba54-0bb5d42adb10" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
- 노드 클릭 영역이 확대되어 더 정확하고 쉽게 선택할 수 있습니다.

## 스타일
- 노드 라벨의 폰트 렌더링이 시스템 기본 폰트를 사용하도록 개선되었습니다.
- 확대/축소 수준에 따라 노드 라벨이 부드럽게 표시되고 숨겨집니다.
- 노드 타입에 따른 시각적 구분이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->