### PR TITLE
API 로그 점검 및 로그 체계 정비

### DIFF
--- a/apps/api/src/common/filters/http-exception.filter.spec.ts
+++ b/apps/api/src/common/filters/http-exception.filter.spec.ts
@@ -1,0 +1,95 @@
+import {
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { HttpExceptionFilter } from './http-exception.filter';
+
+describe('HttpExceptionFilter', () => {
+  let filter: HttpExceptionFilter;
+
+  const mockLogger = {
+    error: jest.fn(),
+    warn: jest.fn(),
+  };
+
+  const mockResponse = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+
+  const mockRequest = {
+    method: 'GET',
+    url: '/test',
+    ip: '127.0.0.1',
+  };
+
+  const mockArgumentsHost = {
+    switchToHttp: () => ({
+      getRequest: () => mockRequest,
+      getResponse: () => mockResponse,
+    }),
+  } as unknown as ArgumentsHost;
+
+  beforeEach(() => {
+    filter = new HttpExceptionFilter();
+
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(mockLogger.error);
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(mockLogger.warn);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('4xx HttpException 발생 시 warn 로그를 남기고 응답을 반환한다', () => {
+    const exception = new HttpException('Bad Request', HttpStatus.BAD_REQUEST);
+
+    filter.catch(exception, mockArgumentsHost);
+
+    expect(mockLogger.warn).toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+
+    expect(mockResponse.status).toHaveBeenCalledWith(400);
+    expect(mockResponse.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 400,
+        path: '/test',
+        method: 'GET',
+        message: 'Bad Request',
+      }),
+    );
+  });
+
+  it('5xx HttpException 발생 시 error 로그를 남긴다', () => {
+    const exception = new HttpException(
+      'Internal Error',
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+
+    filter.catch(exception, mockArgumentsHost);
+
+    expect(mockLogger.error).toHaveBeenCalled();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+
+    expect(mockResponse.status).toHaveBeenCalledWith(500);
+  });
+
+  it('일반 Error 발생 시 500으로 처리하고 error 로그를 남긴다', () => {
+    const exception = new Error('Unexpected failure');
+
+    filter.catch(exception, mockArgumentsHost);
+
+    expect(mockLogger.error).toHaveBeenCalled();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+
+    expect(mockResponse.status).toHaveBeenCalledWith(500);
+    expect(mockResponse.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 500,
+        message: 'Internal server error',
+      }),
+    );
+  });
+});

--- a/apps/api/src/common/filters/http-exception.filter.ts
+++ b/apps/api/src/common/filters/http-exception.filter.ts
@@ -1,0 +1,67 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import type { Request, Response } from 'express';
+
+/**
+ * HTTP 예외 필터
+ * 모든 HTTP 예외를 일관된 형식으로 로깅하고 응답합니다.
+ */
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(HttpExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    const status =
+      exception instanceof HttpException
+        ? exception.getStatus()
+        : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    const message =
+      exception instanceof HttpException
+        ? exception.getResponse()
+        : 'Internal server error';
+
+    const userId = (request as Request & { userId?: number }).userId;
+    const { method, url, ip } = request;
+
+    // 에러 정보 구성
+    const errorResponse = {
+      statusCode: status,
+      timestamp: new Date().toISOString(),
+      path: url,
+      method,
+      message:
+        typeof message === 'string'
+          ? message
+          : (message as { message?: string }).message || 'An error occurred',
+    };
+
+    // 로그 메시지 구성
+    const logMessage = `${method} ${url} ${status} - ${typeof message === 'string' ? message : JSON.stringify(message)}${userId ? ` - UserId: ${userId}` : ''} - IP: ${ip}`;
+
+    // 에러 레벨에 따른 로깅
+    if (status >= 500) {
+      // 서버 에러 (5xx)
+      this.logger.error(
+        logMessage,
+        exception instanceof Error ? exception.stack : undefined,
+      );
+    } else if (status >= 400) {
+      // 클라이언트 에러 (4xx)
+      this.logger.warn(logMessage);
+    }
+
+    // 응답 전송
+    response.status(status).json(errorResponse);
+  }
+}

