### PR TITLE
느린 네트워크 환경 UI 대응

### DIFF
--- a/apps/web/src/app/daily/questions/_components/questions-table-section.tsx
+++ b/apps/web/src/app/daily/questions/_components/questions-table-section.tsx
@@ -1,0 +1,179 @@
+import { Spinner } from "@/components/spinner/spinner";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/pagination/pagination";
+import {
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableRow,
+} from "@/components/table/table";
+import { QuestionLinkButton } from "./question-link-button";
+import { fetchQuestions } from "../_lib/fetch-questions";
+
+interface QuestionsTableBodySectionProps {
+  currentPage: number;
+  selectedCategoryId: number | null;
+  selectedSubCategoryId: number | null;
+  searchQuery: string;
+  selectedSolvedStatus: string | null;
+  selectedMinImportance: number | null;
+  rawSearchParams: {
+    page?: string;
+    categoryId?: string;
+    subCategoryId?: string;
+    search?: string;
+    solvedStatus?: string;
+    minImportance?: string;
+  };
+}
+
+async function QuestionsTableBodySection({
+  currentPage,
+  selectedCategoryId,
+  selectedSubCategoryId,
+  searchQuery,
+  selectedSolvedStatus,
+  selectedMinImportance,
+  rawSearchParams,
+}: QuestionsTableBodySectionProps) {
+  const questionsData = await fetchQuestions({
+    page: currentPage,
+    parentCategoryId: selectedCategoryId ?? undefined,
+    categoryId: selectedSubCategoryId ?? undefined,
+    search: searchQuery || undefined,
+    solvedStatus: selectedSolvedStatus ?? undefined,
+    minImportance: selectedMinImportance ?? undefined,
+  });
+
+  const { questions, totalCount, pageSize, totalPages } = questionsData;
+
+  const startIndex = totalCount === 0 ? 0 : (currentPage - 1) * pageSize + 1;
+  const endIndex =
+    totalCount === 0 ? 0 : Math.min(currentPage * pageSize, totalCount);
+
+  const buildPaginationUrl = (pageNum: number) => {
+    const params = new URLSearchParams();
+    params.set("page", pageNum.toString());
+    if (rawSearchParams.categoryId)
+      params.set("categoryId", rawSearchParams.categoryId);
+    if (rawSearchParams.subCategoryId)
+      params.set("subCategoryId", rawSearchParams.subCategoryId);
+    if (rawSearchParams.search) params.set("search", rawSearchParams.search);
+    if (rawSearchParams.solvedStatus)
+      params.set("solvedStatus", rawSearchParams.solvedStatus);
+    if (rawSearchParams.minImportance)
+      params.set("minImportance", rawSearchParams.minImportance);
+    return `/daily/questions?${params.toString()}`;
+  };
+
+  return (
+    <>
+      <TableBody>
+        {questions.length === 0 ? (
+          <TableRow>
+            <TableCell
+              colSpan={5}
+              className="h-32 text-center text-muted-foreground"
+            >
+              검색 결과가 없습니다.
+            </TableCell>
+          </TableRow>
+        ) : (
+          questions.map((question) => (
+            <TableRow key={question.id}>
+              <TableCell className="text-muted-foreground font-medium">
+                {question.category?.parent?.name ?? "-"}
+              </TableCell>
+              <TableCell className="text-muted-foreground">
+                <span className="text-sm py-1 px-2 bg-muted text-muted-foreground rounded-sm font-medium">
+                  {question.category?.name ?? "-"}
+                </span>
+              </TableCell>
+              <TableCell>
+                <QuestionLinkButton question={question} />
+              </TableCell>
+              <TableCell className="text-center">
+                {(question.avgImportance ?? 0).toFixed(1)}
+              </TableCell>
+              <TableCell className="text-center">
+                {question.score !== null ? (
+                  <span className="text-teal-600 font-medium text-sm bg-teal-50 px-2 py-1 rounded-sm">
+                    {question.score}점
+                  </span>
+                ) : (
+                  ""
+                )}
+              </TableCell>
+            </TableRow>
+          ))
+        )}
+      </TableBody>
+      <TableFooter>
+        <TableRow className="hover:bg-transparent">
+          <TableCell colSpan={2}>
+            <span className="text-muted-foreground text-sm">
+              {startIndex} - {endIndex} / 총 {totalCount}개
+            </span>
+          </TableCell>
+          <TableCell colSpan={3} className="text-right">
+            <Pagination className="justify-end">
+              <PaginationContent>
+                <PaginationItem>
+                  {currentPage > 1 ? (
+                    <PaginationPrevious
+                      href={buildPaginationUrl(currentPage - 1)}
+                    />
+                  ) : (
+                    <PaginationPrevious
+                      className="pointer-events-none opacity-50"
+                      aria-disabled="true"
+                    />
+                  )}
+                </PaginationItem>
+                <PaginationItem>
+                  <div className="px-2">
+                    {currentPage} / {totalPages}
+                  </div>
+                </PaginationItem>
+                <PaginationItem>
+                  {currentPage < totalPages ? (
+                    <PaginationNext
+                      href={buildPaginationUrl(currentPage + 1)}
+                    />
+                  ) : (
+                    <PaginationNext
+                      className="pointer-events-none opacity-50"
+                      aria-disabled="true"
+                    />
+                  )}
+                </PaginationItem>
+              </PaginationContent>
+            </Pagination>
+          </TableCell>
+        </TableRow>
+      </TableFooter>
+    </>
+  );
+}
+
+function TableLoadingFallback() {
+  return (
+    <TableBody>
+      <TableRow>
+        <TableCell colSpan={5} className="h-96 text-center">
+          <div className="flex flex-col items-center gap-3">
+            <Spinner className="w-8 h-8" />
+            <p className="text-sm text-slate-500">문제를 불러오는 중입니다</p>
+          </div>
+        </TableCell>
+      </TableRow>
+    </TableBody>
+  );
+}
+
+export { QuestionsTableBodySection, TableLoadingFallback };

