### PR TITLE
문제 풀이 페이지에서 녹음 완료 후 다시 들어볼 수 있는 기능 추가

### DIFF
--- a/apps/web/src/app/daily/questions/[questionId]/_components/voice-input.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/_components/voice-input.tsx
@@ -164,6 +164,8 @@ function VoiceInput({
                   type="button"
                   onClick={isPlaying ? pausePlayback : playRecording}
                   disabled={isSubmitting}
+                  aria-label={isPlaying ? "일시정지" : "재생"}
+                  aria-pressed={isPlaying}
                   className="flex items-center justify-center w-10 h-10 rounded-full bg-primary text-white hover:bg-primary/90 transition-colors disabled:opacity-50"
                 >
                   {isPlaying ? (
@@ -185,6 +187,8 @@ function VoiceInput({
                     onValueCommit={handleSeekEnd}
                     disabled={isSubmitting}
                     className="flex-1"
+                    aria-label="녹음 재생 위치"
+                    aria-valuetext={`${formatTime(Math.floor(playbackTime))} / ${formatTime(Math.floor(duration || elapsedSeconds))}`}
                   />
                   <span className="text-sm tabular-nums text-muted-foreground min-w-17.5 text-right">
                     {formatTime(Math.floor(playbackTime))} /{" "}

--- a/apps/web/src/app/daily/questions/[questionId]/_components/voice-input.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/_components/voice-input.tsx
@@ -10,7 +10,10 @@ import {
   MicOff,
   ShieldAlert,
   AlertCircle,
+  Play,
+  Pause,
 } from "lucide-react";
+import { Slider } from "@/components/slider/slider";
 import useRecorder, { RecorderStatus } from "../_hooks/use-recorder";
 import RecordButton from "./record-button";
 import useWav from "@/hooks/use-wav";
@@ -51,9 +54,32 @@ function VoiceInput({
     stopRecording,
     retryRecording,
     getAudioBlob,
+    isPlaying,
+    playbackTime,
+    duration,
+    playRecording,
+    pausePlayback,
+    seekTo,
   } = useRecorder({ maxDurationSeconds });
 
   const { play: playDing, ready: dingWavReady } = useWav("/ui-confirm.wav", 1);
+
+  const wasPlayingBeforeSeekRef = React.useRef(false);
+
+  const handleSeekStart = () => {
+    if (isPlaying) {
+      wasPlayingBeforeSeekRef.current = true;
+      pausePlayback();
+    }
+  };
+
+  const handleSeekEnd = (value: number[]) => {
+    seekTo(value[0]);
+    if (wasPlayingBeforeSeekRef.current) {
+      wasPlayingBeforeSeekRef.current = false;
+      playRecording();
+    }
+  };
 
   const recordingState: RecordingState = isRecording
     ? "recording"
@@ -122,8 +148,42 @@ function VoiceInput({
             maxDurationSeconds={maxDurationSeconds}
           />
 
-          <div className="max-w-lg">
-            <Waveform historyRef={historyRef} />
+          <div className="max-w-lg w-full px-6">
+            {hasRecorded ? (
+              <div className="flex items-center gap-3 h-40">
+                <button
+                  type="button"
+                  onClick={isPlaying ? pausePlayback : playRecording}
+                  disabled={isSubmitting}
+                  className="flex items-center justify-center w-10 h-10 rounded-full bg-primary text-white hover:bg-primary/90 transition-colors disabled:opacity-50"
+                >
+                  {isPlaying ? (
+                    <Pause className="w-5 h-5" />
+                  ) : (
+                    <Play className="w-5 h-5 ml-0.5" />
+                  )}
+                </button>
+                <div className="flex-1 flex items-center gap-3">
+                  <Slider
+                    value={[playbackTime]}
+                    min={0}
+                    max={duration || elapsedSeconds}
+                    step={0.1}
+                    onPointerDown={handleSeekStart}
+                    onValueChange={([value]) => seekTo(value)}
+                    onValueCommit={handleSeekEnd}
+                    disabled={isSubmitting}
+                    className="flex-1"
+                  />
+                  <span className="text-sm tabular-nums text-muted-foreground min-w-17.5 text-right">
+                    {formatTime(Math.floor(playbackTime))} /{" "}
+                    {formatTime(Math.floor(duration || elapsedSeconds))}
+                  </span>
+                </div>
+              </div>
+            ) : (
+              <Waveform historyRef={historyRef} />
+            )}
           </div>
 
           <div className="flex items-center justify-center h-24">

--- a/apps/web/src/app/daily/questions/[questionId]/_components/voice-input.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/_components/voice-input.tsx
@@ -67,16 +67,25 @@ function VoiceInput({
   const wasPlayingBeforeSeekRef = React.useRef(false);
 
   const handleSeekStart = () => {
+    wasPlayingBeforeSeekRef.current = isPlaying;
     if (isPlaying) {
-      wasPlayingBeforeSeekRef.current = true;
       pausePlayback();
     }
   };
 
   const handleSeekEnd = (value: number[]) => {
     seekTo(value[0]);
-    if (wasPlayingBeforeSeekRef.current) {
-      wasPlayingBeforeSeekRef.current = false;
+    const shouldResume = wasPlayingBeforeSeekRef.current;
+    wasPlayingBeforeSeekRef.current = false;
+    if (shouldResume) {
+      playRecording();
+    }
+  };
+
+  const handleSeekCancel = () => {
+    const shouldResume = wasPlayingBeforeSeekRef.current;
+    wasPlayingBeforeSeekRef.current = false;
+    if (shouldResume) {
       playRecording();
     }
   };
@@ -170,6 +179,8 @@ function VoiceInput({
                     max={duration || elapsedSeconds}
                     step={0.1}
                     onPointerDown={handleSeekStart}
+                    onPointerUp={handleSeekCancel}
+                    onPointerLeave={handleSeekCancel}
                     onValueChange={([value]) => seekTo(value)}
                     onValueCommit={handleSeekEnd}
                     disabled={isSubmitting}
@@ -287,12 +298,12 @@ function StatusMessage({
     <div className="h-20 text-center">
       {state === "recording" && (
         <div className="animate-in fade-in">
-          <p className="text-5xl font-semibold tabular-nums text-center tracking-tight">
-            {formatTime(elapsedSeconds)}{" "}
-            <span className="text-lg text-muted-foreground font-normal">
+          <div className="text-5xl font-semibold tabular-nums text-center tracking-tight flex items-end gap-1">
+            <div>{formatTime(elapsedSeconds)} </div>
+            <div className="text-lg text-muted-foreground font-normal">
               / {formatTime(maxDurationSeconds)}
-            </span>
-          </p>
+            </div>
+          </div>
           <p className="text-muted-foreground text-center mt-1">녹음 중...</p>
         </div>
       )}

--- a/apps/web/src/app/daily/questions/[questionId]/_components/voice-input.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/_components/voice-input.tsx
@@ -148,7 +148,7 @@ function VoiceInput({
             maxDurationSeconds={maxDurationSeconds}
           />
 
-          <div className="max-w-lg w-full px-6">
+          <div className="max-w-sm w-full px-6">
             {hasRecorded ? (
               <div className="flex items-center gap-3 h-40">
                 <button

--- a/apps/web/src/app/daily/questions/[questionId]/_hooks/use-recorder.ts
+++ b/apps/web/src/app/daily/questions/[questionId]/_hooks/use-recorder.ts
@@ -354,10 +354,10 @@ function useRecorder(options: UseRecorderOptions = {}) {
   }, []);
 
   // 재생 시작/재개
-  const playRecording = React.useCallback(() => {
-    if (!recordedBlobRef.current) return;
+  // Audio 엘리먼트 생성 (재생 또는 seek 시 lazy 생성)
+  const ensureAudioElement = React.useCallback(() => {
+    if (!recordedBlobRef.current) return null;
 
-    // Audio 엘리먼트가 없으면 생성
     if (!audioRef.current) {
       audioUrlRef.current = URL.createObjectURL(recordedBlobRef.current);
       audioRef.current = new Audio(audioUrlRef.current);
@@ -376,9 +376,16 @@ function useRecorder(options: UseRecorderOptions = {}) {
       audioRef.current.addEventListener("ended", handleEnded);
     }
 
-    void audioRef.current.play();
-    setIsPlaying(true);
+    return audioRef.current;
   }, []);
+
+  const playRecording = React.useCallback(() => {
+    const audio = ensureAudioElement();
+    if (!audio) return;
+
+    void audio.play();
+    setIsPlaying(true);
+  }, [ensureAudioElement]);
 
   // 일시정지
   const pausePlayback = React.useCallback(() => {
@@ -399,12 +406,16 @@ function useRecorder(options: UseRecorderOptions = {}) {
   }, []);
 
   // 특정 위치로 이동
-  const seekTo = React.useCallback((time: number) => {
-    if (audioRef.current) {
-      audioRef.current.currentTime = time;
-      setPlaybackTime(time);
-    }
-  }, []);
+  const seekTo = React.useCallback(
+    (time: number) => {
+      const audio = ensureAudioElement();
+      if (audio) {
+        audio.currentTime = time;
+        setPlaybackTime(time);
+      }
+    },
+    [ensureAudioElement],
+  );
 
   const getAudioBlob = React.useCallback(
     () => recordedBlobRef.current ?? null,

--- a/apps/web/src/app/daily/questions/[questionId]/_hooks/use-recorder.ts
+++ b/apps/web/src/app/daily/questions/[questionId]/_hooks/use-recorder.ts
@@ -80,6 +80,10 @@ function useRecorder(options: UseRecorderOptions = {}) {
   // 재생 관련 Ref
   const audioRef = React.useRef<HTMLAudioElement | null>(null);
   const audioUrlRef = React.useRef<string | null>(null);
+  const audioHandlersRef = React.useRef<{
+    loadedmetadata: (() => void) | null;
+    ended: (() => void) | null;
+  }>({ loadedmetadata: null, ended: null });
 
   const accumRef = React.useRef({
     sumSq: 0,
@@ -311,11 +315,25 @@ function useRecorder(options: UseRecorderOptions = {}) {
   }, []);
 
   const retryRecording = React.useCallback(() => {
-    // 재생 정리
+    // 재생 정리 - 이벤트 리스너 제거
     if (audioRef.current) {
+      if (audioHandlersRef.current.loadedmetadata) {
+        audioRef.current.removeEventListener(
+          "loadedmetadata",
+          audioHandlersRef.current.loadedmetadata,
+        );
+      }
+      if (audioHandlersRef.current.ended) {
+        audioRef.current.removeEventListener(
+          "ended",
+          audioHandlersRef.current.ended,
+        );
+      }
       audioRef.current.pause();
       audioRef.current = null;
     }
+    audioHandlersRef.current = { loadedmetadata: null, ended: null };
+
     if (audioUrlRef.current) {
       URL.revokeObjectURL(audioUrlRef.current);
       audioUrlRef.current = null;
@@ -344,13 +362,18 @@ function useRecorder(options: UseRecorderOptions = {}) {
       audioUrlRef.current = URL.createObjectURL(recordedBlobRef.current);
       audioRef.current = new Audio(audioUrlRef.current);
 
-      audioRef.current.addEventListener("loadedmetadata", () => {
+      const handleLoadedMetadata = () => {
         setDuration(audioRef.current?.duration ?? 0);
-      });
-
-      audioRef.current.addEventListener("ended", () => {
+      };
+      const handleEnded = () => {
         setIsPlaying(false);
-      });
+      };
+
+      audioHandlersRef.current.loadedmetadata = handleLoadedMetadata;
+      audioHandlersRef.current.ended = handleEnded;
+
+      audioRef.current.addEventListener("loadedmetadata", handleLoadedMetadata);
+      audioRef.current.addEventListener("ended", handleEnded);
     }
 
     void audioRef.current.play();
@@ -429,9 +452,24 @@ function useRecorder(options: UseRecorderOptions = {}) {
     }
   }, isPlaying);
 
-  // 컴포넌트 언마운트 시 오디오 URL 정리
+  // 컴포넌트 언마운트 시 오디오 리소스 정리
   React.useEffect(() => {
     return () => {
+      if (audioRef.current) {
+        if (audioHandlersRef.current.loadedmetadata) {
+          audioRef.current.removeEventListener(
+            "loadedmetadata",
+            audioHandlersRef.current.loadedmetadata,
+          );
+        }
+        if (audioHandlersRef.current.ended) {
+          audioRef.current.removeEventListener(
+            "ended",
+            audioHandlersRef.current.ended,
+          );
+        }
+        audioRef.current.pause();
+      }
       if (audioUrlRef.current) {
         URL.revokeObjectURL(audioUrlRef.current);
       }

--- a/apps/web/src/app/daily/questions/[questionId]/_hooks/use-recorder.ts
+++ b/apps/web/src/app/daily/questions/[questionId]/_hooks/use-recorder.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 import createAudioStreamer, { AudioStreamerHandle } from "@/lib/audio-streamer";
 import { encodePcmToWav } from "@/lib/wav-encoder";
+import useAnimationFrame from "@/hooks/use-animation-frame";
 import {
   AUDIO_CONFIG,
   WAVEFORM_CONFIG,
@@ -57,6 +58,11 @@ function useRecorder(options: UseRecorderOptions = {}) {
   const [elapsedSeconds, setElapsedSeconds] = React.useState(0);
   const [hasRecorded, setHasRecorded] = React.useState(false);
 
+  // 재생 관련 상태
+  const [isPlaying, setIsPlaying] = React.useState(false);
+  const [playbackTime, setPlaybackTime] = React.useState(0);
+  const [duration, setDuration] = React.useState(0);
+
   // 결과 WAV Blob
   const recordedBlobRef = React.useRef<Blob | null>(null);
 
@@ -70,6 +76,10 @@ function useRecorder(options: UseRecorderOptions = {}) {
 
   const timerRef = React.useRef<NodeJS.Timeout | null>(null);
   const streamerRef = React.useRef<AudioStreamerHandle | null>(null);
+
+  // 재생 관련 Ref
+  const audioRef = React.useRef<HTMLAudioElement | null>(null);
+  const audioUrlRef = React.useRef<string | null>(null);
 
   const accumRef = React.useRef({
     sumSq: 0,
@@ -301,6 +311,19 @@ function useRecorder(options: UseRecorderOptions = {}) {
   }, []);
 
   const retryRecording = React.useCallback(() => {
+    // 재생 정리
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current = null;
+    }
+    if (audioUrlRef.current) {
+      URL.revokeObjectURL(audioUrlRef.current);
+      audioUrlRef.current = null;
+    }
+    setIsPlaying(false);
+    setPlaybackTime(0);
+    setDuration(0);
+
     recordedBlobRef.current = null;
     pcmChunksRef.current = [];
     historyRef.current = Array.from(
@@ -310,6 +333,58 @@ function useRecorder(options: UseRecorderOptions = {}) {
     setHasRecorded(false);
     setElapsedSeconds(0);
     setIsRecording(false);
+  }, []);
+
+  // 재생 시작/재개
+  const playRecording = React.useCallback(() => {
+    if (!recordedBlobRef.current) return;
+
+    // Audio 엘리먼트가 없으면 생성
+    if (!audioRef.current) {
+      audioUrlRef.current = URL.createObjectURL(recordedBlobRef.current);
+      audioRef.current = new Audio(audioUrlRef.current);
+
+      audioRef.current.addEventListener("loadedmetadata", () => {
+        setDuration(audioRef.current?.duration ?? 0);
+      });
+
+      audioRef.current.addEventListener("ended", () => {
+        setIsPlaying(false);
+        setPlaybackTime(0);
+        if (audioRef.current) {
+          audioRef.current.currentTime = 0;
+        }
+      });
+    }
+
+    void audioRef.current.play();
+    setIsPlaying(true);
+  }, []);
+
+  // 일시정지
+  const pausePlayback = React.useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      setIsPlaying(false);
+    }
+  }, []);
+
+  // 정지 (처음으로)
+  const stopPlayback = React.useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.currentTime = 0;
+      setIsPlaying(false);
+      setPlaybackTime(0);
+    }
+  }, []);
+
+  // 특정 위치로 이동
+  const seekTo = React.useCallback((time: number) => {
+    if (audioRef.current) {
+      audioRef.current.currentTime = time;
+      setPlaybackTime(time);
+    }
   }, []);
 
   const getAudioBlob = React.useCallback(
@@ -351,6 +426,22 @@ function useRecorder(options: UseRecorderOptions = {}) {
     return newStatus;
   }, [checkStatus]);
 
+  // 재생 중일 때 부드럽게 playbackTime 업데이트
+  useAnimationFrame(() => {
+    if (audioRef.current) {
+      setPlaybackTime(audioRef.current.currentTime);
+    }
+  }, isPlaying);
+
+  // 컴포넌트 언마운트 시 오디오 URL 정리
+  React.useEffect(() => {
+    return () => {
+      if (audioUrlRef.current) {
+        URL.revokeObjectURL(audioUrlRef.current);
+      }
+    };
+  }, []);
+
   return {
     status,
     refreshStatus,
@@ -368,6 +459,15 @@ function useRecorder(options: UseRecorderOptions = {}) {
 
     getAudioBlob, // WAV Blob
     getAudioMimeType, // "audio/wav"
+
+    // 재생 관련
+    isPlaying,
+    playbackTime,
+    duration,
+    playRecording,
+    pausePlayback,
+    stopPlayback,
+    seekTo,
   };
 }
 

--- a/apps/web/src/app/daily/questions/[questionId]/_hooks/use-recorder.ts
+++ b/apps/web/src/app/daily/questions/[questionId]/_hooks/use-recorder.ts
@@ -379,12 +379,17 @@ function useRecorder(options: UseRecorderOptions = {}) {
     return audioRef.current;
   }, []);
 
-  const playRecording = React.useCallback(() => {
+  const playRecording = React.useCallback(async () => {
     const audio = ensureAudioElement();
     if (!audio) return;
 
-    void audio.play();
-    setIsPlaying(true);
+    try {
+      await audio.play();
+      setIsPlaying(true);
+    } catch (error) {
+      setIsPlaying(false);
+      console.error("Failed to play recording:", error);
+    }
   }, [ensureAudioElement]);
 
   // 일시정지

--- a/apps/web/src/app/daily/questions/[questionId]/_hooks/use-recorder.ts
+++ b/apps/web/src/app/daily/questions/[questionId]/_hooks/use-recorder.ts
@@ -350,10 +350,6 @@ function useRecorder(options: UseRecorderOptions = {}) {
 
       audioRef.current.addEventListener("ended", () => {
         setIsPlaying(false);
-        setPlaybackTime(0);
-        if (audioRef.current) {
-          audioRef.current.currentTime = 0;
-        }
       });
     }
 

--- a/apps/web/src/components/slider/slider.tsx
+++ b/apps/web/src/components/slider/slider.tsx
@@ -18,8 +18,8 @@ function Slider({
         ? value
         : Array.isArray(defaultValue)
           ? defaultValue
-          : [min, max],
-    [value, defaultValue, min, max],
+          : [min],
+    [value, defaultValue, min],
   );
 
   return (

--- a/apps/web/src/components/slider/slider.tsx
+++ b/apps/web/src/components/slider/slider.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import * as React from "react";
+import { Slider as SliderPrimitive } from "radix-ui";
+import { cn } from "@/lib/cn";
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  const _values = React.useMemo(
+    () =>
+      Array.isArray(value)
+        ? value
+        : Array.isArray(defaultValue)
+          ? defaultValue
+          : [min, max],
+    [value, defaultValue, min, max],
+  );
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        "data-vertical:min-h-40 relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-vertical:h-full data-vertical:w-auto data-vertical:flex-col",
+        className,
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className="rounded-full data-[orientation=horizontal]:h-1 data-[orientation=horizontal]:w-full data-vertical:h-full data-vertical:w-1 bg-muted relative grow overflow-hidden"
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className="bg-primary absolute select-none data-[orientation=horizontal]:h-full data-vertical:w-full"
+        />
+      </SliderPrimitive.Track>
+      {Array.from({ length: _values.length }, (_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot="slider-thumb"
+          key={index}
+          className="border-ring ring-ring/50 relative size-3 rounded-full border bg-white transition-[color,box-shadow] after:absolute after:-inset-2 hover:ring-[3px] focus-visible:ring-[3px] focus-visible:outline-hidden active:ring-[3px] block shrink-0 select-none disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  );
+}
+
+export { Slider };

--- a/apps/web/src/components/waveform/draw-wave-form.ts
+++ b/apps/web/src/components/waveform/draw-wave-form.ts
@@ -10,22 +10,9 @@ function drawWaveform(
     numberOfPaddingBars: number;
   },
 ) {
-  const { barWidthPx, barGapPx, barColor, numberOfPaddingBars } = opts;
+  const { barWidthPx, barGapPx, barColor } = opts;
 
   ctx.clearRect(0, 0, w, h);
-
-  // padding idle bars
-  if (history.length) {
-    for (let i = 0; i < numberOfPaddingBars; i++) {
-      const x = w - i * (barWidthPx + barGapPx) - barWidthPx;
-      const amp = 4;
-      const y = h / 2 - amp / 2;
-      ctx.fillStyle = barColor;
-      ctx.beginPath();
-      ctx.roundRect(x, y, barWidthPx, amp, barWidthPx / 2);
-      ctx.fill();
-    }
-  }
 
   for (let i = 0; i < history.length; i++) {
     const idxFromRight = history.length - 1 - i;
@@ -37,8 +24,7 @@ function drawWaveform(
     // 최소 높이 설정 (너무 작으면 보이지 않으므로)
     const finalAmp = Math.max(Math.min(newAmp, maxAmplitude), 4);
 
-    const x =
-      w - (numberOfPaddingBars + i) * (barWidthPx + barGapPx) - barWidthPx;
+    const x = w - i * (barWidthPx + barGapPx) - barWidthPx;
     if (x + barWidthPx < 0) break;
 
     const y = h / 2 - finalAmp / 2;

--- a/apps/web/src/hooks/use-animation-frame.ts
+++ b/apps/web/src/hooks/use-animation-frame.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 
 type AnimationCallback = (deltaTime: number) => void;
 
-function useAnimationFrame(callback: AnimationCallback) {
+function useAnimationFrame(callback: AnimationCallback, enabled = true) {
   const callbackRef = React.useRef<AnimationCallback>(callback);
   const rafIdRef = React.useRef<number | null>(null);
   const lastTimeRef = React.useRef<number | null>(null);
@@ -12,6 +12,15 @@ function useAnimationFrame(callback: AnimationCallback) {
   }, [callback]);
 
   React.useEffect(() => {
+    if (!enabled) {
+      if (rafIdRef.current) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+      lastTimeRef.current = null;
+      return;
+    }
+
     const loop = (time: number) => {
       const last = lastTimeRef.current;
       const deltaTime = last === null ? 0 : time - last;
@@ -29,7 +38,7 @@ function useAnimationFrame(callback: AnimationCallback) {
       rafIdRef.current = null;
       lastTimeRef.current = null;
     };
-  }, []);
+  }, [enabled]);
 }
 
 export default useAnimationFrame;


### PR DESCRIPTION
## 🔸 작업 내용

- use-recorder.tsx 훅에 녹음 플레이백 관련 기능들을 추가했습니다.
- 문제 풀이 페이지에서 녹음 완료 후, 녹음을 다시 들어볼 수 있도록 플레이백 UI를 추가했습니다.
- `useAnimationFrame` 훅에 `enabled` 옵션을 추가했습니다. `enabled`가 true일 때만 애니메이션 프레임 콜백이 호출됩니다.

## 🔸 참고

### 플레이백 슬라이더가 부드럽게 업데이트되지 않는 문제

문제 상황:

- HTML5 Audio의 timeupdate 이벤트가 약 4Hz(250ms 간격)로 불규칙하게 발생
- 이로 인해 Slider의 playbackTime 업데이트가 끊기면서 움직임

해결 방법:

- timeupdate 이벤트 리스너를 제거
- requestAnimationFrame 기반의 useAnimationFrame 훅을 사용하여 약 60fps로 playbackTime 업데이트
- 기존 훅에 enabled 파라미터를 추가하여 isPlaying 상태일 때만 실행되도록 변경



## 🔸 참고

https://github.com/user-attachments/assets/ced315eb-930b-481f-a35d-d6325ad37e00



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 녹음 재생 UI 추가: 재생/일시정지 버튼, 탐색용 슬라이더, 재생 시간 표시로 정적 파형을 대체(녹음 존재 시).
  * 정밀 탐색 지원: 탐색 시작 시 일시정지, 탐색 종료 후 이전 재생 상태로 자동 복원.

* **버그 픽스 / 개선**
  * 재생 상태 및 시간 동기화 개선, 재시도·언마운트 시 오디오 자원 정리 강화.
  * 파형 렌더링 간소화로 초기 여백 제거 및 위치 계산 개선.
  * 애니메이션 루프에 활성화 플래그 추가로 성능 제어 가능.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->