### PR TITLE
리포트 페이지에서 submissionId 없이 접근 시 최신 submission으로 fallback

### DIFF
--- a/apps/web/src/app/mypage/_contents/solved-content.tsx
+++ b/apps/web/src/app/mypage/_contents/solved-content.tsx
@@ -59,7 +59,7 @@ async function SolvedContent({
                 </TableCell>
                 <TableCell>
                   <Link
-                    href={`/reports/${problem.reportId}`}
+                    href={`/reports/${problem.questionId}`}
                     className="text-slate-900 font-medium text-sm hover:text-teal-600 hover:cursor-pointer hover:underline"
                   >
                     {problem.title}

--- a/apps/web/src/app/reports/[questionId]/_lib/services/page-data.ts
+++ b/apps/web/src/app/reports/[questionId]/_lib/services/page-data.ts
@@ -8,7 +8,7 @@ async function getReportPageData(questionId: number, submissionId?: number) {
     getReportHistory(questionId),
   ]);
 
-  const selectedSubmissionId = submissionId ?? history[0]?.submissionId;
+  const selectedSubmissionId = submissionId ?? history.at(-1)?.submissionId;
 
   const evaluation = selectedSubmissionId
     ? await getReportEvaluation(selectedSubmissionId)

--- a/apps/web/src/app/reports/[questionId]/page.tsx
+++ b/apps/web/src/app/reports/[questionId]/page.tsx
@@ -14,17 +14,18 @@ async function ReportPage({ params, searchParams }: ReportPageProps) {
   const { questionId } = await params;
   const { attempt: submissionId } = await searchParams;
 
-  if (!submissionId) {
-    notFound();
-  }
-
   const { question, history, evaluation, highestScore } =
-    await getReportPageData(Number(questionId), Number(submissionId));
-  const selectedAttempt = history.find(
-    (h) => h.submissionId === Number(submissionId),
-  );
+    await getReportPageData(
+      Number(questionId),
+      submissionId ? Number(submissionId) : undefined,
+    );
 
-  if (!question || !history || !selectedAttempt || !evaluation) {
+  // submissionId가 없으면 최신 submission으로 fallback
+  const selectedAttempt = submissionId
+    ? history.find((h) => h.submissionId === Number(submissionId))
+    : history[history.length - 1];
+
+  if (!question || !history.length || !selectedAttempt || !evaluation) {
     notFound();
   }
 

--- a/apps/web/src/app/reports/[questionId]/page.tsx
+++ b/apps/web/src/app/reports/[questionId]/page.tsx
@@ -12,17 +12,21 @@ interface ReportPageProps {
 
 async function ReportPage({ params, searchParams }: ReportPageProps) {
   const { questionId } = await params;
-  const { attempt: submissionId } = await searchParams;
+  const { attempt: submissionIdParam } = await searchParams;
+
+  const parsedSubmissionId = submissionIdParam
+    ? Number(submissionIdParam)
+    : undefined;
+  const validSubmissionId = Number.isFinite(parsedSubmissionId)
+    ? parsedSubmissionId
+    : undefined;
 
   const { question, history, evaluation, highestScore } =
-    await getReportPageData(
-      Number(questionId),
-      submissionId ? Number(submissionId) : undefined,
-    );
+    await getReportPageData(Number(questionId), validSubmissionId);
 
-  // submissionId가 없으면 최신 submission으로 fallback
-  const selectedAttempt = submissionId
-    ? history.find((h) => h.submissionId === Number(submissionId))
+  // submissionId가 없거나 유효하지 않으면 최신 submission으로 fallback
+  const selectedAttempt = validSubmissionId
+    ? history.find((h) => h.submissionId === validSubmissionId)
     : history[history.length - 1];
 
   if (!question || !history.length || !selectedAttempt || !evaluation) {


### PR DESCRIPTION
## 🔸 작업 내용

- 마이페이지의 내가 푼 문제 리스트에서 항목을 클릭해서 들어오면 Not Found에러가 났습니다. 원인은 두가지 였습니다:
  - reports/{questionId} 가 아닌 reports/{reportId}를 사용하고 있었습니다. 
  - reports/{questionId}로 들어와도 404가 떴는데 이유는 search parameter에 submission id가 없으면 404를 던지기 때문입니다.
- 따라서 search parameter로 submission id를 받지못하면 제일 최신 답변을 기준으로 체점 결과 화면을 보여주는 것으로 수정했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 제출 ID가 지정되지 않은 경우 보고서 페이지에서 가장 최신 제출 기록을 기본값으로 사용하도록 개선하였습니다. 이로 인해 기본적으로 가장 최근 평가 결과가 표시됩니다.
  * 풀이(해결) 콘텐츠 테이블의 보고서 링크 경로를 업데이트하여 올바른 항목으로 이동하도록 수정했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->