--- a/apps/api/src/common/interceptors/logging.interceptor.spec.ts
+++ b/apps/api/src/common/interceptors/logging.interceptor.spec.ts
@@ -1,0 +1,132 @@
+import { ExecutionContext, Logger } from '@nestjs/common';
+import type { Request, Response } from 'express';
+import { of, throwError } from 'rxjs';
+import { LoggingInterceptor } from './logging.interceptor';
+
+describe('LoggingInterceptor', () => {
+  let interceptor: LoggingInterceptor;
+
+  const mockLogger = {
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+
+  beforeEach(() => {
+    interceptor = new LoggingInterceptor();
+
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(mockLogger.log);
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(mockLogger.warn);
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(mockLogger.error);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createExecutionContext = ({
+    url = '/test',
+    method = 'GET',
+    statusCode = 200,
+  } = {}): ExecutionContext => {
+    const request = {
+      url,
+      method,
+      ip: '127.0.0.1',
+      get: () => 'jest-agent',
+    } as unknown as Request;
+
+    const response = {
+      statusCode,
+    } as unknown as Response;
+
+    return {
+      switchToHttp: () => ({
+        getRequest: () => request,
+        getResponse: () => response,
+      }),
+    } as ExecutionContext;
+  };
+
+  it('정상 요청에 대해 요청/응답 로그를 남긴다', (done) => {
+    const context = createExecutionContext({ statusCode: 200 });
+
+    const next = {
+      handle: () => of('ok'),
+    };
+
+    interceptor.intercept(context, next).subscribe({
+      next: () => {
+        expect(mockLogger.log).toHaveBeenCalled();
+        expect(mockLogger.warn).not.toHaveBeenCalled();
+        expect(mockLogger.error).not.toHaveBeenCalled();
+        done();
+      },
+    });
+  });
+
+  it('4xx 응답일 경우 warn 로그를 남긴다', (done) => {
+    const context = createExecutionContext({ statusCode: 400 });
+
+    const next = {
+      handle: () => of('bad request'),
+    };
+
+    interceptor.intercept(context, next).subscribe({
+      next: () => {
+        expect(mockLogger.warn).toHaveBeenCalled();
+        done();
+      },
+    });
+  });
+
+  it('5xx 응답일 경우 error 로그를 남긴다', (done) => {
+    const context = createExecutionContext({ statusCode: 500 });
+
+    const next = {
+      handle: () => of('server error'),
+    };
+
+    interceptor.intercept(context, next).subscribe({
+      next: () => {
+        expect(mockLogger.error).toHaveBeenCalled();
+        done();
+      },
+    });
+  });
+
+  it('에러 발생 시 error 로그를 남기고 에러를 다시 throw 한다', (done) => {
+    const context = createExecutionContext();
+
+    const error = new Error('boom');
+
+    const next = {
+      handle: () => throwError(() => error),
+    };
+
+    interceptor.intercept(context, next).subscribe({
+      error: (err) => {
+        expect(err).toBe(error);
+        expect(mockLogger.error).toHaveBeenCalled();
+        done();
+      },
+    });
+  });
+
+  it('제외된 경로는 로깅하지 않는다', (done) => {
+    const context = createExecutionContext({ url: '/health' });
+
+    const next = {
+      handle: () => of('ok'),
+    };
+
+    interceptor.intercept(context, next).subscribe({
+      next: () => {
+        expect(mockLogger.log).not.toHaveBeenCalled();
+        expect(mockLogger.warn).not.toHaveBeenCalled();
+        expect(mockLogger.error).not.toHaveBeenCalled();
+        done();
+      },
+    });
+  });
+});

--- a/apps/api/src/common/interceptors/logging.interceptor.ts
+++ b/apps/api/src/common/interceptors/logging.interceptor.ts
@@ -19,12 +19,7 @@ export class LoggingInterceptor implements NestInterceptor {
   private readonly logger = new Logger(LoggingInterceptor.name);
 
   // 로그에서 제외할 경로 목록
-  private readonly excludedPaths = [
-    '/health',
-    '/api-docs',
-    '/api-docs-json',
-    '/favicon.ico',
-  ];
+  private readonly excludedPaths = ['/health', '/api-docs', '/api-docs-json'];
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     const request = context.switchToHttp().getRequest<Request>();

--- a/apps/api/src/common/interceptors/logging.interceptor.ts
+++ b/apps/api/src/common/interceptors/logging.interceptor.ts
@@ -1,0 +1,89 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  Logger,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import type { Request, Response } from 'express';
+
+/**
+ * HTTP 요청/응답 로깅 인터셉터
+ * 모든 HTTP 요청과 응답을 로깅합니다.
+ */
+@Injectable()
+export class LoggingInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(LoggingInterceptor.name);
+
+  // 로그에서 제외할 경로 목록
+  private readonly excludedPaths = [
+    '/health',
+    '/api-docs',
+    '/api-docs-json',
+    '/favicon.ico',
+  ];
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const response = context.switchToHttp().getResponse<Response>();
+
+    // 제외된 경로는 로깅하지 않음
+    if (this.excludedPaths.some((path) => request.url.startsWith(path))) {
+      return next.handle();
+    }
+
+    const { method, url, ip } = request;
+    const userAgent = request.get('user-agent') || '';
+    const startTime = Date.now();
+
+    // 요청 정보 추출
+    const userId = (request as Request & { userId?: number }).userId;
+    const requestId = this.generateRequestId();
+
+    // 요청 로그
+    this.logger.log(
+      `[${requestId}] ${method} ${url} - IP: ${ip} - UserAgent: ${userAgent}${userId ? ` - UserId: ${userId}` : ''}`,
+    );
+
+    return next.handle().pipe(
+      tap({
+        next: () => {
+          const duration = Date.now() - startTime;
+          const statusCode = response.statusCode;
+
+          // 응답 로그
+          const logMessage = `[${requestId}] ${method} ${url} ${statusCode} - ${duration}ms`;
+
+          if (statusCode >= 500) {
+            this.logger.error(logMessage);
+          } else if (statusCode >= 400) {
+            this.logger.warn(logMessage);
+          } else {
+            this.logger.log(logMessage);
+          }
+        },
+        error: (error: unknown) => {
+          const duration = Date.now() - startTime;
+          const statusCode = response.statusCode || 500;
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+          const errorStack = error instanceof Error ? error.stack : undefined;
+
+          this.logger.error(
+            `[${requestId}] ${method} ${url} ${statusCode} - ${duration}ms - Error: ${errorMessage}`,
+            errorStack,
+          );
+        },
+      }),
+    );
+  }
+
+  /**
+   * 요청 추적을 위한 고유 ID 생성
+   */
+  private generateRequestId(): string {
+    return `req-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+  }
+}

--- a/apps/api/src/common/interceptors/logging.interceptor.ts
+++ b/apps/api/src/common/interceptors/logging.interceptor.ts
@@ -4,6 +4,7 @@ import {
   ExecutionContext,
   CallHandler,
   Logger,
+  HttpException,
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
@@ -66,7 +67,7 @@ export class LoggingInterceptor implements NestInterceptor {
         },
         error: (error: unknown) => {
           const duration = Date.now() - startTime;
-          const statusCode = response.statusCode || 500;
+          const statusCode = this.extractStatusCode(error, response.statusCode);
           const errorMessage =
             error instanceof Error ? error.message : String(error);
           const errorStack = error instanceof Error ? error.stack : undefined;
@@ -85,5 +86,20 @@ export class LoggingInterceptor implements NestInterceptor {
    */
   private generateRequestId(): string {
     return `req-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+  }
+
+  private extractStatusCode(
+    error: unknown,
+    responseStatusCode: number,
+  ): number {
+    if (error instanceof HttpException) {
+      return error.getStatus();
+    }
+
+    if (error instanceof Error) {
+      return responseStatusCode >= 400 ? responseStatusCode : 500;
+    }
+
+    return 500;
   }
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -88,7 +88,9 @@ async function bootstrap() {
 
   const logger = new Logger('Bootstrap');
   logger.log(`🚀 Application is running on: http://localhost:${port}`);
-  logger.log(`📚 Swagger documentation: http://localhost:${port}/api-docs`);
+  if (isSwaggerEnabled) {
+    logger.log(`📚 Swagger documentation: http://localhost:${port}/api-docs`);
+  }
   logger.log(`🌍 Environment: ${nodeEnv}`);
 }
 void bootstrap();

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,12 +1,34 @@
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe } from '@nestjs/common';
+import { ValidationPipe, Logger } from '@nestjs/common';
 import { AppModule } from './app.module';
 import cookieParser from 'cookie-parser';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import type { Request, Response } from 'express';
+import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
+import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  // Logger 설정
+  const nodeEnv = process.env.NODE_ENV || 'development';
+  const loggerOptions: (
+    | 'debug'
+    | 'verbose'
+    | 'error'
+    | 'warn'
+    | 'log'
+    | 'fatal'
+  )[] =
+    nodeEnv === 'production'
+      ? ['error', 'warn', 'log'] // 프로덕션: DEBUG 제외
+      : ['error', 'warn', 'log', 'debug', 'verbose']; // 개발: 모든 레벨
+
+  const app = await NestFactory.create(AppModule, {
+    logger: loggerOptions,
+  });
+
+  // 전역 인터셉터 및 필터 설정
+  app.useGlobalInterceptors(new LoggingInterceptor());
+  app.useGlobalFilters(new HttpExceptionFilter());
 
   // ValidationPipe 전역 설정
   app.useGlobalPipes(new ValidationPipe());
@@ -23,7 +45,6 @@ async function bootstrap() {
   }
 
   // Swagger 설정 (로컬/개발 환경에서만 노출)
-  const nodeEnv = process.env.NODE_ENV || 'development';
   const isSwaggerEnabled = nodeEnv === 'development' || nodeEnv === 'local';
 
   if (isSwaggerEnabled) {
@@ -62,6 +83,12 @@ async function bootstrap() {
       });
   }
 
-  await app.listen(process.env.PORT ?? 8000);
+  const port = process.env.PORT ?? 8000;
+  await app.listen(port);
+
+  const logger = new Logger('Bootstrap');
+  logger.log(`🚀 Application is running on: http://localhost:${port}`);
+  logger.log(`📚 Swagger documentation: http://localhost:${port}/api-docs`);
+  logger.log(`🌍 Environment: ${nodeEnv}`);
 }
 void bootstrap();

