### PR TITLE
fix: 폰트 사이즈 키움에 따라서 Tab UI의 레이아웃이 깨지는 문제 수정

### DIFF
--- a/apps/web/src/components/tabs/tabs.tsx
+++ b/apps/web/src/components/tabs/tabs.tsx
@@ -13,7 +13,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "ml-5 inline-flex h-10 items-center justify-center rounded-lg gap-2 text-zinc-500",
+      "ml-5 inline-flex h-12.5 items-center justify-center rounded-lg gap-2 text-zinc-500",
       className,
     )}
     {...props}
@@ -28,7 +28,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-t-xl px-5 py-3 text-base font-semibold ring-offset-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-slate-100 text-slate-400  data-[state=active]:border-slate-200 border-x-slate-100  border-t-slate-100 border-b-slate-200 data-[state=active]:border-b-white data-[state=active]:bg-white border data-[state=active]:text-teal-500",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-t-xl px-5 py-3 text-base font-semibold ring-offset-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-slate-100 text-slate-400  data-[state=active]:border-t-slate-200 data-[state=active]:border-x-slate-200 data-[state=active]:border-b-white data-[state=active]:shadow-[0px_1px_0px_0px_#FFFFFFFF] border-slate-100  data-[state=active]:bg-white border data-[state=active]:text-teal-500",
       className,
     )}
     {...props}
@@ -43,7 +43,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-0.5 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-950 focus-visible:ring-offset-2",
+      "ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-950 focus-visible:ring-offset-2",
       className,
     )}
     {...props}


### PR DESCRIPTION
## 🔸 작업 내용

- 폰트 사이즈 키움에 따라서 Tab UI의 레이아웃이 깨지는 문제 수정

## 🔸 참고

수정 전:

<img width="530" height="101" alt="Screenshot 2026-01-27 at 12 12 35 PM" src="https://github.com/user-attachments/assets/95b80f83-6d3a-44bf-99ab-ff6c48c512a7" />

수정 후:

<img width="555" height="121" alt="Screenshot 2026-01-27 at 12 12 19 PM" src="https://github.com/user-attachments/assets/cd661194-103e-498d-bc16-c167e0735467" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일
  * 탭 리스트의 높이가 증가하여 더 넓은 공간을 확보했습니다.
  * 활성 탭에 테두리, 그림자, 개선된 간격이 추가되어 시각적 강조가 향상되었습니다.
  * 탭 콘텐츠의 포커스 상태 스타일이 최적화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->