### PR TITLE
서비스 전반 폰트사이즈를 키움

### DIFF
--- a/apps/web/src/app/(auth)/_components/login-form.tsx
+++ b/apps/web/src/app/(auth)/_components/login-form.tsx
@@ -34,7 +34,7 @@ function LoginForm({ loginAction }: LoginFormProps) {
 
       {/* 이메일 입력 섹션 */}
       <div className="space-y-2 mb-4">
-        <label htmlFor="email" className="text-xs font-medium">
+        <label htmlFor="email" className="text-sm font-medium">
           이메일
         </label>
         <InputGroup className="h-11">
@@ -51,7 +51,7 @@ function LoginForm({ loginAction }: LoginFormProps) {
 
       {/* 비밀번호 입력 섹션 */}
       <div className="space-y-2 mb-6">
-        <label htmlFor="password" className="text-xs font-medium">
+        <label htmlFor="password" className="text-sm font-medium">
           비밀번호
         </label>
         <InputGroup className="h-11">

--- a/apps/web/src/app/(auth)/_components/signup-form.tsx
+++ b/apps/web/src/app/(auth)/_components/signup-form.tsx
@@ -35,7 +35,7 @@ function SignUpForm({ signupAction }: SignUpFormProps) {
 
       {/* 이름(닉네임) 입력 */}
       <div className="space-y-2 mb-4">
-        <label htmlFor="nickname" className="text-xs font-medium">
+        <label htmlFor="nickname" className="text-sm font-medium">
           이름
         </label>
         <InputGroup className="h-11">
@@ -53,7 +53,7 @@ function SignUpForm({ signupAction }: SignUpFormProps) {
 
       {/* 이메일 입력 섹션 */}
       <div className="space-y-2 mb-4">
-        <label htmlFor="email" className="text-xs font-medium">
+        <label htmlFor="email" className="text-sm font-medium">
           이메일
         </label>
         <InputGroup className="h-11">
@@ -72,7 +72,7 @@ function SignUpForm({ signupAction }: SignUpFormProps) {
 
       {/* 비밀번호 입력 섹션 */}
       <div className="space-y-2 mb-4">
-        <label htmlFor="password" className="text-xs font-medium">
+        <label htmlFor="password" className="text-sm font-medium">
           비밀번호
         </label>
         <InputGroup className="h-11">
@@ -91,7 +91,7 @@ function SignUpForm({ signupAction }: SignUpFormProps) {
 
       {/* 비밀번호 확인 입력 */}
       <div className="space-y-2 mb-4">
-        <label htmlFor="passwordConfirm" className="text-xs font-medium">
+        <label htmlFor="passwordConfirm" className="text-sm font-medium">
           비밀번호 확인
         </label>
         <InputGroup className="h-11">
@@ -110,7 +110,7 @@ function SignUpForm({ signupAction }: SignUpFormProps) {
 
       <div className="flex items-center gap-2 py-2 mb-4">
         <Checkbox id="terms" name="terms" required />
-        <label htmlFor="terms" className="text-xs text-muted-foreground">
+        <label htmlFor="terms" className="text-sm text-muted-foreground">
           <span className="text-teal-600 font-semibold">서비스 이용약관</span>{" "}
           및{" "}
           <span className="text-teal-600 font-semibold">개인정보 처리방침</span>

--- a/apps/web/src/app/daily/questions/[questionId]/_components/importance-rating.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/_components/importance-rating.tsx
@@ -73,10 +73,10 @@ function ImportanceRating({
         <input type="hidden" name="score" value={score} />
 
         <div className="text-center space-y-1">
-          <h2 className="text-lg font-bold text-zinc-900">
+          <h2 className="text-xl font-bold text-zinc-900">
             이 문제가 얼마나 중요했나요?
           </h2>
-          <p className="text-sm text-zinc-500">
+          <p className="text-base text-zinc-500">
             문제의 중요도를 별점으로 평가해주세요
           </p>
         </div>

--- a/apps/web/src/app/daily/questions/[questionId]/_components/question-card.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/_components/question-card.tsx
@@ -29,7 +29,7 @@ export default function QuestionCard({
       </button>
 
       {(parentCategoryName || categoryName) && (
-        <p className="text-gray-500 text-xs mb-3">
+        <p className="text-gray-500 text-sm mb-3">
           {[parentCategoryName, categoryName].filter(Boolean).join(" | ")}
         </p>
       )}
@@ -40,7 +40,7 @@ export default function QuestionCard({
           <p className="text-zinc-600 leading-relaxed">{content}</p>
         </>
       ) : (
-        <p className="text-gray-400 text-sm">문제가 숨겨져 있습니다</p>
+        <p className="text-gray-400 text-base">문제가 숨겨져 있습니다</p>
       )}
     </section>
   );

--- a/apps/web/src/app/daily/questions/_components/question-filters.tsx
+++ b/apps/web/src/app/daily/questions/_components/question-filters.tsx
@@ -7,7 +7,6 @@ import {
   InputGroupInput,
 } from "@/components/input-group/input-group";
 import { SegmentedControl } from "@/components/segmented-control/segmented-control";
-import { cn } from "@/lib/cn";
 import { Search } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import * as React from "react";
@@ -82,7 +81,7 @@ function QuestionFilters({
     <div className="bg-white p-7 border rounded-xl">
       <div className="flex gap-4 pb-7 border-b">
         <Button
-          variant={selectedCategoryId === null ? "default" : "ghost"}
+          variant={selectedCategoryId === null ? "default" : "secondary"}
           onClick={() => handleCategoryChange(null)}
         >
           All
@@ -90,7 +89,9 @@ function QuestionFilters({
         {categories.map((category) => (
           <Button
             key={category.id}
-            variant={selectedCategoryId === category.id ? "default" : "ghost"}
+            variant={
+              selectedCategoryId === category.id ? "default" : "secondary"
+            }
             onClick={() => handleCategoryChange(category.id)}
           >
             {category.name}
@@ -107,13 +108,7 @@ function QuestionFilters({
             세부 주제
           </div>
           <Button
-            variant="outline"
-            size="sm"
-            className={cn(
-              !selectedSubCategoryId
-                ? "border-teal-100 bg-teal-50 text-teal-500 hover:bg-teal-50 hover:text-teal-500"
-                : "",
-            )}
+            variant={selectedSubCategoryId === null ? "default" : "secondary"}
             onClick={() => handleSubCategoryChange(null)}
           >
             전체
@@ -121,13 +116,11 @@ function QuestionFilters({
           {subCategories.map((subCategory) => (
             <Button
               key={subCategory.id}
-              variant="outline"
-              size="sm"
-              className={cn(
-                selectedSubCategoryId === subCategory.id
-                  ? "border-teal-100 bg-teal-50 text-teal-500 hover:bg-teal-50 hover:text-teal-500"
-                  : "",
-              )}
+              variant={
+                subCategory.id === selectedSubCategoryId
+                  ? "default"
+                  : "secondary"
+              }
               onClick={() => handleSubCategoryChange(subCategory.id)}
             >
               {subCategory.name}

--- a/apps/web/src/app/daily/questions/_components/question-link-button.tsx
+++ b/apps/web/src/app/daily/questions/_components/question-link-button.tsx
@@ -16,7 +16,7 @@ function QuestionLinkButton({ question }: QuestionLinkButtonProps) {
     <>
       <Button
         variant="link"
-        className="text-slate-900 text-sm hover:text-teal-600 hover:underline hover:cursor-pointer px-0"
+        className="text-slate-900 text-base hover:text-teal-600 hover:underline hover:cursor-pointer px-0"
         onClick={() => setIsModalOpen(true)}
       >
         {question.title}

--- a/apps/web/src/app/daily/questions/_components/question-modal.tsx
+++ b/apps/web/src/app/daily/questions/_components/question-modal.tsx
@@ -28,21 +28,21 @@ function QuestionModal({ question, onClose }: QuestionModalProps) {
         <div className="p-8">
           {/* 배지 영역 */}
           <div className="flex gap-2 mb-4">
-            <span className="px-2.5 py-1 rounded-md bg-gray-100 text-gray-500 text-xs font-medium">
+            <span className="px-2.5 py-1 rounded-md bg-gray-100 text-gray-500 text-sm font-medium">
               {question.category?.name}
             </span>
             {/* 중요도 숫자 표기 */}
-            <span className="px-2.5 py-1 rounded-md bg-yellow-50 text-yellow-600 text-xs font-medium flex items-center gap-1">
+            <span className="px-2.5 py-1 rounded-md bg-yellow-50 text-yellow-600 text-sm font-medium flex items-center gap-1">
               <span>⭐️</span>
               {(question.avgImportance ?? 0).toFixed(1)}
             </span>
           </div>
 
           {/* 제목 및 내용 */}
-          <h2 className="text-xl font-bold text-gray-900 mb-4 leading-tight">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4 leading-tight">
             {question.title}
           </h2>
-          <p className="text-gray-600 text-sm leading-relaxed mb-8 whitespace-pre-wrap">
+          <p className="text-gray-600 text-base leading-relaxed mb-8 whitespace-pre-wrap">
             {question.content}
           </p>
 
@@ -65,7 +65,7 @@ function QuestionModal({ question, onClose }: QuestionModalProps) {
               variant="outline"
               size="lg"
               onClick={onClose}
-              className="flex-1 rounded-xl text-sm font-semibold border-gray-200 text-gray-600 hover:bg-gray-50"
+              className="flex-1 font-semibold border-gray-200 text-gray-600 hover:bg-gray-50"
             >
               닫기
             </Button>
@@ -73,7 +73,7 @@ function QuestionModal({ question, onClose }: QuestionModalProps) {
               asChild
               variant="default"
               size="lg"
-              className="flex-1 rounded-xl text-sm font-semibold shadow-lg shadow-gray-200"
+              className="flex-1 font-semibold"
             >
               <Link href={`/daily/questions/${question.id}?mode=${answerMode}`}>
                 시작하기

--- a/apps/web/src/app/daily/questions/page.tsx
+++ b/apps/web/src/app/daily/questions/page.tsx
@@ -104,7 +104,7 @@ async function QuestionListPage({ searchParams }: QuestionListPageProps) {
   return (
     <main className="w-full max-w-4xl mx-auto px-8 py-15 space-y-8 min-h-screen">
       <div className="mb-8">
-        <h1 className="text-2xl font-bold">문제 리스트</h1>
+        <h1 className="text-3xl font-bold mb-1">문제 리스트</h1>
         <p className="text-muted-foreground">
           총 <span className="font-semibold text-teal-600">{totalCount}</span>
           개의 문제가 준비되어 있습니다.

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -12,8 +12,8 @@
   --popover-foreground: oklch(0.145 0 0);
   --primary: var(--color-teal-400);
   --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
+  --secondary: var(--color-muted);
+  --secondary-foreground: var(--color-slate-700);
   --muted: var(--color-slate-100);
   --muted-foreground: var(--color-slate-500);
   --accent: oklch(0.97 0 0);

--- a/apps/web/src/app/reports/[questionId]/_components/feedback/ai-feedback.tsx
+++ b/apps/web/src/app/reports/[questionId]/_components/feedback/ai-feedback.tsx
@@ -5,10 +5,10 @@ interface AiFeedbackProps {
 function AiFeedback({ feedback }: AiFeedbackProps) {
   return (
     <div className="bg-slate-50 rounded-2xl p-6 mb-8 border border-slate-50">
-      <div className="flex text-[0.625rem] font-extrabold text-slate-400 mb-2 uppercase">
+      <div className="flex text-sm font-semibold text-slate-400 mb-2 uppercase">
         <span>AI MENTOR&apos;S FEEDBACK</span>
       </div>
-      <p className="text-sm font-medium leading-relaxed text-slate-700 m-0">
+      <p className="text-base font-medium leading-relaxed text-slate-700 m-0">
         {feedback}
       </p>
     </div>

--- a/apps/web/src/app/reports/[questionId]/_components/feedback/feedback-section.tsx
+++ b/apps/web/src/app/reports/[questionId]/_components/feedback/feedback-section.tsx
@@ -30,17 +30,17 @@ function FeedbackSection({
           <div className="w-14 h-14 border-4 border-[#4FD1C5] border-t-transparent rounded-full animate-spin" />
 
           <div className="text-center">
-            <h2 className="font-bold text-slate-900 mb-3">
+            <h2 className="text-xl font-bold text-slate-900 mb-3">
               {isSttPending
                 ? "음성을 텍스트로 변환하고 있습니다"
                 : "답변을 분석하고 있습니다"}
             </h2>
-            <p className="text-sm text-slate-500 leading-relaxed">
+            <p className="text-base text-slate-500 leading-relaxed">
               {isSttPending
                 ? "음성 인식 중입니다."
                 : "AI 면접관이 5가지 핵심 지표를 기반으로 채점 중 입니다."}
             </p>
-            <p className="text-sm text-slate-500">
+            <p className="text-base text-slate-500">
               잠시만 기다려주세요. (약 5~10초 소요)
             </p>
           </div>
@@ -60,10 +60,10 @@ function FeedbackSection({
           </div>
 
           <div className="text-center">
-            <h2 className="font-bold text-slate-900 mb-3">
+            <h2 className="font-bold text-slate-900 mb-3 text-xl">
               {isSttFailed ? "음성 인식에 실패했습니다" : "채점에 실패했습니다"}
             </h2>
-            <p className="text-sm text-slate-500">
+            <p className="text-slate-500">
               {isSttFailed
                 ? "오디오 파일 형식이 손상되어 분석할 수 없습니다."
                 : "채점 처리 중 오류가 발생했습니다. 다시 시도해주세요."}
@@ -73,12 +73,12 @@ function FeedbackSection({
           {isSttFailed ? (
             <RetryButton
               question={question}
-              className="flex cursor-pointer items-center gap-2.5 bg-teal-400 hover:bg-teal-500 text-white font-bold px-4 py-2.5 rounded-xl transition-colors text-sm"
+              className="flex cursor-pointer items-center gap-2.5 bg-teal-400 hover:bg-teal-500 text-white font-bold px-4 py-2.5 rounded-xl transition-colors text-base"
             />
           ) : (
             <ReEvaluateButton
               submissionId={data.submissionId}
-              className="flex cursor-pointer items-center gap-2.5 bg-teal-400 hover:bg-teal-500 text-white font-bold px-4 py-2.5 rounded-xl transition-colors text-sm"
+              className="flex cursor-pointer items-center gap-2.5 bg-teal-400 hover:bg-teal-500 text-white font-bold px-4 py-2.5 rounded-xl transition-colors text-base"
             />
           )}
         </div>
@@ -90,11 +90,11 @@ function FeedbackSection({
     <section className="bg-white rounded-xl border border-[#E2E8F0] p-9 transition-all duration-300">
       <div className="flex justify-between items-center mb-6">
         <div>
-          <div className="text-xs font-extrabold text-zinc-400 tracking-widest uppercase mb-1">
+          <div className="text-sm font-extrabold text-zinc-400 tracking-widest uppercase mb-1">
             TRIAL #{attempt}
           </div>
-          <h2 className="text-2xl font-bold text-zinc-900">분석 리포트</h2>
-          <div className="text-xs text-zinc-400">{data.date} 완료</div>
+          <h2 className="text-2xl font-bold text-zinc-900 mb-1">분석 리포트</h2>
+          <div className="text-sm text-zinc-400">{data.date} 완료</div>
         </div>
 
         <ScoreGauge score={data.totalScore ?? 0} />

--- a/apps/web/src/app/reports/[questionId]/_components/feedback/metric-item.tsx
+++ b/apps/web/src/app/reports/[questionId]/_components/feedback/metric-item.tsx
@@ -19,10 +19,12 @@ function MetricItem({ label, score, max, reason, value }: MetricItemProps) {
     return (
       <div className="border border-slate-100 rounded-xl bg-white p-4 shadow-[0_2px_8px_rgba(0,0,0,0.02)]">
         <div className="flex justify-between items-end mb-2">
-          <span className="font-bold text-sm text-slate-800">{label}</span>
+          <span className="font-bold text-base text-slate-800">{label}</span>
           <div className="flex items-baseline gap-0.5">
-            <span className="text-lg font-black text-slate-700">{score}</span>
-            <span className="text-[0.625rem] font-medium text-slate-400">
+            <span className="text-2xl font-extrabold text-slate-700">
+              {score}
+            </span>
+            <span className="text-base font-medium text-muted-foreground">
               / {max}
             </span>
           </div>
@@ -48,12 +50,14 @@ function MetricItem({ label, score, max, reason, value }: MetricItemProps) {
         <Accordion.Trigger className="group w-full p-4 flex justify-between items-center hover:bg-slate-50 rounded-xl transition-colors">
           <div className="flex-1">
             <div className="flex justify-between items-end mb-2">
-              <span className="font-bold text-sm text-slate-800">{label}</span>
+              <span className="font-bold text-base text-slate-800">
+                {label}
+              </span>
               <div className="flex items-baseline gap-0.5">
-                <span className="text-lg font-black text-slate-700">
+                <span className="text-2xl font-extrabold text-slate-700">
                   {score}
                 </span>
-                <span className="text-[0.625rem] font-medium text-slate-400">
+                <span className="text-base font-medium text-muted-foreground">
                   / {max}
                 </span>
               </div>
@@ -67,13 +71,15 @@ function MetricItem({ label, score, max, reason, value }: MetricItemProps) {
             </div>
           </div>
 
-          <ChevronDown className="ml-4 h-4 w-4 text-slate-400 transition-transform duration-200 group-data-[state=open]:rotate-180" />
+          <ChevronDown className="ml-4 h-4 w-4 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180" />
         </Accordion.Trigger>
       </Accordion.Header>
 
       <Accordion.Content className="overflow-hidden data-[state=open]:animate-accordion-down data-[state=closed]:animate-accordion-up">
         <div className="px-4 pb-4 pt-2">
-          <p className="text-xs leading-relaxed text-slate-500">{reason}</p>
+          <p className="text-base leading-relaxed text-muted-foreground">
+            {reason}
+          </p>
         </div>
       </Accordion.Content>
     </Accordion.Item>

--- a/apps/web/src/app/reports/[questionId]/_components/feedback/metrics-list.tsx
+++ b/apps/web/src/app/reports/[questionId]/_components/feedback/metrics-list.tsx
@@ -57,10 +57,8 @@ function MetricsList({ feedback, isPending }: MetricsListProps) {
   return (
     <div className="space-y-6">
       <div className="mb-4">
-        <h3 className="font-extrabold text-slate-900 mb-0.5">
-          성취도 상세 분석
-        </h3>
-        <span className="text-xs text-slate-400">
+        <h3 className="font-bold text-xl mb-0.5">성취도 상세 분석</h3>
+        <span className="text-base text-muted-foreground">
           항목별 평가 상세 내역입니다
         </span>
       </div>

--- a/apps/web/src/app/reports/[questionId]/_components/history/history-item.tsx
+++ b/apps/web/src/app/reports/[questionId]/_components/history/history-item.tsx
@@ -53,7 +53,7 @@ function HistoryItem({ item, isSelected, href, index }: HistoryItemProps) {
       <div className="flex justify-between items-center">
         <div className="flex flex-col gap-1 items-start">
           <span
-            className={`text-xs font-bold tracking-wide transition-colors ${
+            className={`text-sm font-bold tracking-wide transition-colors ${
               isSelected
                 ? "text-teal-600"
                 : "text-slate-400 group-hover:text-teal-500"
@@ -61,7 +61,7 @@ function HistoryItem({ item, isSelected, href, index }: HistoryItemProps) {
           >
             TRIAL #{index}
           </span>
-          <div className="text-xs font-medium text-slate-400">
+          <div className="text-sm font-medium text-slate-400">
             {item.date.split(" ")[0]}
           </div>
         </div>

--- a/apps/web/src/app/reports/[questionId]/_components/report-header.tsx
+++ b/apps/web/src/app/reports/[questionId]/_components/report-header.tsx
@@ -14,7 +14,7 @@ interface ReportHeaderProps {
 function ReportHeader({ question, highestScore }: ReportHeaderProps) {
   return (
     <section className="bg-white border border-gray-200 rounded-xl p-9">
-      <p className="text-gray-500 text-xs mb-3">
+      <p className="text-gray-500 text-sm mb-3">
         {question.categoryDisplay}{" "}
         {question.subCategory && `| ${question.subCategory}`}
       </p>
@@ -22,12 +22,12 @@ function ReportHeader({ question, highestScore }: ReportHeaderProps) {
       <p className="text-gray-600 leading-relaxed mb-6">{question.content}</p>
       <hr className="border-gray-200 mb-6" />
       <div className="flex items-center justify-between">
-        <div className="bg-teal-50 border border-teal-100 text-teal-600 px-4 py-2.5 rounded-xl text-sm font-bold">
+        <div className="bg-teal-50 border border-teal-100 text-teal-600 px-4 py-2.5 rounded-xl text-base font-bold">
           나의 최고 점수 : {highestScore ?? 0}점
         </div>
         <RetryButton
           question={question}
-          className="flex cursor-pointer items-center gap-2.5 bg-teal-400 hover:bg-teal-500 text-white font-bold px-4 py-2.5 rounded-xl transition-colors text-sm"
+          className="flex cursor-pointer items-center gap-2.5 bg-teal-400 hover:bg-teal-500 text-white font-bold px-4 py-2.5 rounded-xl transition-colors text-base"
         />
       </div>
     </section>

--- a/apps/web/src/app/reports/[questionId]/_components/report-tabs.tsx
+++ b/apps/web/src/app/reports/[questionId]/_components/report-tabs.tsx
@@ -70,7 +70,7 @@ function ReportTabs({
               {selectedAttempt.answerContent && (
                 <div className="flex items-center gap-2 px-3 py-1.5">
                   <div className="w-1.5 h-1.5 bg-emerald-400 rounded-full" />
-                  <span className="text-xs text-slate-500">
+                  <span className="text-sm text-slate-500">
                     AI 음성 복원 완료
                   </span>
                 </div>
@@ -100,7 +100,7 @@ function ReportTabs({
                     {keywords.map((keyword, index) => (
                       <span
                         key={index}
-                        className="px-2 py-1.5 bg-slate-100 text-slate-700 text-xs font-medium rounded-md"
+                        className="px-2 py-1.5 bg-slate-100 text-slate-700 text-sm font-medium rounded-md"
                       >
                         <span className="text-slate-400 font-semibold">#</span>{" "}
                         {keyword}

--- a/apps/web/src/components/button/button.tsx
+++ b/apps/web/src/components/button/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:cursor-pointer",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-base font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive hover:cursor-pointer",
   {
     variants: {
       variant: {

--- a/apps/web/src/components/input-group/input-group.tsx
+++ b/apps/web/src/components/input-group/input-group.tsx
@@ -14,7 +14,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
       role="group"
       className={cn(
         "group/input-group border-input bg-slate-50 dark:bg-input/30 relative flex w-full items-center rounded-md border transition-[color,box-shadow] outline-none",
-        "h-9 min-w-0 has-[>textarea]:h-auto",
+        "h-11 min-w-0 has-[>textarea]:h-auto",
 
         // Placeholder
         "placeholder:text-muted-foreground",
@@ -39,7 +39,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 const inputGroupAddonVariants = cva(
-  "text-muted-foreground flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium select-none [&>svg:not([class*='size-'])]:size-4 [&>kbd]:rounded-[calc(var(--radius)-5px)] group-data-[disabled=true]/input-group:opacity-50",
+  "text-muted-foreground flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-base font-medium select-none [&>svg:not([class*='size-'])]:size-4 [&>kbd]:rounded-[calc(var(--radius)-5px)] group-data-[disabled=true]/input-group:opacity-50",
   {
     variants: {
       align: {
@@ -82,7 +82,7 @@ function InputGroupAddon({
 }
 
 const inputGroupButtonVariants = cva(
-  "text-sm shadow-none flex gap-2 items-center",
+  "text-base shadow-none flex gap-2 items-center",
   {
     variants: {
       size: {
@@ -122,7 +122,7 @@ function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
   return (
     <span
       className={cn(
-        "text-muted-foreground flex items-center gap-2 text-sm [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        "text-muted-foreground flex items-center gap-2 text-base [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/apps/web/src/components/input/input.tsx
+++ b/apps/web/src/components/input/input.tsx
@@ -7,7 +7,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-sm transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-11 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
         "focus-visible:border-ring focus-visible:ring-ring/10 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className,

--- a/apps/web/src/components/segmented-control/segmented-control.tsx
+++ b/apps/web/src/components/segmented-control/segmented-control.tsx
@@ -27,7 +27,7 @@ const segmentedControlItemVariants = cva(
       size: {
         default: "px-4 h-8",
         sm: "px-3 h-6 text-xs",
-        lg: "px-5 h-14",
+        lg: "px-5 h-10",
       },
       selected: {
         true: "text-foreground",

--- a/apps/web/src/components/segmented-control/segmented-control.tsx
+++ b/apps/web/src/components/segmented-control/segmented-control.tsx
@@ -9,9 +9,9 @@ const segmentedControlVariants = cva(
   {
     variants: {
       size: {
-        default: "h-10",
-        sm: "h-8",
-        lg: "h-12",
+        default: "h-12",
+        sm: "h-10",
+        lg: "h-14",
       },
     },
     defaultVariants: {
@@ -21,13 +21,13 @@ const segmentedControlVariants = cva(
 );
 
 const segmentedControlItemVariants = cva(
-  "relative z-10 flex items-center justify-center text-sm font-medium transition-colors duration-200 rounded-md cursor-pointer",
+  "relative z-10 flex items-center justify-center text-base font-medium transition-colors duration-200 rounded-md cursor-pointer",
   {
     variants: {
       size: {
         default: "px-4 h-8",
         sm: "px-3 h-6 text-xs",
-        lg: "px-5 h-10",
+        lg: "px-5 h-14",
       },
       selected: {
         true: "text-foreground",

--- a/apps/web/src/components/table/table.tsx
+++ b/apps/web/src/components/table/table.tsx
@@ -66,7 +66,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-xs bg-muted text-muted-foreground h-10 px-6 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-0.5",
+        "text-sm bg-muted text-muted-foreground h-10 px-6 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-0.5",
         className,
       )}
       {...props}

--- a/apps/web/src/components/tabs/tabs.tsx
+++ b/apps/web/src/components/tabs/tabs.tsx
@@ -28,7 +28,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-t-xl px-5 py-3 text-sm font-semibold ring-offset-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-slate-100 text-slate-400  data-[state=active]:border-slate-200 border-x-slate-100  border-t-slate-100 border-b-slate-200 data-[state=active]:border-b-white data-[state=active]:bg-white border data-[state=active]:text-teal-500",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-t-xl px-5 py-3 text-base font-semibold ring-offset-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-slate-100 text-slate-400  data-[state=active]:border-slate-200 border-x-slate-100  border-t-slate-100 border-b-slate-200 data-[state=active]:border-b-white data-[state=active]:bg-white border data-[state=active]:text-teal-500",
       className,
     )}
     {...props}


### PR DESCRIPTION
## 🔸 작업 내용

- 폰트 크기가 너무 작다는 사용자 피드백에 따라서 서비스 전반의 폰트 사이즈를 키웠습니다.
- 버튼과 탭, 그리고 텍스트 필드가 원래 text-sm(14px)이였는데 text-base (16px)로 조정했습니다.
- description 영역의 텍스트 사이즈가 text-sm이였는데, text-base로 조정했습니다.
- text-xs가 사용되는 모든 곳들을 text-sm으로 조정했습니다.
- 이에 따라 일부 text-base와, text-lg, text-xl 폰트들이 비율에 맞춰 더 키웠습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * UI 전반 텍스트 크기 상향으로 가독성 향상(헤딩·본문·레이블·버튼 등)
  * 입력 컴포넌트와 버튼 높이 및 폰트 크기 일관성 조정
  * 색상 변수 도입으로 디자인 시스템 통일
  * 버튼·필터 등 컨트롤의 시각적 스타일 정렬 및 간소화
  * 타이포그래피 계층 구조 전반 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->