--- a/apps/api/test/jest-e2e.json
+++ b/apps/api/test/jest-e2e.json
@@ -1,9 +1,12 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
+  "rootDir": "..",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/src/$1"
   }
 }

--- a/apps/api/test/logging.e2e-spec.ts
+++ b/apps/api/test/logging.e2e-spec.ts
@@ -1,0 +1,112 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { AppModule } from '../src/app.module';
+import { LoggingInterceptor } from '../src/common/interceptors/logging.interceptor';
+import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
+
+describe('Logging E2E Tests', () => {
+  let app: INestApplication<App>;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+
+    // 인터셉터와 필터 등록
+    app.useGlobalInterceptors(new LoggingInterceptor());
+    app.useGlobalFilters(new HttpExceptionFilter());
+
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('LoggingInterceptor', () => {
+    it('정상 요청을 로깅해야 함', () => {
+      return request(app.getHttpServer())
+        .get('/')
+        .expect(200)
+        .expect((res) => {
+          // 요청이 성공적으로 처리되었는지 확인
+          expect(res.status).toBe(200);
+        });
+    });
+
+    it('제외된 경로(/health)는 로깅하지 않아야 함', () => {
+      return request(app.getHttpServer())
+        .get('/health')
+        .expect((res) => {
+          // 헬스체크는 로깅되지 않아야 함
+          expect(res.status).toBeGreaterThanOrEqual(200);
+          expect(res.status).toBeLessThan(500);
+        });
+    });
+  });
+
+  describe('HttpExceptionFilter', () => {
+    it('404 에러를 올바른 형식으로 응답해야 함', () => {
+      return request(app.getHttpServer())
+        .get('/api/nonexistent')
+        .expect(404)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('statusCode', 404);
+          expect(res.body).toHaveProperty('timestamp');
+          expect(res.body).toHaveProperty('path', '/api/nonexistent');
+          expect(res.body).toHaveProperty('method', 'GET');
+          expect(res.body).toHaveProperty('message');
+        });
+    });
+
+    it('에러 응답에 타임스탬프가 ISO 형식이어야 함', () => {
+      return request(app.getHttpServer())
+        .get('/api/nonexistent')
+        .expect(404)
+        .expect((res) => {
+          const body = res.body as { timestamp: string };
+          expect(body.timestamp).toMatch(
+            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+          );
+        });
+    });
+
+    it('에러 응답에 요청 정보가 포함되어야 함', () => {
+      return request(app.getHttpServer())
+        .post('/api/invalid-endpoint')
+        .send({ data: 'test' })
+        .expect(404)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('method', 'POST');
+          expect(res.body).toHaveProperty('path');
+        });
+    });
+  });
+
+  describe('통합 테스트', () => {
+    it('요청-응답 사이클이 올바르게 로깅되어야 함', () => {
+      return request(app.getHttpServer())
+        .get('/')
+        .expect(200)
+        .expect((res) => {
+          // 응답이 정상적으로 반환되는지 확인
+          expect(res.status).toBe(200);
+        });
+    });
+
+    it('에러 발생 시 필터가 올바르게 처리해야 함', () => {
+      return request(app.getHttpServer())
+        .get('/api/error-test')
+        .expect((res) => {
+          // 404 또는 다른 에러 상태 코드
+          expect(res.status).toBeGreaterThanOrEqual(400);
+          expect(res.body).toHaveProperty('statusCode');
+          expect(res.body).toHaveProperty('message');
+        });
+    });
+  });
+});


