### PR TITLE
스트릭 컴포넌트 툴팁 제공 및 문제 단위로 스트릭 계산되게 수정. 마이페이지 목데이터 삭제

### DIFF
--- a/apps/api/src/answer-submission/answer-submission.module.ts
+++ b/apps/api/src/answer-submission/answer-submission.module.ts
@@ -15,7 +15,7 @@ import { AnswerEvaluationModule } from '../answer-evaluation/answer-evaluation.m
     TypeOrmModule.forFeature([AnswerSubmission, AudioAsset, Question]),
     forwardRef(() => SttModule),
     forwardRef(() => AnswerEvaluationModule),
-    StreaksModule,
+    forwardRef(() => StreaksModule),
     AuthModule,
   ],
   controllers: [AnswerSubmissionController],

--- a/apps/api/src/answer-submission/answer-submission.service.ts
+++ b/apps/api/src/answer-submission/answer-submission.service.ts
@@ -6,27 +6,28 @@ import {
   NotFoundException,
   forwardRef,
 } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 import { EvaluationStatus } from 'src/answer-evaluation/answer-evaluation.constants';
 import { AnswerEvaluationService } from 'src/answer-evaluation/answer-evaluation.service';
 import { StreaksService } from 'src/streaks/streaks.service';
 import { Repository } from 'typeorm';
-import { OnEvent } from '@nestjs/event-emitter';
+import { Question } from '../question/entities/question.entity';
+import { SttService } from '../stt/stt.service';
 import {
   AudioAsset,
   AudioUploadStatus,
 } from '../uploads/entities/audio-asset.entity';
-import { Question } from '../question/entities/question.entity';
-import { SttService } from '../stt/stt.service';
 import { UpdateImportanceDto } from './dtos/update-importance-rating.dto';
 
+import { YearlyAnswerSubmissionsDto } from 'src/streaks/dtos/streaks-count.dto';
+import { AudioUploadCompletedEvent } from '../uploads/events/audio-upload-completed.event';
 import {
   InputType,
   ProcessStatus,
   QuizMode,
 } from './answer-submission.constants';
 import { AnswerSubmissionResponseDto } from './dtos/answer-submission-response.dto';
-import { AudioUploadCompletedEvent } from '../uploads/events/audio-upload-completed.event';
 import { SubmitAnswerDto } from './dtos/submit-answer.dto';
 import { AnswerSubmission } from './entities/answer-submission.entity';
 
@@ -342,6 +343,7 @@ export class AnswerSubmissionService {
    * 오디오 업로드 완료 이벤트 핸들러
    * 업로드 완료 시 해당 audioAssetId로 제출된 답변이 있고 STT가 아직 PENDING이면 STT 요청
    */
+
   @OnEvent('audio.upload.completed')
   async handleAudioUploadCompleted(
     event: AudioUploadCompletedEvent,
@@ -413,5 +415,30 @@ export class AnswerSubmissionService {
         );
       }
     }
+  }
+
+  // 스트릭 계산을 위해 연간 문제 풀이 목록 출력
+  async getDistinctQuestionsByYear(
+    userId: number,
+    start: Date,
+    end: Date,
+  ): Promise<YearlyAnswerSubmissionsDto[]> {
+    return this.answerSubmissionRepository
+      .createQueryBuilder('submission')
+      .distinctOn(['submission.questionId'])
+      .innerJoin('submission.question', 'question')
+      .select('submission.id', 'id')
+      .addSelect('submission.submittedAt', 'submittedAt')
+      .addSelect('submission.questionId', 'questionId')
+      .addSelect('question.title', 'title')
+      .where('submission.userId = :userId', { userId })
+      .andWhere(
+        'submission.submittedAt >= :start AND submission.submittedAt < :end',
+        { start, end },
+      )
+      .orderBy('submission.questionId', 'ASC')
+      .addOrderBy('submission.submittedAt', 'ASC')
+      .addOrderBy('submission.id', 'DESC')
+      .getRawMany<YearlyAnswerSubmissionsDto>();
   }
 }

--- a/apps/api/src/streaks/dtos/streaks-count.dto.ts
+++ b/apps/api/src/streaks/dtos/streaks-count.dto.ts
@@ -1,11 +1,32 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+export class YearlyAnswerSubmissionsDto {
+  @ApiProperty({ description: '제출 ID', example: 1 })
+  id: number;
+
+  @ApiProperty({
+    description: '제출 일시',
+  })
+  submittedAt: Date;
+
+  @ApiProperty({ description: '문제 ID', example: 10 })
+  questionId: number;
+
+  @ApiProperty({ description: '문제 제목', example: 'HTTP와 HTTPS의 차이' })
+  title: string;
+}
 export class GetYearlyActivityCountResponseDto {
   @ApiProperty({
-    description: '연간 학습일 수',
+    description: '연간 고유 문제 제출 수',
     example: 120,
   })
-  streakCount: number;
+  submittedQuestionCount: number;
+
+  @ApiProperty({
+    description: '문제 제출 상세 정보',
+    type: [YearlyAnswerSubmissionsDto],
+  })
+  yearlyAnswerSubmissions: YearlyAnswerSubmissionsDto[];
 }
 
 export class GetConsecutiveDayCountResponseDto {

--- a/apps/api/src/streaks/entities/streaks.entity.ts
+++ b/apps/api/src/streaks/entities/streaks.entity.ts
@@ -1,6 +1,7 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, PrimaryGeneratedColumn, Unique } from 'typeorm';
 
 @Entity()