--- a/apps/web/src/app/daily/questions/_components/total-count-section.tsx
+++ b/apps/web/src/app/daily/questions/_components/total-count-section.tsx
@@ -1,0 +1,47 @@
+import { fetchQuestions } from "../_lib/fetch-questions";
+
+interface TotalCountSectionProps {
+  selectedCategoryId: number | null;
+  selectedSubCategoryId: number | null;
+  searchQuery: string;
+  selectedSolvedStatus: string | null;
+  selectedMinImportance: number | null;
+}
+
+async function TotalCountSection({
+  selectedCategoryId,
+  selectedSubCategoryId,
+  searchQuery,
+  selectedSolvedStatus,
+  selectedMinImportance,
+}: TotalCountSectionProps) {
+  const questionsData = await fetchQuestions({
+    page: 1,
+    parentCategoryId: selectedCategoryId ?? undefined,
+    categoryId: selectedSubCategoryId ?? undefined,
+    search: searchQuery || undefined,
+    solvedStatus: selectedSolvedStatus ?? undefined,
+    minImportance: selectedMinImportance ?? undefined,
+  });
+
+  return (
+    <p className="text-muted-foreground">
+      총{" "}
+      <span className="font-semibold text-teal-600">
+        {questionsData.totalCount}
+      </span>
+      개의 문제가 준비되어 있습니다.
+    </p>
+  );
+}
+
+function TotalCountLoadingFallback() {
+  return (
+    <p className="text-muted-foreground">
+      총 <span className="font-semibold text-teal-600">...</span>
+      개의 문제가 준비되어 있습니다.
+    </p>
+  );
+}
+
+export { TotalCountSection, TotalCountLoadingFallback };