### PR DESCRIPTION
## 🔸 작업 내용

- #250 
- #251

### 1. 로그 체계 문서화
- [notion 학습 정리 - API 로그 체계](https://www.notion.so/API-2f48f02a9667808684c1f654409823c2?source=copy_link) 작성
  - 로그 레벨 기준 정의 (DEBUG, INFO, WARN, ERROR)
  - 로그 종류 및 목적 문서화 (요청/응답, 에러, 비즈니스, 외부 서비스, 데이터베이스)
  - 로그 포맷 표준 정의
  - Logger 사용 가이드 및 예시 코드
  - 환경별 로그 레벨 설정 가이드

### 2. 요청/응답 로깅 인터셉터 구현
- `apps/api/src/common/interceptors/logging.interceptor.ts` 생성
  - 모든 HTTP 요청/응답 자동 로깅
  - 요청 ID 생성으로 요청 추적 가능
  - 처리 시간(duration) 측정
  - 사용자 ID, IP, User-Agent 정보 포함
  - 헬스체크(`/health`), Swagger(`/api-docs`) 등 특정 경로 제외
  - 상태 코드에 따른 로그 레벨 자동 조정 (2xx: INFO, 4xx: WARN, 5xx: ERROR)

### 3. 예외 필터 구현
- `apps/api/src/common/filters/http-exception.filter.ts` 생성
  - 모든 HTTP 예외를 일관된 형식으로 로깅 및 응답
  - 에러 레벨에 따른 로그 레벨 자동 조정 (4xx: WARN, 5xx: ERROR)
  - 구조화된 에러 응답 제공 (statusCode, timestamp, path, method, message)
  - 스택 트레이스 포함 (5xx 에러)
  - 사용자 ID, IP 주소 등 컨텍스트 정보 포함

### 4. 전역 설정 업데이트
- `apps/api/src/main.ts` 수정
  - 환경별 로그 레벨 자동 조정 (개발: 모든 레벨, 프로덕션: INFO/WARN/ERROR)
  - 전역 인터셉터 및 필터 등록
  - 애플리케이션 시작 시 환경 정보 로깅

### 5. 테스트 코드 작성
- 단위 테스트
  - `apps/api/src/common/interceptors/logging.interceptor.spec.ts` (5개 테스트 케이스)
  - `apps/api/src/common/filters/http-exception.filter.spec.ts` (3개 테스트 케이스)
- E2E 테스트
  - `apps/api/test/logging.e2e-spec.ts` (통합 테스트)

## 🔸 고민 했던 부분

### 1. 로그 레벨 기준 정의
**고민**: 어떤 상황에서 어떤 로그 레벨을 사용해야 할지 명확한 기준이 필요했습니다.

**결과**: 
- DEBUG: 개발 환경에서만 사용, 상세한 디버깅 정보
- INFO: 일반적인 애플리케이션 흐름 추적
- WARN: 재시도 가능한 실패, 복구 가능한 상태
- ERROR: 복구 불가능한 에러, 예외 발생

각 레벨의 사용 예시와 목적을 문서에 명시하여 일관되게 사용할 수 있도록 했습니다.

### 2. 인터셉터와 필터의 역할 분리
**고민**: 요청/응답 로깅과 에러 로깅을 어떻게 분리할지 고민했습니다.

**결과**:
- **인터셉터**: 정상적인 요청/응답 흐름 로깅 (성공, 실패 모두 포함)
- **필터**: 예외 발생 시 에러 로깅 및 일관된 에러 응답 형식 제공

이렇게 분리하였고, 각각의 책임이 명확해진 것을 확인하였습니다.

### 3. 환경별 로그 레벨 설정
**고민**: 개발 환경과 프로덕션 환경에서 로그 레벨을 어떻게 다르게 설정할지 고민했습니다.

**결과**:
- 개발 환경: 모든 레벨 활성화 (DEBUG, INFO, WARN, ERROR)
- 프로덕션 환경: DEBUG 제외 (INFO, WARN, ERROR만 활성화)
- `main.ts`에서 환경 변수를 기반으로 자동 조정

이를 통해 개발 시에는 상세한 정보를 얻을 수 있고, 프로덕션에서는 필요한 정보만 출력하도록 하였습니다.

### 4. 요청 추적 ID(Request ID) 도입

**고민**: 동시에 여러 요청이 들어올 경우, 요청 로그와 응답 로그가 섞여 하나의 요청 흐름을 추적하기 어려웠습니다.

**해결**: 각 요청마다 고유한 Request ID를 생성하고, 요청·응답·에러 로그에 동일한 ID를 포함하도록 구현했습니다.

**결과**:
- 요청과 응답 로그를 명확하게 매칭할 수 있게 됨
- 동일 엔드포인트의 동시 요청도 쉽게 구분 가능
- 특정 요청의 전체 처리 흐름을 로그에서 빠르게 추적 가능
- 향후 분산 환경에서 Correlation ID로 확장 가능한 구조 확보

이를 통해 하나의 요청이 어떤 경로로 처리되고, 어떤 결과를 남겼는지 로그 상에서 추적할 수 있도록 했습니다.

## 🔸 참고

### 테스트 실행 방법
```bash
# 단위 테스트
pnpm test logging.interceptor.spec
pnpm test http-exception.filter.spec

# E2E 테스트
pnpm test:e2e logging.e2e-spec
```

### 로그 예시

**요청/응답 로그 및 에러 로그**

<img width="943" height="326" alt="스크린샷 2026-01-26 22 24 27" src="https://github.com/user-attachments/assets/d04d6ad7-3bb9-4bca-809a-94e750b6ce87" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 글로벌 예외 처리 필터와 요청/응답 로깅 인터셉터를 통합해 일관된 에러 응답(상태, 타임스탬프, 경로, 메서드 등)과 요청별 식별자(requestId)를 포함한 구조화된 로그 제공
  * 환경별 로거 구성, 글로벌 검증 파이프·쿠키 파서 적용, 개발에서만 Swagger/CORS 노출 및 시작 로그 개선

* **Tests**
  * 예외 필터·로깅 인터셉터 대상 단위 테스트 추가(4xx/5xx/일반 오류 로그·응답 검증)
  * 통합 E2E 테스트 추가(정상/오류 경로 및 /health 등 제외 경로 검증)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->