+@Unique(['userId', 'activityDate'])
 export class Streaks {
   @PrimaryGeneratedColumn()
   id: number;

--- a/apps/api/src/streaks/streaks.controller.ts
+++ b/apps/api/src/streaks/streaks.controller.ts
@@ -37,7 +37,7 @@ export class StreaksController {
     required: false,
     type: Number,
     description: '조회할 연도 (기본값: 현재 연도)',
-    example: 2024,
+    example: 2026,
   })
   @ApiResponse({
     status: 200,

--- a/apps/api/src/streaks/streaks.module.ts
+++ b/apps/api/src/streaks/streaks.module.ts
@@ -1,13 +1,17 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { AnswerSubmission } from 'src/answer-submission/entities/answer-submission.entity';
+import { AnswerSubmissionModule } from 'src/answer-submission/answer-submission.module';
 import { AuthModule } from '../auth/auth.module';
 import { Streaks } from './entities/streaks.entity';
 import { StreaksController } from './streaks.controller';
 import { StreaksService } from './streaks.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Streaks, AnswerSubmission]), AuthModule],
+  imports: [
+    TypeOrmModule.forFeature([Streaks]),
+    forwardRef(() => AnswerSubmissionModule),
+    AuthModule,
+  ],
   controllers: [StreaksController],
   providers: [StreaksService],
   exports: [StreaksService],

--- a/apps/api/src/streaks/streaks.module.ts
+++ b/apps/api/src/streaks/streaks.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AnswerSubmission } from 'src/answer-submission/entities/answer-submission.entity';
+import { AuthModule } from '../auth/auth.module';
 import { Streaks } from './entities/streaks.entity';
 import { StreaksController } from './streaks.controller';
 import { StreaksService } from './streaks.service';
-import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Streaks]), AuthModule],
+  imports: [TypeOrmModule.forFeature([Streaks, AnswerSubmission]), AuthModule],
   controllers: [StreaksController],
   providers: [StreaksService],
   exports: [StreaksService],

--- a/apps/api/src/streaks/streaks.service.spec.ts
+++ b/apps/api/src/streaks/streaks.service.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { AnswerSubmission } from 'src/answer-submission/entities/answer-submission.entity';
+import { AnswerSubmissionService } from 'src/answer-submission/answer-submission.service';
 import { Streaks } from './entities/streaks.entity';
 import { StreaksService } from './streaks.service';
 
