### PR TITLE
문제 별 타 유저 점수 및 피드백 확인 API 구현

### DIFF
--- a/apps/api/src/answer-submission/answer-submission.service.ts
+++ b/apps/api/src/answer-submission/answer-submission.service.ts
@@ -294,6 +294,36 @@ export class AnswerSubmissionService {
     };
   }
 
+  /**
+   * 타 유저 답변 상세 조회용 제출 엔티티 조회
+   * - 존재하지 않는 제출 ID 이거나
+   * - 현재 사용자 본인의 제출인 경우
+   *   NotFoundException 을 던집니다.
+   */
+  async getSubmissionForOtherUser(
+    submissionId: number,
+    currentUserId: number,
+  ): Promise<AnswerSubmission> {
+    const submission = await this.answerSubmissionRepository.findOne({
+      where: { id: submissionId },
+    });
+
+    if (!submission) {
+      throw new NotFoundException(
+        `ID가 ${submissionId}인 제출 내역을 찾을 수 없습니다.`,
+      );
+    }
+
+    // 본인 제출은 다른 사람 답변 상세에서 조회 불가
+    if (submission.userId === currentUserId) {
+      throw new NotFoundException(
+        `ID가 ${submissionId}인 제출 내역을 찾을 수 없습니다.`,
+      );
+    }
+
+    return submission;
+  }
+
   async updateImportance(
     userId: number,
     updateDto: UpdateImportanceDto,

--- a/apps/api/src/question/dtos/other-submission-detail.dto.ts
+++ b/apps/api/src/question/dtos/other-submission-detail.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AnswerSubmissionResponseDto } from 'src/answer-submission/dtos/answer-submission-response.dto';
+
+export class OtherSubmissionDetailDto {
+  @ApiProperty({ description: '답변 작성자 닉네임', example: 'user_1010' })
+  nickname: string;
+
+  @ApiProperty({
+    description: '제출 정보 (답변 내용, 제출 시각, 총점 등)',
+    type: AnswerSubmissionResponseDto,
+  })
+  submission: AnswerSubmissionResponseDto;
+}

--- a/apps/api/src/question/dtos/other-submission-detail.dto.ts
+++ b/apps/api/src/question/dtos/other-submission-detail.dto.ts
@@ -1,13 +1,27 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { AnswerSubmissionResponseDto } from 'src/answer-submission/dtos/answer-submission-response.dto';
+import { QuestionInfoDto } from './question-info.dto';
 
 export class OtherSubmissionDetailDto {
   @ApiProperty({ description: '답변 작성자 닉네임', example: 'user_1010' })
   nickname: string;
 
   @ApiProperty({
+    description: '문제 정보',
+    type: QuestionInfoDto,
+  })
+  question: QuestionInfoDto;
+
+  @ApiProperty({
     description: '제출 정보 (답변 내용, 제출 시각, 총점 등)',
     type: AnswerSubmissionResponseDto,
   })
   submission: AnswerSubmissionResponseDto;
+
+  @ApiProperty({
+    description: '핵심 키워드 목록',
+    type: [String],
+    example: ['Speed', 'Streaming', 'Stateless'],
+  })
+  keywords: string[];
 }

--- a/apps/api/src/question/dtos/other-submission-item.dto.ts
+++ b/apps/api/src/question/dtos/other-submission-item.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class OtherSubmissionItemDto {
+  @ApiProperty({ description: '제출 ID', example: 123 })
+  submissionId: number;
+
+  @ApiProperty({ description: '사용자 닉네임', example: 'user_1010' })
+  nickname: string;
+
+  @ApiProperty({ description: '총점', example: 100 })
+  totalScore: number;
+
+  @ApiProperty({
+    description: '제출 시각',
+    example: '2023-10-07T11:39:00.000Z',
+  })
+  submittedAt: Date;
+}

--- a/apps/api/src/question/dtos/paginated-other-submissions.dto.ts
+++ b/apps/api/src/question/dtos/paginated-other-submissions.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { OtherSubmissionItemDto } from './other-submission-item.dto';
+
+export class PaginatedOtherSubmissionsDto {
+  @ApiProperty({
+    type: [OtherSubmissionItemDto],
+    description: '다른 사용자들의 제출 목록',
+  })
+  submissions: OtherSubmissionItemDto[];
+
+  @ApiProperty({ example: 45, description: '전체 제출 수' })
+  totalCount: number;
+
+  @ApiProperty({ example: 10, description: '페이지당 제출 수' })
+  pageSize: number;
+
+  @ApiProperty({ example: 1, description: '현재 페이지 번호' })
+  currentPage: number;
+
+  @ApiProperty({ example: 5, description: '전체 페이지 수' })
+  totalPages: number;
+}