--- a/apps/web/src/app/daily/questions/page.tsx
+++ b/apps/web/src/app/daily/questions/page.tsx
@@ -1,26 +1,23 @@
-import {
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/pagination/pagination";
+import { Suspense } from "react";
 import {
   Table,
-  TableBody,
-  TableCell,
-  TableFooter,
   TableHead,
   TableHeader,
   TableRow,
 } from "@/components/table/table";
 import QuestionFilters from "./_components/question-filters";
-import { QuestionLinkButton } from "./_components/question-link-button";
+import {
+  QuestionsTableBodySection,
+  TableLoadingFallback,
+} from "./_components/questions-table-section";
+import {
+  TotalCountSection,
+  TotalCountLoadingFallback,
+} from "./_components/total-count-section";
 import {
   fetchCategoryTree,
   fetchRootCategories,
 } from "./_lib/fetch-categories";
-import { fetchQuestions } from "./_lib/fetch-questions";
 
 interface QuestionListPageProps {
   searchParams: Promise<{
@@ -67,48 +64,27 @@ async function QuestionListPage({ searchParams }: QuestionListPageProps) {
   const categoryTreePromise = selectedCategoryId
     ? fetchCategoryTree(selectedCategoryId)
     : Promise.resolve(null);
-  const questionsPromise = fetchQuestions({
-    page: currentPage,
-    parentCategoryId: selectedCategoryId ?? undefined,
-    categoryId: selectedSubCategoryId ?? undefined,
-    search: searchQuery || undefined,
-    solvedStatus: selectedSolvedStatus ?? undefined,
-    minImportance: selectedMinImportance ?? undefined,
-  });
 
-  const [rootCategories, selectedCategoryTree, questionsData] =
-    await Promise.all([
-      rootCategoriesPromise,
-      categoryTreePromise,
-      questionsPromise,
-    ]);
+  const [rootCategories, selectedCategoryTree] = await Promise.all([
+    rootCategoriesPromise,
+    categoryTreePromise,
+  ]);
 
-  const { questions, totalCount, pageSize, totalPages } = questionsData;
   const subCategories = selectedCategoryTree?.children ?? [];
-
-  const startIndex = totalCount === 0 ? 0 : (currentPage - 1) * pageSize + 1;
-  const endIndex =
-    totalCount === 0 ? 0 : Math.min(currentPage * pageSize, totalCount);
-
-  const buildPaginationUrl = (pageNum: number) => {
-    const params = new URLSearchParams();
-    params.set("page", pageNum.toString());
-    if (categoryId) params.set("categoryId", categoryId);
-    if (subCategoryId) params.set("subCategoryId", subCategoryId);
-    if (searchQuery) params.set("search", searchQuery);
-    if (solvedStatus) params.set("solvedStatus", solvedStatus);
-    if (minImportance) params.set("minImportance", minImportance);
-    return `/daily/questions?${params.toString()}`;
-  };
 
   return (
     <main className="w-full max-w-4xl mx-auto px-8 py-15 space-y-8 min-h-screen">
       <div className="mb-8">
         <h1 className="text-3xl font-bold mb-1">문제 리스트</h1>
-        <p className="text-muted-foreground">
-          총 <span className="font-semibold text-teal-600">{totalCount}</span>
-          개의 문제가 준비되어 있습니다.
-        </p>
+        <Suspense fallback={<TotalCountLoadingFallback />}>
+          <TotalCountSection
+            selectedCategoryId={selectedCategoryId}
+            selectedSubCategoryId={selectedSubCategoryId}
+            searchQuery={searchQuery}
+            selectedSolvedStatus={selectedSolvedStatus}
+            selectedMinImportance={selectedMinImportance}
+          />
+        </Suspense>
       </div>
       <QuestionFilters
         categories={rootCategories}
@@ -129,90 +105,24 @@ async function QuestionListPage({ searchParams }: QuestionListPageProps) {
             <TableHead className="w-20 text-center">내 점수</TableHead>
           </TableRow>
         </TableHeader>
-        <TableBody>
-          {questions.length === 0 ? (
-            <TableRow>
-              <TableCell
-                colSpan={4}
-                className="h-32 text-center text-muted-foreground"
-              >
-                검색 결과가 없습니다.
-              </TableCell>
-            </TableRow>
-          ) : (
-            questions.map((question) => (
-              <TableRow key={question.id}>
-                <TableCell className="text-muted-foreground font-medium">
-                  {question.category?.parent?.name ?? "-"}
-                </TableCell>
-                <TableCell className="text-muted-foreground">
-                  <span className="text-sm py-1 px-2 bg-muted text-muted-foreground rounded-sm font-medium">
-                    {question.category?.name ?? "-"}
-                  </span>
-                </TableCell>
-                <TableCell>
-                  <QuestionLinkButton question={question} />
-                </TableCell>
-                <TableCell className="text-center">
-                  {(question.avgImportance ?? 0).toFixed(1)}
-                </TableCell>
-                <TableCell className="text-center">
-                  {question.score !== null ? (
-                    <span className="text-teal-600 font-medium text-sm bg-teal-50 px-2 py-1 rounded-sm">
-                      {question.score}점
-                    </span>
-                  ) : (
-                    ""
-                  )}
-                </TableCell>
-              </TableRow>
-            ))
-          )}
-        </TableBody>
-        <TableFooter>
-          <TableRow className="hover:bg-transparent">
-            <TableCell colSpan={2}>
-              <span className="text-muted-foreground text-sm">
-                {startIndex} - {endIndex} / 총 {totalCount}개
-              </span>
-            </TableCell>
-            <TableCell colSpan={3} className="text-right">
-              <Pagination className="justify-end">
-                <PaginationContent>
-                  <PaginationItem>
-                    {currentPage > 1 ? (
-                      <PaginationPrevious
-                        href={buildPaginationUrl(currentPage - 1)}
-                      />
-                    ) : (
-                      <PaginationPrevious
-                        className="pointer-events-none opacity-50"
-                        aria-disabled="true"
-                      />
-                    )}
-                  </PaginationItem>
-                  <PaginationItem>
-                    <div className="px-2">
-                      {currentPage} / {totalPages}
-                    </div>
-                  </PaginationItem>
-                  <PaginationItem>
-                    {currentPage < totalPages ? (
-                      <PaginationNext
-                        href={buildPaginationUrl(currentPage + 1)}
-                      />
-                    ) : (
-                      <PaginationNext
-                        className="pointer-events-none opacity-50"
-                        aria-disabled="true"
-                      />
-                    )}
-                  </PaginationItem>
-                </PaginationContent>
-              </Pagination>
-            </TableCell>
-          </TableRow>
-        </TableFooter>
+        <Suspense fallback={<TableLoadingFallback />}>
+          <QuestionsTableBodySection
+            currentPage={currentPage}
+            selectedCategoryId={selectedCategoryId}
+            selectedSubCategoryId={selectedSubCategoryId}
+            searchQuery={searchQuery}
+            selectedSolvedStatus={selectedSolvedStatus}
+            selectedMinImportance={selectedMinImportance}
+            rawSearchParams={{
+              page,
+              categoryId,
+              subCategoryId,
+              search,
+              solvedStatus,
+              minImportance,
+            }}
+          />
+        </Suspense>
       </Table>
       <div data-boostad-zone></div>
     </main>


### PR DESCRIPTION
## 🔸 작업 내용

- #246 
- 문제 리스트 페이지 테이블 로딩 처리

## 🔸 고민 했던 부분
### 문제 리스트 페이지
- 테이블에서 제목을 제외한 부분만 로딩 처리하고 싶었습니다.
- 기존 구조에서는 페이지 컴포넌트에서 `fetchQuestions`를 한 번 호출하여 모든 데이터(totalCount, questions, pagination)를 가져왔습니다.
- 이때 totalCount와 테이블 데이터가 같은 questionData를 사용해서 상단의 totalCount를 표시하려면 결국 전체 fetch가 완료되어야 했습니다. 다시 말해서 테이블만 suspense로 감싸도 독립적인 로딩이 불가능한 것이었습니다.
- 그래서 questions-table-section과 total-count-section의 두 개의 컴포넌트로 분리한 뒤 각자 데이터를 fetch 하고 suspense 처리를 했습니다.
- 이 과정에서 fetchQuestions를 중복 호출하게 되는데 이러면 API 호출 비용이 2배로 드는 것은 아닌가 하는 의문이 들었습니다.
-  Next.js의 Request Deduplication 덕분에 실제로는 한 번만 호출됩니다. Next.js는 동일한 렌더 트리에서 같은 URL + 옵션으로 fetch하면 자동으로 중복 제거를 해서 실제 네트워크 요청은 1번만 발생하고 두 컴포넌트는 동일한 결과를 공유합니다! [Next.js request-memoization](https://nextjs.org/docs/app/guides/caching#request-memoization)

### 렌더링 느린 부분 체크
- 배포 환경에서 네트워크 스로틀링(3G)을 적용하여 렌더링이 특히 느린 구간이 있는지 점검했습니다.
- 그래프/스트릭 영역에서 지연이 가장 눈에 띄었고 네트워크 요청 지연보다는 canvas 초기 로딩으로 인한 흰 화면 노출 시간이 더 길기 때문으로 판단했습니다.
- canvas가 로딩되기 전 스피너를 노출하는 방안을 검토했으나, 네트워크 환경이 좋은 경우 아주 짧은 로딩에도 스피너가 깜빡이는 현상이 발생할 수 있어 UX 측면에서 좋지 않다고 판단했습니다. 추후 canvas 내부에서 로딩 상태를 직접 처리하거나 렌더링 성능을 개선하는 방향으로 보완하면 좋을 것 같습니다.

### 루트 loading.tsx
- 루트 레벨에서 로딩 UI를 제공하는 방법도 시도했는데 마찬가지로 네트워크가 빠른 환경에서는 불필요한 깜빡임이 발생하여 현재 PR에서는 제외했습니다.
- 이후 필요하다면 일정 시간 이상 로딩이 지속되는 경우에만 UI를 노출하거나 로딩 UI를 의도적으로 최소 시간 이상 유지하는 방식도 고려할 수 있을 것 같습니다.

## 🔸 참고
- 문제 리스트 페이지 테이블 로딩

https://github.com/user-attachments/assets/8b042fbe-974a-48b5-8aeb-60f5c8319d0e

- 3G 환경 페이지 렌더링 속도 확인

https://github.com/user-attachments/assets/bfc560db-cade-4416-903c-57c714ef8afa

- 루트 loading 페이지 있을 때 대략적인 느낌

https://github.com/user-attachments/assets/b5429484-f102-4ab5-9f9d-55889965d8e3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 질문 목록 페이지 구조 개선: 페이지네이션과 데이터 로딩 로직을 독립적인 섹션으로 분리했습니다.
  * 비동기 렌더링 지원 추가: 질문 목록과 총 개수 표시 시 로딩 상태를 더 효과적으로 처리합니다.
  * 필터링 및 검색 기능 강화: 카테고리, 검색어, 중요도 필터링이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->