@@ -13,20 +13,8 @@ describe('StreaksService', () => {
     upsert: jest.fn(),
   };
 
-  const mockQueryBuilder = {
-    distinctOn: jest.fn().mockReturnThis(),
-    innerJoin: jest.fn().mockReturnThis(),
-    select: jest.fn().mockReturnThis(),
-    addSelect: jest.fn().mockReturnThis(),
-    where: jest.fn().mockReturnThis(),
-    andWhere: jest.fn().mockReturnThis(),
-    orderBy: jest.fn().mockReturnThis(),
-    addOrderBy: jest.fn().mockReturnThis(),
-    getRawMany: jest.fn(),
-  };
-
-  const mockAnswerSubmissionRepository = {
-    createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+  const mockAnswerSubmissionService = {
+    getDistinctQuestionsByYear: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -38,8 +26,8 @@ describe('StreaksService', () => {
           useValue: mockStreaksRepository,
         },
         {
-          provide: getRepositoryToken(AnswerSubmission),
-          useValue: mockAnswerSubmissionRepository,
+          provide: AnswerSubmissionService,
+          useValue: mockAnswerSubmissionService,
         },
       ],
     }).compile();
@@ -54,7 +42,9 @@ describe('StreaksService', () => {
 
   describe('getYearlyActivityCount', () => {
     it('데이터가 없으면 submittedQuestionCount 0과 빈 배열을 리턴한다', async () => {
-      mockQueryBuilder.getRawMany.mockResolvedValue([]);
+      mockAnswerSubmissionService.getDistinctQuestionsByYear.mockResolvedValue(
+        [],
+      );
 
       const result = await service.getYearlyActivityCount(1, 2026);
 
@@ -97,7 +87,9 @@ describe('StreaksService', () => {
           title: '문제5',
         },
       ];
-      mockQueryBuilder.getRawMany.mockResolvedValue(mockRows);
+      mockAnswerSubmissionService.getDistinctQuestionsByYear.mockResolvedValue(
+        mockRows,
+      );
 
       const result = await service.getYearlyActivityCount(1, 2026);
 
@@ -107,29 +99,32 @@ describe('StreaksService', () => {
       });
     });
 
-    it('과거 연도를 조회하면 해당 연도의 날짜 범위로 쿼리한다', async () => {
-      mockQueryBuilder.getRawMany.mockResolvedValue([]);
+    it('과거 연도를 조회하면 해당 연도의 날짜 범위로 서비스를 호출한다', async () => {
+      mockAnswerSubmissionService.getDistinctQuestionsByYear.mockResolvedValue(
+        [],
+      );
 
       await service.getYearlyActivityCount(1, 2025);
 
-      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
-        'submission.submittedAt >= :start AND submission.submittedAt < :end',
-        {
-          start: new Date('2025-01-01T00:00:00+09:00'),
-          end: new Date('2026-01-01T00:00:00+09:00'),
-        },
+      expect(
+        mockAnswerSubmissionService.getDistinctQuestionsByYear,
+      ).toHaveBeenCalledWith(
+        1,
+        new Date('2025-01-01T00:00:00+09:00'),
+        new Date('2026-01-01T00:00:00+09:00'),
       );
     });
 
     it('userId를 필터 조건으로 사용한다', async () => {
-      mockQueryBuilder.getRawMany.mockResolvedValue([]);
+      mockAnswerSubmissionService.getDistinctQuestionsByYear.mockResolvedValue(
+        [],
+      );
 
       await service.getYearlyActivityCount(42, 2026);
 
-      expect(mockQueryBuilder.where).toHaveBeenCalledWith(
-        'submission.userId = :userId',
-        { userId: 42 },
-      );
+      expect(
+        mockAnswerSubmissionService.getDistinctQuestionsByYear,
+      ).toHaveBeenCalledWith(42, expect.any(Date), expect.any(Date));
     });
   });
 

--- a/apps/api/src/streaks/streaks.service.spec.ts
+++ b/apps/api/src/streaks/streaks.service.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { AnswerSubmission } from 'src/answer-submission/entities/answer-submission.entity';
 import { Streaks } from './entities/streaks.entity';
 import { StreaksService } from './streaks.service';
 
@@ -8,10 +9,24 @@ describe('StreaksService', () => {
   let service: StreaksService;
 
   const mockStreaksRepository = {
-    count: jest.fn(),
     find: jest.fn(),
-    findOneBy: jest.fn(),
-    insert: jest.fn(),
+    upsert: jest.fn(),
+  };
+
+  const mockQueryBuilder = {
+    distinctOn: jest.fn().mockReturnThis(),
+    innerJoin: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn(),
+  };
+
+  const mockAnswerSubmissionRepository = {
+    createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
   };
 
   beforeEach(async () => {
@@ -21,6 +36,10 @@ describe('StreaksService', () => {
         {
           provide: getRepositoryToken(Streaks),
           useValue: mockStreaksRepository,
+        },
+        {
+          provide: getRepositoryToken(AnswerSubmission),
+          useValue: mockAnswerSubmissionRepository,
         },
       ],
     }).compile();
@@ -34,53 +53,83 @@ describe('StreaksService', () => {
   });
 
   describe('getYearlyActivityCount', () => {
-    it('2026년 기준으로 데이터가 없으면 0이 리턴된다', async () => {
-      mockStreaksRepository.count.mockResolvedValue(0);
+    it('데이터가 없으면 submittedQuestionCount 0과 빈 배열을 리턴한다', async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValue([]);
 
       const result = await service.getYearlyActivityCount(1, 2026);
 
-      expect(result).toEqual({ streakCount: 0 });
+      expect(result).toEqual({
+        submittedQuestionCount: 0,
+        yearlyAnswerSubmissions: [],
+      });
     });
 
-    it('2026년 기준으로 데이터가 5개 있으면 5가 리턴된다', async () => {
-      mockStreaksRepository.count.mockResolvedValue(5);
+    it('고유 문제 5개가 있으면 submittedQuestionCount 5를 리턴한다', async () => {
+      const mockRows = [
+        {
+          id: 1,
+          submittedAt: new Date('2026-01-01'),
+          questionId: 1,
+          title: '문제1',
+        },
+        {
+          id: 2,
+          submittedAt: new Date('2026-01-02'),
+          questionId: 2,
+          title: '문제2',
+        },
+        {
+          id: 3,
+          submittedAt: new Date('2026-01-03'),
+          questionId: 3,
+          title: '문제3',
+        },
+        {
+          id: 4,
+          submittedAt: new Date('2026-01-04'),
+          questionId: 4,
+          title: '문제4',
+        },
+        {
+          id: 5,
+          submittedAt: new Date('2026-01-05'),
+          questionId: 5,
+          title: '문제5',
+        },
+      ];
+      mockQueryBuilder.getRawMany.mockResolvedValue(mockRows);
 
       const result = await service.getYearlyActivityCount(1, 2026);
 
-      expect(result).toEqual({ streakCount: 5 });
+      expect(result).toEqual({
+        submittedQuestionCount: 5,
+        yearlyAnswerSubmissions: mockRows,
+      });
     });
 
-    it('2025년 기준으로 데이터가 없으면 0을 리턴한다', async () => {
-      mockStreaksRepository.count.mockResolvedValue(0);
+    it('과거 연도를 조회하면 해당 연도의 날짜 범위로 쿼리한다', async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValue([]);
 
-      const result = await service.getYearlyActivityCount(1, 2025);
+      await service.getYearlyActivityCount(1, 2025);
 
-      expect(result).toEqual({ streakCount: 0 });
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+        'submission.submittedAt >= :start AND submission.submittedAt < :end',
+        {
+          start: new Date('2025-01-01T00:00:00+09:00'),
+          end: new Date('2026-01-01T00:00:00+09:00'),
+        },
+      );
     });
 
-    it('2025년 기준으로 데이터가 5개 있으면 5를 리턴한다', async () => {
-      mockStreaksRepository.count.mockResolvedValue(5);
+    it('userId를 필터 조건으로 사용한다', async () => {
+      mockQueryBuilder.getRawMany.mockResolvedValue([]);
 
-      const result = await service.getYearlyActivityCount(1, 2025);
+      await service.getYearlyActivityCount(42, 2026);
 
-      expect(result).toEqual({ streakCount: 5 });
-    });
-
-    it('2025년 3개 + 2026년 5개 혼합 시 2026년 조회하면 5를 리턴한다', async () => {
-      mockStreaksRepository.count.mockResolvedValue(5);
-
-      const result = await service.getYearlyActivityCount(1, 2026);
-
-      expect(result).toEqual({ streakCount: 5 });
-    });
-
-    it('userId별로 데이터를 구분하여 조회한다', async () => {
-      mockStreaksRepository.count.mockResolvedValue(5);
-
-      const result = await service.getYearlyActivityCount(1, 2026);
-
-      expect(mockStreaksRepository.count).toHaveBeenCalled();
-      expect(result).toEqual({ streakCount: 5 });
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+        'submission.userId = :userId',
+        { userId: 42 },
+      );
     });
   });
 
@@ -182,42 +231,49 @@ describe('StreaksService', () => {
 
       expect(result).toEqual({ consecutiveDayCount: 1 });
     });
+
+    it('최근 365일 이내 데이터만 조회한다', async () => {
+      mockStreaksRepository.find.mockResolvedValue([]);
+
+      await service.getConsecutiveDayCount(1);
+
+      expect(mockStreaksRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            userId: 1,
+            activityDate: expect.anything(),
+          }),
+          order: { activityDate: 'DESC' },
+        }),
+      );
+    });
   });
 
   describe('recordDailyActivity', () => {
-    it('스트릭 데이터가 조회되지 않으면 데이터를 추가하고 true를 리턴한다', async () => {
-      mockStreaksRepository.findOneBy.mockResolvedValue(null);
-      mockStreaksRepository.insert.mockResolvedValue({} as any);
+    it('upsert를 호출하고 success: true를 리턴한다', async () => {
+      mockStreaksRepository.upsert.mockResolvedValue({} as any);
 
       const result = await service.recordDailyActivity(1);
 
-      expect(mockStreaksRepository.findOneBy).toHaveBeenCalledWith({
-        userId: 1,
-        activityDate: expect.any(Date),
-      });
-      expect(mockStreaksRepository.insert).toHaveBeenCalledWith({
-        userId: 1,
-        activityDate: expect.any(Date),
-      });
+      expect(mockStreaksRepository.upsert).toHaveBeenCalledWith(
+        {
+          userId: 1,
+          activityDate: expect.any(Date),
+        },
+        ['userId', 'activityDate'],
+      );
       expect(result).toEqual({ success: true });
     });
 
-    it('스트릭 데이터가 이미 조회된다면 데이터를 조작하지 않고 true를 리턴한다', async () => {
-      const existingStreak = {
-        id: 1,
-        userId: 1,
-        activityDate: new Date(),
-      };
-      mockStreaksRepository.findOneBy.mockResolvedValue(existingStreak);
+    it('중복 호출 시에도 upsert로 안전하게 처리한다', async () => {
+      mockStreaksRepository.upsert.mockResolvedValue({} as any);
 
-      const result = await service.recordDailyActivity(1);
+      const result1 = await service.recordDailyActivity(1);
+      const result2 = await service.recordDailyActivity(1);
 
-      expect(mockStreaksRepository.findOneBy).toHaveBeenCalledWith({
-        userId: 1,
-        activityDate: expect.any(Date),
-      });
-      expect(mockStreaksRepository.insert).not.toHaveBeenCalled();
-      expect(result).toEqual({ success: true });
+      expect(mockStreaksRepository.upsert).toHaveBeenCalledTimes(2);
+      expect(result1).toEqual({ success: true });
+      expect(result2).toEqual({ success: true });
     });
   });
 });

--- a/apps/api/src/streaks/streaks.service.ts
+++ b/apps/api/src/streaks/streaks.service.ts
@@ -1,11 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, forwardRef } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { AnswerSubmission } from 'src/answer-submission/entities/answer-submission.entity';
+import { AnswerSubmissionService } from 'src/answer-submission/answer-submission.service';
 import { MoreThanOrEqual, Repository } from 'typeorm';
-import {
-  GetYearlyActivityCountResponseDto,
-  YearlyAnswerSubmissionsDto,
-} from './dtos/streaks-count.dto';
+import { GetYearlyActivityCountResponseDto } from './dtos/streaks-count.dto';
 import { Streaks } from './entities/streaks.entity';
 
 @Injectable()
@@ -13,8 +10,8 @@ export class StreaksService {
   constructor(
     @InjectRepository(Streaks)
     private readonly streaksRepository: Repository<Streaks>,
-    @InjectRepository(AnswerSubmission)
-    private readonly answerSubmissionRepository: Repository<AnswerSubmission>,
+    @Inject(forwardRef(() => AnswerSubmissionService))
+    private readonly answerSubmissionService: AnswerSubmissionService,
   ) {}
 
   private getKSTNow(): Date {
@@ -37,22 +34,12 @@ export class StreaksService {
       year < kstYear
         ? new Date(`${year + 1}-01-01T00:00:00+09:00`)
         : new Date();
-    const rows = await this.answerSubmissionRepository
-      .createQueryBuilder('submission')
-      .distinctOn(['submission.questionId'])
-      .innerJoin('submission.question', 'question')
-      .select('submission.id', 'id')
-      .addSelect('submission.submittedAt', 'submittedAt')
-      .addSelect('submission.questionId', 'questionId')
-      .addSelect('question.title', 'title')
-      .where('submission.userId = :userId', { userId })
-      .andWhere(
-        'submission.submittedAt >= :start AND submission.submittedAt < :end',
-        { start, end },
-      )
-      .addOrderBy('submission.submittedAt', 'ASC')
-      .addOrderBy('submission.id', 'DESC') // 동일한 시각에 여러 제출이 있을 경우를 대비해서 혹시 모르니까 사용
-      .getRawMany<YearlyAnswerSubmissionsDto>();
+
+    const rows = await this.answerSubmissionService.getDistinctQuestionsByYear(
+      userId,
+      start,
+      end,
+    );
 
     return {
       submittedQuestionCount: rows.length,

--- a/apps/api/src/streaks/streaks.service.ts
+++ b/apps/api/src/streaks/streaks.service.ts
@@ -1,6 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Between, Repository } from 'typeorm';
+import { AnswerSubmission } from 'src/answer-submission/entities/answer-submission.entity';
+import { MoreThanOrEqual, Repository } from 'typeorm';
+import {
+  GetYearlyActivityCountResponseDto,
+  YearlyAnswerSubmissionsDto,
+} from './dtos/streaks-count.dto';
 import { Streaks } from './entities/streaks.entity';
 
 @Injectable()
@@ -8,33 +13,70 @@ export class StreaksService {
   constructor(
     @InjectRepository(Streaks)
     private readonly streaksRepository: Repository<Streaks>,
+    @InjectRepository(AnswerSubmission)
+    private readonly answerSubmissionRepository: Repository<AnswerSubmission>,
   ) {}
+
+  private getKSTNow(): Date {
+    return new Date(Date.now() + 9 * 60 * 60 * 1000);
+  }
+
+  private getKSTDateString(date?: Date): string {
+    const d = date ?? this.getKSTNow();
+    return d.toISOString().split('T')[0];
+  }
 
   async getYearlyActivityCount(
     userId: number,
     year: number,
-  ): Promise<{ streakCount: number }> {
-    const today = new Date();
-    const start = new Date(`${year}-01-01`);
+  ): Promise<GetYearlyActivityCountResponseDto> {
+    const kstNow = this.getKSTNow();
+    const kstYear = kstNow.getUTCFullYear();
+    const start = new Date(`${year}-01-01T00:00:00+09:00`);
     const end =
-      today.getFullYear() < year ? new Date(`${year}-12-31`) : new Date();
-    const streakCount = await this.streaksRepository.count({
-      where: {
-        userId: userId,
-        activityDate: Between(start, end),
-      },
-    });
-    return { streakCount };
+      year < kstYear
+        ? new Date(`${year + 1}-01-01T00:00:00+09:00`)
+        : new Date();
+    const rows = await this.answerSubmissionRepository
+      .createQueryBuilder('submission')
+      .distinctOn(['submission.questionId'])
+      .innerJoin('submission.question', 'question')
+      .select('submission.id', 'id')
+      .addSelect('submission.submittedAt', 'submittedAt')
+      .addSelect('submission.questionId', 'questionId')
+      .addSelect('question.title', 'title')
+      .where('submission.userId = :userId', { userId })
+      .andWhere(
+        'submission.submittedAt >= :start AND submission.submittedAt < :end',
+        { start, end },
+      )
+      .orderBy('submission.questionId', 'ASC')
+      .addOrderBy('submission.submittedAt', 'ASC')
+      .addOrderBy('submission.id', 'DESC')
+      .getRawMany<YearlyAnswerSubmissionsDto>();
+
+    return {
+      submittedQuestionCount: rows.length,
+      yearlyAnswerSubmissions: rows,
+    };
   }
 
   async getConsecutiveDayCount(
     userId: number,
   ): Promise<{ consecutiveDayCount: number }> {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0); //시간으로 인해 이틀 뒤로 날짜가 밀리는것을 방지하기 위한 정규화
+    const kstNow = this.getKSTNow();
+    const todayString = this.getKSTDateString(kstNow);
+    const today = new Date(todayString);
+    today.setHours(0, 0, 0, 0);
+
+    const oneYearAgo = new Date(today);
+    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
 
     const userStreaks = await this.streaksRepository.find({
-      where: { userId },
+      where: {
+        userId,
+        activityDate: MoreThanOrEqual(oneYearAgo),
+      },
       order: { activityDate: 'DESC' },
     });
 
@@ -65,20 +107,11 @@ export class StreaksService {
   }
 
   async recordDailyActivity(userId: number): Promise<{ success: boolean }> {
-    // 한국 시간으로 submittedAt 구하기 -> UTC + 9시간
-    const utcDate = new Date();
-    const submittedAt = new Date(utcDate.getTime() + 9 * 60 * 60 * 1000);
-    const checkDay = await this.streaksRepository.findOneBy({
-      userId: userId,
-      activityDate: submittedAt,
-    });
-    if (checkDay) {
-      return { success: true };
-    }
-    await this.streaksRepository.insert({
-      userId: userId,
-      activityDate: submittedAt,
-    });
+    const kstDateString = this.getKSTDateString();
+    await this.streaksRepository.upsert(
+      { userId, activityDate: new Date(kstDateString) },
+      ['userId', 'activityDate'],
+    );
     return { success: true };
   }
 }

--- a/apps/api/src/streaks/streaks.service.ts
+++ b/apps/api/src/streaks/streaks.service.ts
@@ -50,9 +50,8 @@ export class StreaksService {
         'submission.submittedAt >= :start AND submission.submittedAt < :end',
         { start, end },
       )
-      .orderBy('submission.questionId', 'ASC')
       .addOrderBy('submission.submittedAt', 'ASC')
-      .addOrderBy('submission.id', 'DESC')
+      .addOrderBy('submission.id', 'DESC') // 동일한 시각에 여러 제출이 있을 경우를 대비해서 혹시 모르니까 사용
       .getRawMany<YearlyAnswerSubmissionsDto>();
 
     return {

--- a/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.stories.tsx
+++ b/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.stories.tsx
@@ -1,5 +1,32 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import type { YearlyAnswerSubmissions } from "../../_types/streak";
 import VoronoiStreak from "./voronoi-streak";
+
+function generateMockSubmissions(count: number): YearlyAnswerSubmissions[] {
+  const titles = [
+    "두 수의 합",
+    "배열 뒤집기",
+    "문자열 정렬",
+    "이진 탐색",
+    "DFS와 BFS",
+    "최단 경로",
+    "동적 프로그래밍",
+    "그리디 알고리즘",
+    "스택과 큐",
+    "해시맵 활용",
+  ];
+
+  return Array.from({ length: count }, (_, i) => {
+    const date = new Date(2025, 0, 1);
+    date.setDate(date.getDate() + i);
+    return {
+      id: i + 1,
+      submittedAt: date.toISOString(),
+      questionid: i + 100,
+      title: titles[i % titles.length],
+    };
+  });
+}
 
 const meta = {
   title: "Components/VoronoiStreak",
@@ -15,12 +42,17 @@ const meta = {
     },
     streakCount: {
       control: { type: "range", min: 0, max: 365, step: 1 },
-      description: "스트릭 일수 (0-365)",
+      description: "제출한 문제 수 (0-365)",
+    },
+    yearlyAnswerSubmissions: {
+      control: false,
+      description: "연간 문제 제출 내역",
     },
   },
   args: {
     imageSrc: "/starry-night.jpg",
     streakCount: 0,
+    yearlyAnswerSubmissions: [],
   },
   decorators: [
     (Story) => (
@@ -37,23 +69,27 @@ type Story = StoryObj<typeof meta>;
 export const Day1: Story = {
   args: {
     streakCount: 1,
+    yearlyAnswerSubmissions: generateMockSubmissions(1),
   },
 };
 
 export const Day30: Story = {
   args: {
     streakCount: 30,
+    yearlyAnswerSubmissions: generateMockSubmissions(30),
   },
 };
 
 export const Day180: Story = {
   args: {
     streakCount: 180,
+    yearlyAnswerSubmissions: generateMockSubmissions(180),
   },
 };
 
 export const Day365: Story = {
   args: {
     streakCount: 365,
+    yearlyAnswerSubmissions: generateMockSubmissions(365),
   },
 };

--- a/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.stories.tsx
+++ b/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.stories.tsx
@@ -22,7 +22,7 @@ function generateMockSubmissions(count: number): YearlyAnswerSubmissions[] {
     return {
       id: i + 1,
       submittedAt: date.toISOString(),
-      questionid: i + 100,
+      questionId: i + 100,
       title: titles[i % titles.length],
     };
   });

--- a/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.tsx
+++ b/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.tsx
@@ -32,6 +32,8 @@ function VoronoiStreak({
   yearlyAnswerSubmissions,
 }: VoronoiStreakProps) {
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
+  const canvasRectRef = React.useRef<DOMRect | null>(null);
+  const tooltipRef = React.useRef<HTMLDivElement>(null);
   const { width, height } = useCanvas2D(canvasRef);
   const [cellData, setCellData] = React.useState<CellData[]>([]);
   // 가까운 cell을 찾기 위한 delaunay ref 저장
@@ -146,7 +148,10 @@ function VoronoiStreak({
     (e: React.MouseEvent<HTMLDivElement>) => {
       if (!canvasRef.current || !delaunayRef.current || cellData.length === 0)
         return;
-      const rect = canvasRef.current.getBoundingClientRect();
+      if (!canvasRectRef.current) {
+        canvasRectRef.current = canvasRef.current.getBoundingClientRect();
+      }
+      const rect = canvasRectRef.current;
       const canvasX = e.clientX - rect.left;
       const canvasY = e.clientY - rect.top;
       const closeDelaunayIdx = delaunayRef.current.find(canvasX, canvasY);
@@ -166,6 +171,31 @@ function VoronoiStreak({
     setHoveredInfo(null);
   }, []);
 
+  React.useLayoutEffect(() => {
+    const tooltipEl = tooltipRef.current;
+    if (!hoveredInfo || !tooltipEl) return;
+
+    // 우측 하단에서 tooltip 넓이에 따라 위치가 계속 바뀌기 때문에 줄바꿈x
+    tooltipEl.style.textWrap = "nowrap";
+    const offsetX = 5;
+    const offsetY = 10;
+    let left = hoveredInfo.x + offsetX;
+    let top = hoveredInfo.y + offsetY;
+
+    const tooltipWidth = tooltipEl.offsetWidth;
+    const tooltipHeight = tooltipEl.offsetHeight;
+
+    if (left + tooltipWidth > width) {
+      left = hoveredInfo.x - tooltipWidth - offsetX;
+    }
+    if (top + tooltipHeight > height) {
+      top = hoveredInfo.y - tooltipHeight - offsetY;
+    }
+
+    tooltipEl.style.left = `${Math.max(0, left)}px`;
+    tooltipEl.style.top = `${Math.max(0, top)}px`;
+  }, [hoveredInfo, width, height]);
+
   const convertDateString = (submittedAt: string) => {
     const date = new Date(submittedAt);
     return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
@@ -180,6 +210,7 @@ function VoronoiStreak({
       <canvas className="w-full h-full" ref={canvasRef} />
       {hoveredInfo && (
         <div
+          ref={tooltipRef}
           className="absolute z-10 bg-white rounded-lg shadow-lg border border-slate-200 px-3 py-2"
           style={{ left: hoveredInfo.x + 5, top: hoveredInfo.y + 10 }}
         >

--- a/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.tsx
+++ b/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.tsx
@@ -43,6 +43,30 @@ function VoronoiStreak({
     submission: YearlyAnswerSubmissions;
   } | null>(null);
 
+  const canvasRectRef = React.useRef<DOMRect | null>(null);
+  React.useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const updateRect = () => {
+      canvasRectRef.current = canvas.getBoundingClientRect();
+    };
+
+    updateRect();
+
+    const resizeObserver = new ResizeObserver(updateRect);
+    resizeObserver.observe(canvas);
+
+    window.addEventListener("scroll", updateRect, {
+      passive: true,
+      capture: true,
+    });
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener("scroll", updateRect);
+    };
+  }, []);
   React.useEffect(() => {
     if (!imageSrc || width === 0 || height === 0) return;
 
@@ -147,8 +171,8 @@ function VoronoiStreak({
     (e: React.MouseEvent<HTMLDivElement>) => {
       if (!canvasRef.current || !delaunayRef.current || cellData.length === 0)
         return;
-
-      const rect = canvasRef.current.getBoundingClientRect();
+      if (!canvasRectRef.current) return;
+      const rect = canvasRectRef.current;
       const canvasX = e.clientX - rect.left;
       const canvasY = e.clientY - rect.top;
       const closeDelaunayIdx = delaunayRef.current.find(canvasX, canvasY);

--- a/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.tsx
+++ b/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.tsx
@@ -12,10 +12,12 @@ import {
 import computeCells from "../../_lib/compute-cells";
 import generateRandomPoint from "../../_lib/generate-random-point";
 import lloydRelaxation from "../../_lib/lloyd-relaxation";
+import { YearlyAnswerSubmissions } from "../../_types/streak";
 
 interface VoronoiStreakProps {
   streakCount: number;
   imageSrc: string;
+  yearlyAnswerSubmissions: YearlyAnswerSubmissions[];
 }
 
 interface CellData {
@@ -24,10 +26,21 @@ interface CellData {
   cluster: number;
 }
 
-function VoronoiStreak({ streakCount, imageSrc }: VoronoiStreakProps) {
+function VoronoiStreak({
+  streakCount,
+  imageSrc,
+  yearlyAnswerSubmissions,
+}: VoronoiStreakProps) {
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
   const { width, height } = useCanvas2D(canvasRef);
   const [cellData, setCellData] = React.useState<CellData[]>([]);
+  // 가까운 cell을 찾기 위한 delaunay ref 저장
+  const delaunayRef = React.useRef<Delaunay<Delaunay.Point> | null>(null);
+  const [hoveredInfo, setHoveredInfo] = React.useState<{
+    x: number;
+    y: number;
+    submission: YearlyAnswerSubmissions;
+  } | null>(null);
 
   React.useEffect(() => {
     if (!imageSrc || width === 0 || height === 0) return;
@@ -58,15 +71,6 @@ function VoronoiStreak({ streakCount, imageSrc }: VoronoiStreakProps) {
         tempVoronoi.update();
       }
 
-      /*
-      //points 정렬 순서 : x축 -> y축 기준으로 오름차순 정렬
-      points.sort((a, b) => {
-        const xDiff = a[0] - b[0];
-        if (Math.abs(xDiff) > 5) return xDiff;
-        return b[1] - a[1];
-      });
-      */
-
       // K-Means 기반 클러스터링 진행 (seed 기반 초기 centroids로 결과 고정)
       const lcg = randomLcg(VORONOI_NUMBER_CONSTANT.SEED);
       const initialCentroids: [number, number][] = [];
@@ -88,6 +92,7 @@ function VoronoiStreak({ streakCount, imageSrc }: VoronoiStreakProps) {
       const clusters = pointsWithCluster.map((p) => p.cluster);
 
       const delaunay = Delaunay.from(points);
+      delaunayRef.current = delaunay;
       const voronoi = delaunay.voronoi([0, 0, width, height]);
       const computedCells = computeCells(
         points,
@@ -135,7 +140,59 @@ function VoronoiStreak({ streakCount, imageSrc }: VoronoiStreakProps) {
       cancelAnimationFrame(animationId);
     };
   }, [cellData, streakCount, width, height]);
-  return <canvas className="w-full h-full" ref={canvasRef} />;
+
+  // 마우스가 위치한 cell이면서 색이 칠해졌을 때 -> 문제 정보 & 풀이 시간 보일 수 있게 수정
+  const handleMouseMove = React.useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!canvasRef.current || !delaunayRef.current || cellData.length === 0)
+        return;
+      const rect = canvasRef.current.getBoundingClientRect();
+      const canvasX = e.clientX - rect.left;
+      const canvasY = e.clientY - rect.top;
+      const closeDelaunayIdx = delaunayRef.current.find(canvasX, canvasY);
+      const cluster = cellData[closeDelaunayIdx].cluster;
+      const submission = yearlyAnswerSubmissions[cluster];
+
+      if (cluster < streakCount && submission) {
+        setHoveredInfo({ x: canvasX, y: canvasY, submission });
+      } else {
+        setHoveredInfo(null);
+      }
+    },
+    [cellData, yearlyAnswerSubmissions, streakCount],
+  );
+
+  const handleMouseLeave = React.useCallback(() => {
+    setHoveredInfo(null);
+  }, []);
+
+  const convertDateString = (submittedAt: string) => {
+    const date = new Date(submittedAt);
+    return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
+  };
+
+  return (
+    <div
+      className="relative"
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+    >
+      <canvas className="w-full h-full" ref={canvasRef} />
+      {hoveredInfo && (
+        <div
+          className="absolute z-10 bg-white rounded-lg shadow-lg border border-slate-200 px-3 py-2"
+          style={{ left: hoveredInfo.x + 5, top: hoveredInfo.y + 10 }}
+        >
+          <p className="text-sm font-semibold text-teal-500">
+            {hoveredInfo.submission.title}
+          </p>
+          <p className="text-xs text-slate-700">
+            {convertDateString(hoveredInfo.submission.submittedAt)}
+          </p>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export default VoronoiStreak;

--- a/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.tsx
+++ b/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.tsx
@@ -32,7 +32,6 @@ function VoronoiStreak({
   yearlyAnswerSubmissions,
 }: VoronoiStreakProps) {
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
-  const canvasRectRef = React.useRef<DOMRect | null>(null);
   const tooltipRef = React.useRef<HTMLDivElement>(null);
   const { width, height } = useCanvas2D(canvasRef);
   const [cellData, setCellData] = React.useState<CellData[]>([]);
@@ -148,10 +147,8 @@ function VoronoiStreak({
     (e: React.MouseEvent<HTMLDivElement>) => {
       if (!canvasRef.current || !delaunayRef.current || cellData.length === 0)
         return;
-      if (!canvasRectRef.current) {
-        canvasRectRef.current = canvasRef.current.getBoundingClientRect();
-      }
-      const rect = canvasRectRef.current;
+
+      const rect = canvasRef.current.getBoundingClientRect();
       const canvasX = e.clientX - rect.left;
       const canvasY = e.clientY - rect.top;
       const closeDelaunayIdx = delaunayRef.current.find(canvasX, canvasY);

--- a/apps/web/src/app/mypage/_contents/streak-content.tsx
+++ b/apps/web/src/app/mypage/_contents/streak-content.tsx
@@ -1,26 +1,32 @@
 import VoronoiStreak from "../_components/voronoi-streak/voronoi-streak";
+import { YearlyAnswerSubmissions } from "../_types/streak";
 
 async function StreakContent({
   streakCount,
   imageSrc,
+  yearlyAnswerSubmissions,
 }: {
   streakCount: number;
   imageSrc: string;
+  yearlyAnswerSubmissions: YearlyAnswerSubmissions[];
 }) {
   return (
     <>
       <div className="py-8 flex flex-col justify-start gap-2">
         <div className="flex items-center gap-3">
           <span className="text-lg font-bold text-slate-900">명화 스트릭</span>
-          <span className="text-sm font-medium text-slate-500">
-            <span className="text-teal-500">{streakCount}일</span>/365일
-          </span>
+
+          <span className="text-teal-500">{streakCount}개</span>
         </div>
         <span className="text-sm font-medium text-slate-500">
-          1년간의 노력으로 그림을 완성해보세요.
+          꾸준히 문제를 풀면서 그림을 완성해보세요.
         </span>
       </div>
-      <VoronoiStreak streakCount={streakCount} imageSrc={imageSrc} />
+      <VoronoiStreak
+        streakCount={streakCount}
+        imageSrc={imageSrc}
+        yearlyAnswerSubmissions={yearlyAnswerSubmissions}
+      />
     </>
   );
 }

--- a/apps/web/src/app/mypage/_types/graph-view.ts
+++ b/apps/web/src/app/mypage/_types/graph-view.ts
@@ -1,7 +1,9 @@
-export enum NodeType {
-  "QUESTION",
-  "KEYWORD",
-}
+export const NodeType = {
+  QUESTION: "QUESTION",
+  KEYWORD: "KEYWORD",
+} as const;
+
+export type NodeType = (typeof NodeType)[keyof typeof NodeType];
 
 export interface GraphNode {
   id: number;

--- a/apps/web/src/app/mypage/_types/streak.ts
+++ b/apps/web/src/app/mypage/_types/streak.ts
@@ -1,4 +1,4 @@
-interface YearlyAnswerSubmissions {
+export interface YearlyAnswerSubmissions {
   id: number;
   submittedAt: string;
   questionid: number;

--- a/apps/web/src/app/mypage/_types/streak.ts
+++ b/apps/web/src/app/mypage/_types/streak.ts
@@ -1,7 +1,7 @@
 export interface YearlyAnswerSubmissions {
   id: number;
   submittedAt: string;
-  questionid: number;
+  questionId: number;
   title: string;
 }
 export interface StreakCountDto {

--- a/apps/web/src/app/mypage/_types/streak.ts
+++ b/apps/web/src/app/mypage/_types/streak.ts
@@ -1,5 +1,12 @@
+interface YearlyAnswerSubmissions {
+  id: number;
+  submittedAt: string;
+  questionid: number;
+  title: string;
+}
 export interface StreakCountDto {
-  streakCount: number;
+  submittedQuestionCount: number;
+  yearlyAnswerSubmissions: YearlyAnswerSubmissions[];
 }
 
 export interface StreakSequenceDto {

--- a/apps/web/src/app/mypage/page.tsx
+++ b/apps/web/src/app/mypage/page.tsx
@@ -29,7 +29,7 @@ async function MyPage() {
   ]);
   const {
     submittedQuestionCount,
-    yearlyAnswerSubmissions: _,
+    yearlyAnswerSubmissions,
     consecutiveDayCount,
   } = streakData;
   const { problems, totalCount } = solvedData;
@@ -72,6 +72,7 @@ async function MyPage() {
           <StreakContent
             streakCount={submittedQuestionCount}
             imageSrc={imageSrc}
+            yearlyAnswerSubmissions={yearlyAnswerSubmissions}
           />
         </TabsContent>
         <TabsContent

--- a/apps/web/src/app/mypage/page.tsx
+++ b/apps/web/src/app/mypage/page.tsx
@@ -8,7 +8,6 @@ import { BookText, Brush, CircleCheckBig } from "lucide-react";
 import { redirect } from "next/navigation";
 import { getCurrentUser } from "../(auth)/_utils/auth";
 import UserStatsCard from "./_components/user-stats-card/user-stats-card";
-import { mockGraphData } from "./_constants/graph-mock";
 import GraphContent from "./_contents/graph-content";
 import SolvedContent from "./_contents/solved-content";
 import StreakContent from "./_contents/streak-content";
@@ -22,7 +21,7 @@ async function MyPage() {
   if (!user) {
     redirect("/login");
   }
-  const [userData, _graphData, streakData, solvedData] = await Promise.all([
+  const [userData, graphData, streakData, solvedData] = await Promise.all([
     fetchUserInfo(),
     fetchGraph(),
     fetchStreaks(),
@@ -32,7 +31,6 @@ async function MyPage() {
   const { problems, totalCount } = solvedData;
 
   const imageSrc = "/starry-night.jpg";
-  const mockData = mockGraphData; // 추후 리팩토링시 해당 부분 삭제
   return (
     <div className="w-full px-8 pt-15 pb-25 max-w-4xl flex flex-col gap-10">
       <UserStatsCard
@@ -61,7 +59,7 @@ async function MyPage() {
           className="bg-white w-full px-8 pb-8 rounded-xl border border-slate-200"
           value="graph"
         >
-          <GraphContent graphData={mockData} />
+          <GraphContent graphData={graphData} />
         </TabsContent>
         <TabsContent
           className="bg-white w-full px-8 pb-8 rounded-xl border border-slate-200"

--- a/apps/web/src/app/mypage/page.tsx
+++ b/apps/web/src/app/mypage/page.tsx
@@ -34,6 +34,7 @@ async function MyPage() {
   } = streakData;
   const { problems, totalCount } = solvedData;
 
+  // Refactor Todo: 365개 전부 채웠을 때 새로운 그림으로 전환하기
   const imageSrc = "/starry-night.jpg";
   return (
     <div className="w-full px-8 pt-15 pb-25 max-w-4xl flex flex-col gap-10">

--- a/apps/web/src/app/mypage/page.tsx
+++ b/apps/web/src/app/mypage/page.tsx
@@ -27,7 +27,11 @@ async function MyPage() {
     fetchStreaks(),
     fetchSolvedProblem(),
   ]);
-  const { streakCount, consecutiveDayCount } = streakData;
+  const {
+    submittedQuestionCount,
+    yearlyAnswerSubmissions: _,
+    consecutiveDayCount,
+  } = streakData;
   const { problems, totalCount } = solvedData;
 
   const imageSrc = "/starry-night.jpg";
@@ -65,7 +69,10 @@ async function MyPage() {
           className="bg-white w-full px-8 pb-8 rounded-xl border border-slate-200"
           value="streak"
         >
-          <StreakContent streakCount={streakCount} imageSrc={imageSrc} />
+          <StreakContent
+            streakCount={submittedQuestionCount}
+            imageSrc={imageSrc}
+          />
         </TabsContent>
         <TabsContent
           className="bg-white w-full px-8 pb-8 rounded-xl border border-slate-200"


### PR DESCRIPTION
## 🔸 작업 내용
- close: #284 
- /mypage mock데이터 제거 및 실제 서버 패칭을 통해 받아온 데이터를 사용하도록 수정
- streak 성공을 날짜 기준이 아닌 문제 풀이 개수가 기준이 되도록 수정
- 문제 개수로 변경한 백엔드 결과에 따라 FE에서 해당 스트릭이 채워진 문제와 문제 풀이 시간 툴팁으로 보여주기

## 🔸 고민 했던 부분
### 문제 정보를 가져올 때 streaks에서 answerSubmissions를 주로 다루어도 되는가
- 스트릭에서 문제 개수를 가져올 때 문제 정보를 tooltip으로 보여주고싶었다.
- 이를 위해 문제 정보를 가져와야하는데 answerSubmission.service에서 id값을 통해 가져올지 streaksService에서 해당 엔티티의 값을 조회하여 처리하는게 좋을지에 대한 고민이 있었다.
- 객체지향적 관점에서 answerSubmission에서 처리하는것이 더 맞지 않을까? 라는 생각을 했었다. 따라서 기존에 streak에서 answerSubmission으로 쿼리 위치를 옮기고, streaks.service에서는 단순히 해당 메서드를 호출하는 방식으로 수정하였다.

## 🔸 참고
### API 수정
<img width="496" height="351" alt="image" src="https://github.com/user-attachments/assets/2f49b9e9-98f0-40b5-af51-596c48e96916" />

### 스트릭 구현부분
![화면 기록 2026-01-27 오후 4 56 38](https://github.com/user-attachments/assets/1ab7c0aa-182b-4349-b5f3-4be298be0327)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 연간 고유 문제 제출 목록 및 제출 수 제공(연간 제출 상세 포함)
  * 스트릭 시각화에 마우스 호버 시 제출 제목·제출 일시 툴팁 표시

* **개선사항**
  * 지표 레이블을 "일수"에서 "제출한 문제 수"로 변경 및 UI 표기 "X개"로 업데이트
  * KST 기준 날짜 계산 적용 및 일별 기록 멱등성(업서트) 강화
  * 사용자·날짜 복합 유니크 제약으로 데이터 무결성 강화

* **버그 수정**
  * 모듈 간 순환 의존성 처리 개선

* **테스트**
  * 연간·일별 집계와 동시성 관련 테스트 보강

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->