--- a/apps/api/src/question/dtos/paginated-other-submissions.dto.ts
+++ b/apps/api/src/question/dtos/paginated-other-submissions.dto.ts
@@ -1,7 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { OtherSubmissionItemDto } from './other-submission-item.dto';
+import { QuestionInfoDto } from './question-info.dto';
 
 export class PaginatedOtherSubmissionsDto {
+  @ApiProperty({
+    description: '문제 정보',
+    type: QuestionInfoDto,
+  })
+  question: QuestionInfoDto;
+
   @ApiProperty({
     type: [OtherSubmissionItemDto],
     description: '다른 사용자들의 제출 목록',

--- a/apps/api/src/question/dtos/question-info.dto.ts
+++ b/apps/api/src/question/dtos/question-info.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 class ParentCategoryInfoDto {
   @ApiProperty({ description: '상위 카테고리 ID', example: 1 })
@@ -15,7 +15,7 @@ class CategoryInfoDto {
   @ApiProperty({ description: '카테고리 이름', example: 'API 설계' })
   name: string;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     description: '상위 카테고리 정보',
     type: ParentCategoryInfoDto,
     nullable: true,

--- a/apps/api/src/question/dtos/question-info.dto.ts
+++ b/apps/api/src/question/dtos/question-info.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+class ParentCategoryInfoDto {
+  @ApiProperty({ description: '상위 카테고리 ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '상위 카테고리 이름', example: '백엔드' })
+  name: string;
+}
+
+class CategoryInfoDto {
+  @ApiProperty({ description: '카테고리 ID', example: 2 })
+  id: number;
+
+  @ApiProperty({ description: '카테고리 이름', example: 'API 설계' })
+  name: string;
+
+  @ApiProperty({
+    description: '상위 카테고리 정보',
+    type: ParentCategoryInfoDto,
+    nullable: true,
+  })
+  parent: ParentCategoryInfoDto | null;
+}
+
+export class QuestionInfoDto {
+  @ApiProperty({ description: '문제 ID', example: 1 })
+  id: number;
+
+  @ApiProperty({
+    description: '문제 제목',
+    example: 'REST API와 GraphQL의 차이점을 설명해주세요.',
+  })
+  title: string;
+
+  @ApiProperty({
+    description: '문제 내용 (상세보기에서만 사용)',
+    example: 'REST API와 GraphQL의 차이점을 설명해주세요.',
+    nullable: true,
+  })
+  content?: string;
+
+  @ApiProperty({ description: '카테고리 정보', type: CategoryInfoDto })
+  category: CategoryInfoDto;
+}

--- a/apps/api/src/question/question.controller.ts
+++ b/apps/api/src/question/question.controller.ts
@@ -3,6 +3,7 @@ import {
   Get,
   NotFoundException,
   Param,
+  ParseIntPipe,
   Query,
   UseGuards,
 } from '@nestjs/common';
@@ -14,10 +15,13 @@ import {
   ApiQuery,
   ApiResponse,
   ApiTags,
+  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { UserId } from 'src/auth/decorators/user-id.decorator';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { FindOneParams } from './dtos/find-one-params.dto';
+import { PaginatedOtherSubmissionsDto } from './dtos/paginated-other-submissions.dto';
+import { OtherSubmissionDetailDto } from './dtos/other-submission-detail.dto';
 import { PaginatedQuestionsDto } from './dtos/paginated-questions.dto';
 import { QuestionFilterDto } from './dtos/question-filter.dto';
 import { Question } from './entities/question.entity';
@@ -112,6 +116,102 @@ export class QuestionController {
   @Get('category/:categoryId')
   async getBySubCategory(@Param('categoryId') categoryId: string) {
     return await this.questionService.findByCategory(+categoryId);
+  }
+
+  @Get(':questionId/others/:submissionId')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: '타 유저 제출 상세 조회',
+    description:
+      '특정 문제에 대한 다른 사용자의 제출(답변) 상세 정보와 AI 평가 결과(피드백, 점수, 핵심 키워드 등)를 조회합니다.',
+  })
+  @ApiParam({
+    name: 'questionId',
+    description: '문제 ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiParam({
+    name: 'submissionId',
+    description: '조회할 제출 ID',
+    type: Number,
+    example: 123,
+  })
+  @ApiResponse({
+    status: 200,
+    description: '타 유저 제출 상세 조회 성공',
+    type: OtherSubmissionDetailDto,
+  })
+  @ApiNotFoundResponse({
+    description: '문제 또는 제출 내역을 찾을 수 없습니다',
+  })
+  @ApiUnauthorizedResponse({
+    description: '로그인이 필요합니다',
+  })
+  async getOtherSubmissionDetail(
+    @Param('questionId', ParseIntPipe) questionId: number,
+    @Param('submissionId', ParseIntPipe) submissionId: number,
+    @UserId() userId: number,
+  ): Promise<OtherSubmissionDetailDto> {
+    return await this.questionService.findOtherSubmissionDetail(
+      questionId,
+      submissionId,
+      userId,
+    );
+  }
+
+  @Get(':questionId/others')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: '특정 문제에 대한 타 유저 제출 리스트 조회',
+    description:
+      '특정 문제에 대해 본인을 제외한 다른 사용자들의 제출 이력을 조회합니다. 각 제출물에 대해 제출한 사용자, 점수, 제출 시각을 제공합니다.',
+  })
+  @ApiParam({
+    name: 'questionId',
+    description: '조회할 문제 ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: '페이지 번호 (기본값: 1)',
+    example: 1,
+  })
+  @ApiQuery({
+    name: 'size',
+    required: false,
+    type: Number,
+    description: '페이지 크기 (기본값: 10)',
+    example: 10,
+  })
+  @ApiResponse({
+    status: 200,
+    description: '타 유저 제출 리스트 조회 성공',
+    type: PaginatedOtherSubmissionsDto,
+  })
+  @ApiNotFoundResponse({
+    description: '문제를 찾을 수 없습니다',
+  })
+  @ApiUnauthorizedResponse({
+    description: '로그인이 필요합니다',
+  })
+  async getOtherSubmissions(
+    @Param('questionId', ParseIntPipe) questionId: number,
+    @UserId() userId: number,
+    @Query('page') page?: number,
+    @Query('size') size?: number,
+  ): Promise<PaginatedOtherSubmissionsDto> {
+    return await this.questionService.findOtherSubmissions(
+      questionId,
+      userId,
+      page ?? 1,
+      size ?? 10,
+    );
   }
 
   @Get(':id')

--- a/apps/api/src/question/question.module.ts
+++ b/apps/api/src/question/question.module.ts
@@ -3,13 +3,14 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AnswerSubmissionModule } from 'src/answer-submission/answer-submission.module';
 import { AuthModule } from 'src/auth/auth.module';
 import { CategoryModule } from '../category/category.module';
+import { User } from '../user/entities/user.entity';
 import { Question } from './entities/question.entity';
 import { QuestionController } from './question.controller';
 import { QuestionService } from './question.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Question]),
+    TypeOrmModule.forFeature([Question, User]),
     CategoryModule,
     AuthModule,
     AnswerSubmissionModule,

--- a/apps/api/src/question/question.module.ts
+++ b/apps/api/src/question/question.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AnswerSubmissionModule } from 'src/answer-submission/answer-submission.module';
+import { AnswerEvaluation } from 'src/answer-evaluation/entities/answer-evaluation.entity';
 import { AuthModule } from 'src/auth/auth.module';
 import { CategoryModule } from '../category/category.module';
 import { User } from '../user/entities/user.entity';
@@ -10,7 +11,7 @@ import { QuestionService } from './question.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Question, User]),
+    TypeOrmModule.forFeature([Question, User, AnswerEvaluation]),
     CategoryModule,
     AuthModule,
     AnswerSubmissionModule,

--- a/apps/api/src/question/question.service.spec.ts
+++ b/apps/api/src/question/question.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { AnswerSubmission } from 'src/answer-submission/entities/answer-submission.entity';
 import { AnswerSubmissionService } from 'src/answer-submission/answer-submission.service';
+import { AnswerEvaluation } from 'src/answer-evaluation/entities/answer-evaluation.entity';
 import { User } from 'src/user/entities/user.entity';
 import { Question } from './entities/question.entity';
 import { SolvedStatus } from './question.constants';
@@ -43,6 +44,10 @@ describe('QuestionService', () => {
     findOne: jest.fn(),
   };
 
+  const mockAnswerEvaluationRepository = {
+    findOne: jest.fn(),
+  };
+
   const mockAnswerSubmissionService = {
     getSubmissionForOtherUser: jest.fn(),
   };
@@ -62,6 +67,10 @@ describe('QuestionService', () => {
         {
           provide: getRepositoryToken(User),
           useValue: mockUserRepository,
+        },
+        {
+          provide: getRepositoryToken(AnswerEvaluation),
+          useValue: mockAnswerEvaluationRepository,
         },
         {
           provide: AnswerSubmissionService,

--- a/apps/api/src/question/question.service.spec.ts
+++ b/apps/api/src/question/question.service.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { AnswerSubmission } from 'src/answer-submission/entities/answer-submission.entity';
+import { AnswerSubmissionService } from 'src/answer-submission/answer-submission.service';
+import { User } from 'src/user/entities/user.entity';
 import { Question } from './entities/question.entity';
 import { SolvedStatus } from './question.constants';
 import { QuestionService } from './question.service';
@@ -37,6 +39,14 @@ describe('QuestionService', () => {
     createQueryBuilder: jest.fn(() => mockSubmissionQueryBuilder),
   };
 
+  const mockUserRepository = {
+    findOne: jest.fn(),
+  };
+
+  const mockAnswerSubmissionService = {
+    getSubmissionForOtherUser: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -48,6 +58,14 @@ describe('QuestionService', () => {
         {
           provide: getRepositoryToken(AnswerSubmission),
           useValue: mockAnswerSubmissionRepository,
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: mockUserRepository,
+        },
+        {
+          provide: AnswerSubmissionService,
+          useValue: mockAnswerSubmissionService,
         },
       ],
     }).compile();

--- a/apps/api/src/question/question.service.ts
+++ b/apps/api/src/question/question.service.ts
@@ -1,11 +1,23 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { AnswerSubmission } from 'src/answer-submission/entities/answer-submission.entity';
+import { AnswerSubmissionService } from 'src/answer-submission/answer-submission.service';
+import { EvaluationStatus } from 'src/answer-evaluation/answer-evaluation.constants';
+import { User } from 'src/user/entities/user.entity';
 import { Repository } from 'typeorm';
+import { OtherSubmissionDetailDto } from './dtos/other-submission-detail.dto';
+import { PaginatedOtherSubmissionsDto } from './dtos/paginated-other-submissions.dto';
 import { PaginatedQuestionsDto } from './dtos/paginated-questions.dto';
 import { QuestionFilterDto } from './dtos/question-filter.dto';
 import { Question } from './entities/question.entity';
 import { SolvedStatus } from './question.constants';
+
+interface OtherSubmissionRaw {
+  submissionId: number;
+  nickname: string;
+  totalScore: number;
+  submittedAt: Date;
+}
 
 @Injectable()
 export class QuestionService {
@@ -16,6 +28,9 @@ export class QuestionService {
     private questionRepository: Repository<Question>,
     @InjectRepository(AnswerSubmission)
     private answerSubmissionRepository: Repository<AnswerSubmission>,
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
+    private readonly answerSubmissionService: AnswerSubmissionService,
   ) {}
 
   async findByCategory(categoryId: number) {
@@ -115,6 +130,131 @@ export class QuestionService {
       pageSize: this.pageSize,
       currentPage: page,
       totalPages,
+    };
+  }
+
+  /**
+   * 특정 문제에 대한 다른 사용자들의 제출 리스트 조회 (본인 제외)
+   * @param questionId 문제 ID
+   * @param currentUserId 현재 사용자 ID (본인 제외용)
+   * @param page 페이지 번호 (기본값: 1)
+   * @param size 페이지 크기 (기본값: 10)
+   * @returns 페이징된 다른 사용자 제출 리스트
+   */
+  async findOtherSubmissions(
+    questionId: number,
+    currentUserId: number,
+    page: number = 1,
+    size: number = 10,
+  ): Promise<PaginatedOtherSubmissionsDto> {
+    const skip = (page - 1) * size;
+
+    // 문제 존재 여부 확인
+    const question = await this.questionRepository.findOne({
+      where: { id: questionId },
+    });
+
+    if (!question) {
+      throw new NotFoundException(`Question with ID ${questionId} not found`);
+    }
+
+    // 다른 사용자들의 제출 리스트 조회 (본인 제외, 총점 내림차순)
+    const baseQueryBuilder = this.answerSubmissionRepository
+      .createQueryBuilder('submission')
+      .innerJoin('users', 'user', 'user.id = submission.user_id')
+      .where('submission.question_id = :questionId', { questionId })
+      .andWhere('submission.user_id != :currentUserId', { currentUserId })
+      .andWhere('submission.evaluation_status = :status', {
+        status: EvaluationStatus.COMPLETED,
+      });
+
+    // 데이터 조회용 쿼리
+    const dataQueryBuilder = baseQueryBuilder
+      .select('submission.id', 'submissionId')
+      .addSelect('user.nickname', 'nickname')
+      .addSelect('submission.score', 'totalScore')
+      .addSelect('submission.submitted_at', 'submittedAt')
+      .orderBy('submission.score', 'DESC')
+      .addOrderBy('submission.submitted_at', 'DESC')
+      .skip(skip)
+      .take(size);
+
+    // 카운트 쿼리 (별도로 생성)
+    const countQueryBuilder = baseQueryBuilder.clone();
+
+    const [results, totalCount] = await Promise.all([
+      dataQueryBuilder.getRawMany<OtherSubmissionRaw>(),
+      countQueryBuilder.getCount(),
+    ]);
+
+    const totalPages = Math.ceil(totalCount / size);
+
+    return {
+      submissions: results.map((result) => ({
+        submissionId: result.submissionId,
+        nickname: result.nickname,
+        totalScore: result.totalScore,
+        submittedAt: result.submittedAt,
+      })),
+      totalCount,
+      pageSize: size,
+      currentPage: page,
+      totalPages,
+    };
+  }
+
+  /**
+   * 특정 문제에 대한 타 유저 제출 상세 조회
+   * - 본인 제출이 아니어야 하고
+   * - questionId 와 submission.questionId 가 일치해야 합니다.
+   */
+  async findOtherSubmissionDetail(
+    questionId: number,
+    submissionId: number,
+    currentUserId: number,
+  ): Promise<OtherSubmissionDetailDto> {
+    // 제출 엔티티 조회 (본인 제출 제외)
+    const submission =
+      await this.answerSubmissionService.getSubmissionForOtherUser(
+        submissionId,
+        currentUserId,
+      );
+
+    // 다른 문제에 대한 제출이면 404
+    if (submission.questionId !== questionId) {
+      throw new NotFoundException(
+        `Question ${questionId} 에 대한 제출 내역을 찾을 수 없습니다.`,
+      );
+    }
+
+    // 문제 존재 여부 2차 확인 (삭제된 경우 방지)
+    const question = await this.questionRepository.findOne({
+      where: { id: questionId },
+    });
+    if (!question) {
+      throw new NotFoundException(`Question with ID ${questionId} not found`);
+    }
+
+    // 작성자 닉네임 조회
+    const user = await this.userRepository.findOne({
+      where: { id: submission.userId },
+    });
+    const nickname = user?.nickname ?? '알 수 없는 사용자';
+
+    return {
+      nickname,
+      submission: {
+        id: submission.id,
+        questionId: submission.questionId,
+        submittedAt: submission.submittedAt,
+        audioAssetId: submission.audioAssetId,
+        evaluationStatus: submission.evaluationStatus,
+        sttStatus: submission.sttStatus,
+        inputType: submission.inputType,
+        answerContent: submission.rawAnswer,
+        totalScore: submission.score,
+        duration: submission.takenTime,
+      },
     };
   }
 }

--- a/apps/api/src/question/question.service.ts
+++ b/apps/api/src/question/question.service.ts
@@ -169,7 +169,10 @@ export class QuestionService {
         status: EvaluationStatus.COMPLETED,
       });
 
-    // 데이터 조회용 쿼리
+    // 카운트 쿼리 (select 적용 전에 clone)
+    const countQueryBuilder = baseQueryBuilder.clone();
+
+    // // 데이터 조회용 쿼리
     const dataQueryBuilder = baseQueryBuilder
       .select('submission.id', 'submissionId')
       .addSelect('user.nickname', 'nickname')
@@ -179,9 +182,6 @@ export class QuestionService {
       .addOrderBy('submission.submittedAt', 'DESC')
       .skip(skip)
       .take(size);
-
-    // 카운트 쿼리 (별도로 생성)
-    const countQueryBuilder = baseQueryBuilder.clone();
 
     const [results, totalCount] = await Promise.all([
       dataQueryBuilder.getRawMany<OtherSubmissionRaw>(),

--- a/apps/api/src/question/question.service.ts
+++ b/apps/api/src/question/question.service.ts
@@ -6,6 +6,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { AnswerSubmission } from 'src/answer-submission/entities/answer-submission.entity';
 import { AnswerSubmissionService } from 'src/answer-submission/answer-submission.service';
+import { AnswerEvaluation } from 'src/answer-evaluation/entities/answer-evaluation.entity';
 import { EvaluationStatus } from 'src/answer-evaluation/answer-evaluation.constants';
 import { User } from 'src/user/entities/user.entity';
 import { Repository } from 'typeorm';
@@ -34,6 +35,8 @@ export class QuestionService {
     private answerSubmissionRepository: Repository<AnswerSubmission>,
     @InjectRepository(User)
     private userRepository: Repository<User>,
+    @InjectRepository(AnswerEvaluation)
+    private answerEvaluationRepository: Repository<AnswerEvaluation>,
     private readonly answerSubmissionService: AnswerSubmissionService,
   ) {}
 
@@ -156,9 +159,10 @@ export class QuestionService {
     }
     const skip = (page - 1) * size;
 
-    // 문제 존재 여부 확인
+    // 문제 존재 여부 확인 및 카테고리 정보 포함
     const question = await this.questionRepository.findOne({
       where: { id: questionId },
+      relations: ['category', 'category.parent'],
     });
 
     if (!question) {
@@ -198,6 +202,20 @@ export class QuestionService {
     const totalPages = Math.ceil(totalCount / size);
 
     return {
+      question: {
+        id: question.id,
+        title: question.title,
+        category: {
+          id: question.category?.id ?? 0,
+          name: question.category?.name ?? '',
+          parent: question.category?.parent
+            ? {
+                id: question.category.parent.id,
+                name: question.category.parent.name,
+              }
+            : null,
+        },
+      },
       submissions: results.map((result) => ({
         submissionId: result.submissionId,
         nickname: result.nickname,
@@ -235,9 +253,10 @@ export class QuestionService {
       );
     }
 
-    // 문제 존재 여부 2차 확인 (삭제된 경우 방지)
+    // 문제 존재 여부 2차 확인 및 카테고리 정보 포함
     const question = await this.questionRepository.findOne({
       where: { id: questionId },
+      relations: ['category', 'category.parent'],
     });
     if (!question) {
       throw new NotFoundException(`Question with ID ${questionId} not found`);
@@ -249,8 +268,33 @@ export class QuestionService {
     });
     const nickname = user?.nickname ?? '알 수 없는 사용자';
 
+    // 핵심 키워드 조회 (평가 결과에서)
+    let keywords: string[] = [];
+    const evaluation = await this.answerEvaluationRepository.findOne({
+      where: { submissionId: submission.id },
+      select: ['extractedKeywords'],
+    });
+    if (evaluation?.extractedKeywords) {
+      keywords = evaluation.extractedKeywords;
+    }
+
     return {
       nickname,
+      question: {
+        id: question.id,
+        title: question.title,
+        content: question.content,
+        category: {
+          id: question.category?.id ?? 0,
+          name: question.category?.name ?? '',
+          parent: question.category?.parent
+            ? {
+                id: question.category.parent.id,
+                name: question.category.parent.name,
+              }
+            : null,
+        },
+      },
       submission: {
         id: submission.id,
         questionId: submission.questionId,
@@ -263,6 +307,7 @@ export class QuestionService {
         totalScore: submission.score,
         duration: submission.takenTime,
       },
+      keywords,
     };
   }
 }

--- a/apps/api/src/question/question.service.ts
+++ b/apps/api/src/question/question.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { AnswerSubmission } from 'src/answer-submission/entities/answer-submission.entity';
 import { AnswerSubmissionService } from 'src/answer-submission/answer-submission.service';
@@ -147,6 +151,9 @@ export class QuestionService {
     page: number = 1,
     size: number = 10,
   ): Promise<PaginatedOtherSubmissionsDto> {
+    if (page < 1 || size < 1) {
+      throw new BadRequestException('page 와 size는 1 이상이어야 합니다.');
+    }
     const skip = (page - 1) * size;
 
     // 문제 존재 여부 확인

--- a/apps/api/src/question/question.service.ts
+++ b/apps/api/src/question/question.service.ts
@@ -161,10 +161,11 @@ export class QuestionService {
     // 다른 사용자들의 제출 리스트 조회 (본인 제외, 총점 내림차순)
     const baseQueryBuilder = this.answerSubmissionRepository
       .createQueryBuilder('submission')
-      .innerJoin('users', 'user', 'user.id = submission.user_id')
-      .where('submission.question_id = :questionId', { questionId })
-      .andWhere('submission.user_id != :currentUserId', { currentUserId })
-      .andWhere('submission.evaluation_status = :status', {
+      // AnswerSubmission.userId와 users.id 기준 조인
+      .innerJoin('users', 'user', 'user.id = submission.userId')
+      .where('submission.questionId = :questionId', { questionId })
+      .andWhere('submission.userId != :currentUserId', { currentUserId })
+      .andWhere('submission.evaluationStatus = :status', {
         status: EvaluationStatus.COMPLETED,
       });
 
@@ -173,9 +174,9 @@ export class QuestionService {
       .select('submission.id', 'submissionId')
       .addSelect('user.nickname', 'nickname')
       .addSelect('submission.score', 'totalScore')
-      .addSelect('submission.submitted_at', 'submittedAt')
+      .addSelect('submission.submittedAt', 'submittedAt')
       .orderBy('submission.score', 'DESC')
-      .addOrderBy('submission.submitted_at', 'DESC')
+      .addOrderBy('submission.submittedAt', 'DESC')
       .skip(skip)
       .take(size);
 


### PR DESCRIPTION
## **🔸 작업 내용**

- #286
- #287
- #295 

---

- **타 유저 제출 리스트 조회 API 추가**
  - `GET /questions/:questionId/others`
  - **본인 제출 제외**, `EvaluationStatus.COMPLETED` 인 제출만 대상
  - 응답 필드: `submissionId`, `nickname`, `totalScore`, `submittedAt`
  - 페이징 지원: `page`, `size` 쿼리 파라미터
  - 정렬: 총점 내림차순 → 제출 시각 내림차순

- **타 유저 제출 상세 조회 API 추가**
  - `GET /questions/:questionId/others/:submissionId`
  - 인증 사용자 기준으로 **본인 제출은 조회 불가**
  - `questionId`와 `submission.questionId`가 일치하는지 검증
  - 응답: `OtherSubmissionDetailDto`
    - `nickname`: 답변 작성자 닉네임
    - `submission`: `AnswerSubmissionResponseDto` 재사용 (답변 스크립트, 제출 시각, 점수 등)

- **DTO 및 타입 정리**
  - 리스트용: `OtherSubmissionItemDto`, `PaginatedOtherSubmissionsDto`
  - 상세용: `OtherSubmissionDetailDto` (내부에 `AnswerSubmissionResponseDto` 중첩)
  - TypeORM raw 쿼리 결과용 `OtherSubmissionRaw` 타입 추가 (`getRawMany<OtherSubmissionRaw>()`로 `any` 제거)

- **접근 제어 / 검증 로직**
  - 리스트/상세 모두 `JwtAuthGuard + @UserId()` 적용
  - 상세 조회 시:
    - `getSubmissionForOtherUser`에서 **본인 제출 차단** + 없는 제출 시 404
    - `Question` 존재 여부 재확인 (`Question not found` 시 404)

---

## **🔸 고민 했던 부분**

### 1. DTO 재사용 vs 전용 DTO 설계

- **고민**
  - “다른 사람 답변 상세” 화면에서는 **답변 스크립트만 실제로 필요**하지만,
  - 이미 `AnswerSubmissionResponseDto`가 존재하고, 향후 점수/상태/소요 시간 등 추가 정보가 필요해질 수 있음.

- **결정**
  - 상세 응답 DTO를 `nickname + AnswerSubmissionResponseDto` 형태로 설계:
    - 전용 DTO(`OtherSubmissionDetailDto`) 안에 `submission: AnswerSubmissionResponseDto`를 중첩
    - 프론트는 **`submission.answerContent` 중심으로만 사용**, 필요 시 다른 필드를 쉽게 확장 가능

- **결과**
  - 도메인 관점에서 “다른 사람 답변 상세”라는 의도가 드러나면서도
  - 공통 DTO 재사용으로 타입/스키마 중복을 줄일 수 있었음.

### **2. 기존 API 재사용 vs 새로운 API 분리**

- **고민**
  - 기존 `GET /answer-submissions/:id`(내 제출 상세) 엔드포인트를 재사용할지,
  - `/questions/:questionId/others/:submissionId`처럼 **문제 단위 + 타 유저** 전용 API를 만들지 검토.

- **결정**
  - 기존 API는 “내 제출만 조회”하는 보안/도메인 정책이 강하게 박혀 있음:
    - `submission.userId !== userId`인 경우 404
  - “다른 사람 답변 보기”는
    - **본인 제출 차단**
    - **특정 question에 속하는지 검증**
    - 리스트 API(`GET /questions/:questionId/others`)와 경로 상으로도 자연스럽게 이어져야 함.
  - 그래서 **Question 도메인에 `/questions/:questionId/others/...` 엔드포인트를 새로 추가**하는 쪽으로 분리.

- **결과**
  - “내 제출 상세”와 “다른 사람 제출 상세”의 책임이 분리되어,
  - 접근 제어/정책이 섞이지 않고, 프론트에서도 URL로 의도가 명확해졌다고 ..생각

### **3. API 구현 위치 (`Question` 도메인 vs `AnswerSubmission` 도메인)**

- **고민**
  - 타 유저 제출 데이터는 `answer_submissions` 테이블에 있으므로,
    - `AnswerSubmissionController/Service`에 API를 두는 게 자연스러워 보이기도 함.
  - 하지만 실제 요구사항과 URL은 “**문제별로 다른 사람의 답변을 본다**”에 더 가깝고,
    - 리스트/상세 모두 `/questions/:questionId/...` 형태를 원함.

- **결정**
  - **`Controller`는 `QuestionController`에 두고**,
    - URL 규칙: `/questions/:questionId/others` / `/questions/:questionId/others/:submissionId`
  - 실제 데이터 조회는 QuestionService에서
    - `AnswerSubmission` 리포지토리 + `User` 리포지토리 + `AnswerSubmissionService` 를 활용

- **결과**
  - 라우팅/도메인 구조가 “질문(Question)을 기준으로 보는 화면”과 잘 맞게 정리됨.
  - AnswerSubmission 쪽은 여전히 “제출 행위/내 제출 관리”에 집중할 수 있고,
  - Question 쪽은 “문제별 학습/리포트/다른 사람 답변 보기” 흐름을 담당하는 구조로 나뉨.

---

## **🔸 참고**

### **API 스펙 요약**
  - `GET /questions/:questionId/others`
    - 쿼리: `page`, `size`
    - 응답: `PaginatedOtherSubmissionsDto`
  - GET `/questions/:questionId/others/:submissionId`
    - 응답: `OtherSubmissionDetailDto` (`nickname + AnswerSubmissionResponseDto`)

### 타 사용자의 문제 목록 조회

```json
{
  "question": {
    "id": 1,
    "title": "작업 실행 단위의 이해",
    "category": {
      "id": 8,
      "name": "Operating System",
      "parent": {
        "id": 1,
        "name": "Computer Science"
      }
    }
  },
  "submissions": [
    {
      "submissionId": 1,
      "nickname": "user123",
      "totalScore": 5,
      "submittedAt": "2026-01-27T06:59:25.814Z"
    }
  ],
  "totalCount": 1,
  "pageSize": "10",
  "currentPage": "1",
  "totalPages": 1
}
```

### 제출 상세 조회

```json
{
  "nickname": "user123",
  "question": {
    "id": 1,
    "title": "작업 실행 단위의 이해",
    "content": "프로세스와 스레드의 차이점을 설명하고 멀티 스레드와 멀티 프로세스의 장단점을 비교해주세요.",
    "category": {
      "id": 8,
      "name": "Operating System",
      "parent": {
        "id": 1,
        "name": "Computer Science"
      }
    }
  },
  "submission": {
    "id": 1,
    "questionId": 1,
    "submittedAt": "2026-01-27T06:59:25.814Z",
    "audioAssetId": 1,
    "evaluationStatus": "COMPLETED",
    "sttStatus": "DONE",
    "inputType": "VOICE",
    "answerContent": "프로세스와 스레드의 차이점은 작업 실행 단위에 있습니다.",
    "totalScore": 5,
    "duration": 7000
  },
  "keywords": [
    "프로세스",
    "스레드"
  ]
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 다른 사용자의 제출물 목록(페이지네이션 포함) 및 특정 제출물 상세 조회 기능 추가
  * 상세 응답에 문제 정보와 키워드, 제출 메타정보(닉네임, 총점, 제출시각) 포함

* **인증/접근 제어**
  * 인증 필요 및 본인 제출물은 조회되지 않도록 접근 제어 적용

* **문서**
  * API 응답 스키마 및 예시 보강(Swagger 메타데이터 추가)

* **테스트**
  * 관련 저장소와 서비스 모의(mock)를 추가해 단위 테스트 보강

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->