### PR TITLE
유저는 마이페이지에서 유저 정보를 수정할 수 있다.

### DIFF
--- a/apps/api/migrations/1769582757371-AutoMigration.ts
+++ b/apps/api/migrations/1769582757371-AutoMigration.ts
@@ -1,0 +1,179 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AutoMigration1769582757371 implements MigrationInterface {
+  name = 'AutoMigration1769582757371';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."users_role_enum" AS ENUM('USER', 'ADMIN')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "users" ("id" SERIAL NOT NULL, "email" character varying NOT NULL, "nickname" character varying NOT NULL, "profileImage" character varying, "password" character varying NOT NULL, "role" "public"."users_role_enum" NOT NULL DEFAULT 'USER', "total_point" integer NOT NULL DEFAULT '0', "total_score" double precision NOT NULL DEFAULT '0', "created_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "UQ_97672ac88f789774dd47f7c8be3" UNIQUE ("email"), CONSTRAINT "UQ_ad02a1be8707004cb805a4b5023" UNIQUE ("nickname"), CONSTRAINT "PK_a3ffb1c0c8416b9fc6f907b7433" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "audio_assets" ("id" SERIAL NOT NULL, "user_id" integer NOT NULL, "storage_url" text NOT NULL, "object_key" text, "upload_status" character varying(20) NOT NULL DEFAULT 'pending', "duration_ms" integer, "byte_size" bigint NOT NULL, "codec" character varying(20) NOT NULL, "sample_rate" integer NOT NULL, "channels" integer NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_693b5e6613dd63d1c304ab2c41e" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "streaks" ("id" SERIAL NOT NULL, "acitivity_date" date NOT NULL, "user_id" integer NOT NULL, CONSTRAINT "PK_52547016a1a6409f6e5287ed859" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "categories" ("id" SERIAL NOT NULL, "name" character varying(255) NOT NULL, "depth" integer NOT NULL DEFAULT '1', "parent_id" integer, CONSTRAINT "PK_24dbc6126a28ff948da33e97d3b" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "questions" ("id" SERIAL NOT NULL, "title" character varying(255) NOT NULL, "content" text NOT NULL, "tts_url" character varying(255), "avg_score" double precision NOT NULL DEFAULT '0', "avg_importance" double precision NOT NULL DEFAULT '0', "category_id" integer, CONSTRAINT "PK_08a6d4b0f49ff300bf3a0ca60ac" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "question_solutions" ("id" SERIAL NOT NULL, "question_id" integer NOT NULL, "reference_source" character varying(255) NOT NULL, "standard_definition" text NOT NULL, "technical_mechanism" jsonb NOT NULL, "key_terminology" jsonb NOT NULL, "practical_application" text NOT NULL, "common_misconceptions" text NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "REL_8481ef9b038dfcb760c1be88fd" UNIQUE ("question_id"), CONSTRAINT "PK_d2033af57d5c21a4b504d5ac669" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."graph_nodes_type_enum" AS ENUM('QUESTION', 'KEYWORD')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "graph_nodes" ("id" SERIAL NOT NULL, "user_id" integer NOT NULL, "type" "public"."graph_nodes_type_enum" NOT NULL, "label" character varying(255) NOT NULL, "question_id" integer, CONSTRAINT "PK_2a5943b287182cb16fd26aa0aaa" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_619443842603d72c8bf2de752c" ON "graph_nodes" ("user_id", "type", "question_id") WHERE type = 'QUESTION'`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_760a0d98c818631582a781f768" ON "graph_nodes" ("user_id", "type", "label") WHERE type = 'KEYWORD'`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "graph_edges" ("id" SERIAL NOT NULL, "user_id" integer NOT NULL, "source_id" integer NOT NULL, "target_id" integer NOT NULL, CONSTRAINT "PK_c7b6e013f3760ab6dd3e85b20b8" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_19b842fd6083d50ebe52b9101e" ON "graph_edges" ("user_id", "source_id", "target_id") `,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."answer_submissions_quiz_mode_enum" AS ENUM('DAILY', 'INTERVIEW')`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."answer_submissions_input_type_enum" AS ENUM('VOICE', 'TEXT')`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."answer_submissions_stt_status_enum" AS ENUM('PENDING', 'IN_PROGRESS', 'DONE', 'FAILED')`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."answer_submissions_evaluation_status_enum" AS ENUM('COMPLETED', 'PENDING', 'FAILED')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "answer_submissions" ("id" SERIAL NOT NULL, "quiz_mode" "public"."answer_submissions_quiz_mode_enum" NOT NULL, "input_type" "public"."answer_submissions_input_type_enum" NOT NULL, "raw_answer" text NOT NULL, "self_importance_rating" double precision, "taken_time" integer NOT NULL, "score" integer NOT NULL DEFAULT '0', "submitted_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "stt_status" "public"."answer_submissions_stt_status_enum" NOT NULL DEFAULT 'PENDING', "evaluation_status" "public"."answer_submissions_evaluation_status_enum" NOT NULL DEFAULT 'PENDING', "user_id" integer NOT NULL, "question_id" integer NOT NULL, "audio_asset_id" integer, CONSTRAINT "UQ_15512c14382aa6609260879a7aa" UNIQUE ("audio_asset_id"), CONSTRAINT "REL_15512c14382aa6609260879a7a" UNIQUE ("audio_asset_id"), CONSTRAINT "PK_5e33ef0002975ae5bd3a123fc39" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."answer_evaluations_core_concept_eval_enum" AS ENUM('CORRECT', 'MINOR_ERROR', 'WRONG')`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."answer_evaluations_coverage_eval_enum" AS ENUM('COMPLETE', 'ADEQUATE', 'MINIMAL')`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."answer_evaluations_logic_eval_enum" AS ENUM('CLEAR', 'WEAK', 'NONE')`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."answer_evaluations_depth_eval_enum" AS ENUM('ADVANCED', 'BASIC', 'NONE')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "answer_evaluations" ("id" SERIAL NOT NULL, "submission_id" integer NOT NULL, "feedback_message" text, "detail_analysis" jsonb, "score_details" jsonb, "core_concept_eval" "public"."answer_evaluations_core_concept_eval_enum", "coverage_eval" "public"."answer_evaluations_coverage_eval_enum", "logic_eval" "public"."answer_evaluations_logic_eval_enum", "depth_eval" "public"."answer_evaluations_depth_eval_enum", "has_application" boolean DEFAULT false, "is_complete_sentence" boolean DEFAULT false, "extracted_keywords" text array NOT NULL DEFAULT '{}', "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), CONSTRAINT "REL_8583883ebbb589313987b62628" UNIQUE ("submission_id"), CONSTRAINT "PK_c5515cb44c2a12833fba69d52c5" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "categories" ADD CONSTRAINT "FK_88cea2dc9c31951d06437879b40" FOREIGN KEY ("parent_id") REFERENCES "categories"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "questions" ADD CONSTRAINT "FK_6004e23393f2a8efe414480b75d" FOREIGN KEY ("category_id") REFERENCES "categories"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "question_solutions" ADD CONSTRAINT "FK_8481ef9b038dfcb760c1be88fd5" FOREIGN KEY ("question_id") REFERENCES "questions"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "graph_nodes" ADD CONSTRAINT "FK_e0de4d6e6ed2be66c63f12bb437" FOREIGN KEY ("question_id") REFERENCES "questions"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "graph_edges" ADD CONSTRAINT "FK_16f09c64c126e7380673e1f2a53" FOREIGN KEY ("source_id") REFERENCES "graph_nodes"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "graph_edges" ADD CONSTRAINT "FK_a524073c6db4eda0336c823a59c" FOREIGN KEY ("target_id") REFERENCES "graph_nodes"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "answer_submissions" ADD CONSTRAINT "FK_b42e28b00fa8722a585911cbacc" FOREIGN KEY ("question_id") REFERENCES "questions"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "answer_submissions" ADD CONSTRAINT "FK_15512c14382aa6609260879a7aa" FOREIGN KEY ("audio_asset_id") REFERENCES "audio_assets"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "answer_evaluations" ADD CONSTRAINT "FK_8583883ebbb589313987b626282" FOREIGN KEY ("submission_id") REFERENCES "answer_submissions"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "answer_evaluations" DROP CONSTRAINT "FK_8583883ebbb589313987b626282"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "answer_submissions" DROP CONSTRAINT "FK_15512c14382aa6609260879a7aa"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "answer_submissions" DROP CONSTRAINT "FK_b42e28b00fa8722a585911cbacc"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "graph_edges" DROP CONSTRAINT "FK_a524073c6db4eda0336c823a59c"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "graph_edges" DROP CONSTRAINT "FK_16f09c64c126e7380673e1f2a53"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "graph_nodes" DROP CONSTRAINT "FK_e0de4d6e6ed2be66c63f12bb437"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "question_solutions" DROP CONSTRAINT "FK_8481ef9b038dfcb760c1be88fd5"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "questions" DROP CONSTRAINT "FK_6004e23393f2a8efe414480b75d"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "categories" DROP CONSTRAINT "FK_88cea2dc9c31951d06437879b40"`,
+    );
+    await queryRunner.query(`DROP TABLE "answer_evaluations"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."answer_evaluations_depth_eval_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."answer_evaluations_logic_eval_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."answer_evaluations_coverage_eval_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."answer_evaluations_core_concept_eval_enum"`,
+    );
+    await queryRunner.query(`DROP TABLE "answer_submissions"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."answer_submissions_evaluation_status_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."answer_submissions_stt_status_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."answer_submissions_input_type_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."answer_submissions_quiz_mode_enum"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_19b842fd6083d50ebe52b9101e"`,
+    );
+    await queryRunner.query(`DROP TABLE "graph_edges"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_760a0d98c818631582a781f768"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_619443842603d72c8bf2de752c"`,
+    );
+    await queryRunner.query(`DROP TABLE "graph_nodes"`);
+    await queryRunner.query(`DROP TYPE "public"."graph_nodes_type_enum"`);
+    await queryRunner.query(`DROP TABLE "question_solutions"`);
+    await queryRunner.query(`DROP TABLE "questions"`);
+    await queryRunner.query(`DROP TABLE "categories"`);
+    await queryRunner.query(`DROP TABLE "streaks"`);
+    await queryRunner.query(`DROP TABLE "audio_assets"`);
+    await queryRunner.query(`DROP TABLE "users"`);
+    await queryRunner.query(`DROP TYPE "public"."users_role_enum"`);
+  }
+}

--- a/apps/api/src/object-storage/object-storage.service.ts
+++ b/apps/api/src/object-storage/object-storage.service.ts
@@ -146,6 +146,17 @@ export class ObjectStorageService {
     return `${endpoint}/${this.bucket}/${objectKey}`;
   }
 
+  async createPresignedGetUrl(objectKey: string) {
+    if (!objectKey || objectKey.trim().length === 0) {
+      throw new Error('objectKey is required');
+    }
+
+    return await this.getS3Client().getSignedUrlPromise('getObject', {
+      Bucket: this.bucket,
+      Key: objectKey,
+    });
+  }
+
   /**
    * Object Storage에서 객체 삭제
    * @param objectKey 삭제할 Object Key

--- a/apps/api/src/object-storage/object-storage.service.ts
+++ b/apps/api/src/object-storage/object-storage.service.ts
@@ -146,6 +146,34 @@ export class ObjectStorageService {
     return `${endpoint}/${this.bucket}/${objectKey}`;
   }
 
+  /**
+   * Object Storage에서 객체 삭제
+   * @param objectKey 삭제할 Object Key
+   */
+  async deleteObject(objectKey: string): Promise<void> {
+    if (!objectKey || objectKey.trim().length === 0) {
+      throw new Error('objectKey is required');
+    }
+
+    try {
+      await this.getS3Client()
+        .deleteObject({
+          Bucket: this.bucket,
+          Key: objectKey,
+        })
+        .promise();
+
+      this.logger.log(`Deleted object: ${objectKey}`);
+    } catch (err: unknown) {
+      // 404 NotFound는 존재하지 않기 때문에 성공으로 처리
+      if (this.isS3NotFoundError(err)) {
+        this.logger.log(`Object already deleted: ${objectKey}`);
+        return;
+      }
+      throw err;
+    }
+  }
+
   private isS3NotFoundError(err: unknown): boolean {
     if (typeof err !== 'object' || err === null) return false;
 

--- a/apps/api/src/user/dtos/request/edit-user.request.dto.ts
+++ b/apps/api/src/user/dtos/request/edit-user.request.dto.ts
@@ -5,6 +5,7 @@ import {
   MinLength,
   MaxLength,
   Matches,
+  ValidateIf,
 } from 'class-validator';
 
 const NICKNAME_MIN_LENGTH = 1;
@@ -30,11 +31,15 @@ export class EditUserRequestDto {
   nickname?: string;
 
   @ApiProperty({
-    description: 'Object Storage 키',
+    description:
+      'Object Storage 키. null을 보내면 프로필 이미지 삭제, 문자열을 보내면 이미지 변경, 보내지 않으면 변경 없음',
     example: 'profile-images/uuid-here',
     required: false,
+    nullable: true,
+    type: String,
   })
   @IsOptional()
+  @ValidateIf((o: EditUserRequestDto) => o.objectKey !== null)
   @IsString({ message: 'objectKey는 문자열이어야 합니다.' })
-  objectKey?: string;
+  objectKey?: string | null;
 }

--- a/apps/api/src/user/dtos/request/edit-user.request.dto.ts
+++ b/apps/api/src/user/dtos/request/edit-user.request.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsOptional,
+  IsString,
+  MinLength,
+  MaxLength,
+  Matches,
+} from 'class-validator';
+
+const NICKNAME_MIN_LENGTH = 1;
+const NICKNAME_MAX_LENGTH = 20;
+
+export class EditUserRequestDto {
+  @ApiProperty({
+    description: '닉네임(공백 불가)',
+    example: '김개발',
+    minLength: NICKNAME_MIN_LENGTH,
+    maxLength: NICKNAME_MAX_LENGTH,
+    required: false,
+  })
+  @IsOptional()
+  @IsString({ message: 'nickname은 문자열이어야 합니다.' })
+  @MinLength(NICKNAME_MIN_LENGTH, {
+    message: `nickname은 최소 ${NICKNAME_MIN_LENGTH}자여야 합니다.`,
+  })
+  @MaxLength(NICKNAME_MAX_LENGTH, {
+    message: `nickname은 최대 ${NICKNAME_MAX_LENGTH}자여야 합니다.`,
+  })
+  @Matches(/^\S+$/, { message: 'nickname에는 공백을 포함할 수 없습니다.' })
+  nickname?: string;
+
+  @ApiProperty({
+    description: 'Object Storage 키',
+    example: 'profile-images/uuid-here',
+    required: false,
+  })
+  @IsOptional()
+  @IsString({ message: 'objectKey는 문자열이어야 합니다.' })
+  objectKey?: string;
+}

--- a/apps/api/src/user/dtos/request/edit-user.request.dto.ts
+++ b/apps/api/src/user/dtos/request/edit-user.request.dto.ts
@@ -2,9 +2,9 @@ import { ApiProperty } from '@nestjs/swagger';
 import {
   IsOptional,
   IsString,
-  MinLength,
-  MaxLength,
   Matches,
+  MaxLength,
+  MinLength,
   ValidateIf,
 } from 'class-validator';
 
@@ -41,5 +41,6 @@ export class EditUserRequestDto {
   @IsOptional()
   @ValidateIf((o: EditUserRequestDto) => o.objectKey !== null)
   @IsString({ message: 'objectKey는 문자열이어야 합니다.' })
+  @MinLength(1, { message: 'objectKey는 비어있을 수 없습니다.' })
   objectKey?: string | null;
 }

--- a/apps/api/src/user/dtos/request/user-presigned-url.request.dto.ts
+++ b/apps/api/src/user/dtos/request/user-presigned-url.request.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class UserPresignedUrlRequestDto {
+  @ApiProperty({
+    description: '이미지 Content-Type',
+    example: 'image/jpeg',
+    enum: ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'],
+  })
+  @IsString()
+  contentType: string;
+}

--- a/apps/api/src/user/dtos/request/user-presigned-url.request.dto.ts
+++ b/apps/api/src/user/dtos/request/user-presigned-url.request.dto.ts
@@ -1,12 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { IsIn, IsString } from 'class-validator';
+
+const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp'] as const;
 
 export class UserPresignedUrlRequestDto {
   @ApiProperty({
     description: '이미지 Content-Type',
     example: 'image/jpeg',
-    enum: ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'],
+    enum: ALLOWED_IMAGE_TYPES,
   })
   @IsString()
+  @IsIn(ALLOWED_IMAGE_TYPES)
   contentType: string;
 }

--- a/apps/api/src/user/dtos/response/presigned-url.response.dto.ts
+++ b/apps/api/src/user/dtos/response/presigned-url.response.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PresignedUrlResponseDto {
+  @ApiProperty({ description: '업로드용 Presigned PUT URL' })
+  uploadUrl: string;
+
+  @ApiProperty({ description: 'Object Storage 키' })
+  objectKey: string;
+
+  @ApiProperty({ description: 'URL 만료 시간 (초)' })
+  expiresIn: number;
+}

--- a/apps/api/src/user/dtos/response/user-presigned-url.response.dto.ts
+++ b/apps/api/src/user/dtos/response/user-presigned-url.response.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class PresignedUrlResponseDto {
+export class UserPresignedUrlResponseDto {
   @ApiProperty({ description: '업로드용 Presigned PUT URL' })
   uploadUrl: string;
 

--- a/apps/api/src/user/dtos/response/user.public.response.dto.ts
+++ b/apps/api/src/user/dtos/response/user.public.response.dto.ts
@@ -10,6 +10,13 @@ export class UserPublicResponseDto {
   @ApiProperty({ description: '닉네임', example: 'user123' })
   nickname: string;
 
+  @ApiProperty({
+    description: '프로필 이미지 URL',
+    example: 'https://endpoint/bucket/profile-images/uuid',
+    nullable: true,
+  })
+  profileImage: string | null;
+
   @ApiProperty({ description: '총 포인트', example: 0 })
   totalPoint: number;
 

--- a/apps/api/src/user/entities/user.entity.ts
+++ b/apps/api/src/user/entities/user.entity.ts
@@ -18,7 +18,7 @@ export class User {
   nickname: string;
 
   @Column({ type: 'varchar', nullable: true })
-  profileImage: string;
+  profileImage: string | null;
 
   @Column({ type: 'varchar' })
   password: string;

--- a/apps/api/src/user/entities/user.entity.ts
+++ b/apps/api/src/user/entities/user.entity.ts
@@ -1,8 +1,8 @@
 import {
-  Entity,
-  PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
 } from 'typeorm';
 import { UserRole } from './user-role.enum';
 
@@ -16,6 +16,9 @@ export class User {
 
   @Column({ type: 'varchar', unique: true })
   nickname: string;
+
+  @Column({ type: 'varchar', nullable: true })
+  profileImage: string;
 
   @Column({ type: 'varchar' })
   password: string;

--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -1,32 +1,36 @@
 import {
+  Body,
   Controller,
   Get,
-  Post,
-  Body,
-  Res,
   HttpCode,
   HttpStatus,
+  Patch,
+  Post,
+  Query,
+  Res,
   UseGuards,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
 import {
-  ApiTags,
+  ApiBearerAuth,
+  ApiBody,
   ApiOperation,
   ApiResponse,
-  ApiBody,
-  ApiBearerAuth,
+  ApiTags,
 } from '@nestjs/swagger';
 import type { Response } from 'express';
-import { UserService } from './user.service';
-import { LoginResponseDto } from './dtos/response/login.response.dto';
-import { LoginRequestDto } from './dtos/request/login.request.dto';
 import { AuthService } from '../auth/auth.service';
-import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { UserId } from '../auth/decorators/user-id.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CreateUserRequestDto } from './dtos/request/create-user.request.dto';
-import { UserPublicResponseDto } from './dtos/response/user.public.response.dto';
+import { EditUserRequestDto } from './dtos/request/edit-user.request.dto';
+import { LoginRequestDto } from './dtos/request/login.request.dto';
+import { LoginResponseDto } from './dtos/response/login.response.dto';
+import { PresignedUrlResponseDto } from './dtos/response/presigned-url.response.dto';
 import { SolvedProblemsListResponseDto } from './dtos/response/solved-problems-list-response.dto';
+import { UserPublicResponseDto } from './dtos/response/user.public.response.dto';
+import { UserService } from './user.service';
 
 const USER_CONTROLLER_VALIDATION_PIPE = new ValidationPipe({
   transform: true,
@@ -155,6 +159,7 @@ export class UserController {
       id: user.id,
       email: user.email,
       nickname: user.nickname,
+      profileImage: user.profileImage ?? null,
       totalPoint: user.totalPoint ?? 0,
       totalScore: user.totalScore ?? 0,
       createdAt: user.createdAt.toISOString(),
@@ -179,5 +184,83 @@ export class UserController {
     @UserId() userId: number,
   ): Promise<SolvedProblemsListResponseDto> {
     return await this.userService.getSolvedProblems(userId);
+  }
+
+  @Post('presigned-url')
+  @ApiOperation({ summary: '프로필 이미지 업로드용 Presigned URL 요청' })
+  @ApiBearerAuth('JWT-auth')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiResponse({
+    status: 200,
+    description: 'Presigned URL 생성 성공',
+    type: PresignedUrlResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: '지원하지 않는 Content-Type',
+  })
+  @ApiResponse({
+    status: 401,
+    description: '로그인이 필요합니다',
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Presigned URL 생성 실패',
+  })
+  async requestPresignedUrl(
+    @UserId() userId: number,
+    @Query('contentType') contentType?: string,
+  ): Promise<PresignedUrlResponseDto> {
+    return await this.userService.requestPresignedUrl(userId, contentType);
+  }
+
+  @Patch('me')
+  @ApiOperation({ summary: '사용자 정보 수정 (닉네임, 프로필 이미지)' })
+  @ApiBearerAuth('JWT-auth')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiBody({ type: EditUserRequestDto })
+  @ApiResponse({
+    status: 200,
+    description: '사용자 정보 수정 성공',
+    type: EditUserRequestDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      '잘못된 요청 (유효성 검증 실패, 유효하지 않은 objectKey, 수정할 정보 없음)',
+  })
+  @ApiResponse({
+    status: 401,
+    description: '로그인이 필요합니다',
+  })
+  @ApiResponse({
+    status: 404,
+    description: '사용자를 찾을 수 없습니다',
+  })
+  @ApiResponse({
+    status: 409,
+    description: '이미 사용 중인 닉네임입니다',
+  })
+  @ApiResponse({
+    status: 500,
+    description: '이미지 검증 실패',
+  })
+  @UsePipes(USER_CONTROLLER_VALIDATION_PIPE)
+  async editUser(
+    @UserId() userId: number,
+    @Body() editUserRequestDto: EditUserRequestDto,
+  ): Promise<UserPublicResponseDto> {
+    const user = await this.userService.editUser(userId, editUserRequestDto);
+    return {
+      id: user.id,
+      email: user.email,
+      nickname: user.nickname,
+      profileImage: user.profileImage || null,
+      totalPoint: user.totalPoint ?? 0,
+      totalScore: user.totalScore ?? 0,
+      createdAt: user.createdAt.toISOString(),
+    };
   }
 }

--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -216,11 +216,34 @@ export class UserController {
   }
 
   @Patch('me')
-  @ApiOperation({ summary: '사용자 정보 수정 (닉네임, 프로필 이미지)' })
+  @ApiOperation({
+    summary: '사용자 정보 수정 (닉네임, 프로필 이미지)',
+    description: 'objectKey에 null을 보내면 프로필 이미지가 삭제됩니다.',
+  })
   @ApiBearerAuth('JWT-auth')
   @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.OK)
-  @ApiBody({ type: EditUserRequestDto })
+  @ApiBody({
+    type: EditUserRequestDto,
+    examples: {
+      updateNickname: {
+        summary: '닉네임만 변경',
+        value: { nickname: '새닉네임' },
+      },
+      updateImage: {
+        summary: '프로필 이미지 변경',
+        value: { objectKey: 'profile-images/uuid-here' },
+      },
+      deleteImage: {
+        summary: '프로필 이미지 삭제',
+        value: { objectKey: null },
+      },
+      updateBoth: {
+        summary: '닉네임과 이미지 동시 변경',
+        value: { nickname: '새닉네임', objectKey: 'profile-images/uuid-here' },
+      },
+    },
+  })
   @ApiResponse({
     status: 200,
     description: '사용자 정보 수정 성공',

--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -6,7 +6,6 @@ import {
   HttpStatus,
   Patch,
   Post,
-  Query,
   Res,
   UseGuards,
   UsePipes,
@@ -26,6 +25,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CreateUserRequestDto } from './dtos/request/create-user.request.dto';
 import { EditUserRequestDto } from './dtos/request/edit-user.request.dto';
 import { LoginRequestDto } from './dtos/request/login.request.dto';
+import { UserPresignedUrlRequestDto } from './dtos/request/user-presigned-url.request.dto';
 import { LoginResponseDto } from './dtos/response/login.response.dto';
 import { SolvedProblemsListResponseDto } from './dtos/response/solved-problems-list-response.dto';
 import { UserPresignedUrlResponseDto } from './dtos/response/user-presigned-url.response.dto';
@@ -191,6 +191,7 @@ export class UserController {
   @ApiBearerAuth('JWT-auth')
   @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.OK)
+  @ApiBody({ type: UserPresignedUrlRequestDto })
   @ApiResponse({
     status: 200,
     description: 'Presigned URL 생성 성공',
@@ -210,9 +211,9 @@ export class UserController {
   })
   async requestPresignedUrl(
     @UserId() userId: number,
-    @Query('contentType') contentType?: string,
+    @Body() dto: UserPresignedUrlRequestDto,
   ): Promise<UserPresignedUrlResponseDto> {
-    return await this.userService.requestPresignedUrl(userId, contentType);
+    return await this.userService.requestPresignedUrl(userId, dto.contentType);
   }
 
   @Patch('me')

--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -27,8 +27,8 @@ import { CreateUserRequestDto } from './dtos/request/create-user.request.dto';
 import { EditUserRequestDto } from './dtos/request/edit-user.request.dto';
 import { LoginRequestDto } from './dtos/request/login.request.dto';
 import { LoginResponseDto } from './dtos/response/login.response.dto';
-import { PresignedUrlResponseDto } from './dtos/response/presigned-url.response.dto';
 import { SolvedProblemsListResponseDto } from './dtos/response/solved-problems-list-response.dto';
+import { UserPresignedUrlResponseDto } from './dtos/response/user-presigned-url.response.dto';
 import { UserPublicResponseDto } from './dtos/response/user.public.response.dto';
 import { UserService } from './user.service';
 
@@ -194,7 +194,7 @@ export class UserController {
   @ApiResponse({
     status: 200,
     description: 'Presigned URL 생성 성공',
-    type: PresignedUrlResponseDto,
+    type: UserPresignedUrlResponseDto,
   })
   @ApiResponse({
     status: 400,
@@ -211,7 +211,7 @@ export class UserController {
   async requestPresignedUrl(
     @UserId() userId: number,
     @Query('contentType') contentType?: string,
-  ): Promise<PresignedUrlResponseDto> {
+  ): Promise<UserPresignedUrlResponseDto> {
     return await this.userService.requestPresignedUrl(userId, contentType);
   }
 

--- a/apps/api/src/user/user.module.ts
+++ b/apps/api/src/user/user.module.ts
@@ -1,17 +1,19 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ObjectStorageModule } from 'src/object-storage/object-storage.module';
+import { AnswerSubmission } from '../answer-submission/entities/answer-submission.entity';
+import { AuthModule } from '../auth/auth.module';
+import { Question } from '../question/entities/question.entity';
 import { User } from './entities/user.entity';
+import { UserController } from './user.controller';
 import { UserRepository } from './user.repository';
 import { UserService } from './user.service';
-import { UserController } from './user.controller';
-import { AuthModule } from '../auth/auth.module';
-import { AnswerSubmission } from '../answer-submission/entities/answer-submission.entity';
-import { Question } from '../question/entities/question.entity';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([User, AnswerSubmission, Question]),
     AuthModule,
+    ObjectStorageModule,
   ],
   controllers: [UserController],
   providers: [UserRepository, UserService],

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -1,32 +1,81 @@
 import {
+  BadRequestException,
   ConflictException,
   Injectable,
+  InternalServerErrorException,
+  Logger,
   NotFoundException,
+  OnModuleDestroy,
+  OnModuleInit,
   UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { User } from './entities/user.entity';
+import { randomUUID } from 'crypto';
+import { ObjectStorageService } from 'src/object-storage/object-storage.service';
+import { QueryFailedError, Repository } from 'typeorm';
+import { EvaluationStatus } from '../answer-evaluation/answer-evaluation.constants';
+import { AnswerSubmission } from '../answer-submission/entities/answer-submission.entity';
+import { EditUserRequestDto } from './dtos/request/edit-user.request.dto';
+import { SolvedProblemDto } from './dtos/response/solved-problem.dto';
+import { SolvedProblemsListResponseDto } from './dtos/response/solved-problems-list-response.dto';
 import { UserRole } from './entities/user-role.enum';
+import { User } from './entities/user.entity';
 import { UserRepository } from './user.repository';
 import {
   hashPassword,
   isHashedPassword,
   verifyPassword,
 } from './utils/password.util';
-import { QueryFailedError } from 'typeorm';
-import { AnswerSubmission } from '../answer-submission/entities/answer-submission.entity';
-import { EvaluationStatus } from '../answer-evaluation/answer-evaluation.constants';
-import { SolvedProblemDto } from './dtos/response/solved-problem.dto';
-import { SolvedProblemsListResponseDto } from './dtos/response/solved-problems-list-response.dto';
 
 @Injectable()
-export class UserService {
+export class UserService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(UserService.name);
+  private cleanupInterval: NodeJS.Timeout;
+
   constructor(
     private readonly userRepository: UserRepository,
+    private readonly objectStorageService: ObjectStorageService,
     @InjectRepository(AnswerSubmission)
     private readonly answerSubmissionRepository: Repository<AnswerSubmission>,
   ) {}
+
+  // 메시지큐 대신 사용할 맵
+  private uploadSessions = new Map<
+    string,
+    { userId: number; expiresAt: Date }
+  >();
+
+  // 5분마다 uploadSession 초기화
+  onModuleInit() {
+    this.cleanupInterval = setInterval(
+      () => {
+        this.cleanupExpiredSessions();
+      },
+      5 * 60 * 1000,
+    );
+  }
+
+  onModuleDestroy() {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+    }
+  }
+
+  private cleanupExpiredSessions() {
+    const now = new Date();
+    let cleanedCount = 0;
+
+    for (const [key, session] of this.uploadSessions.entries()) {
+      if (session.expiresAt <= now) {
+        this.uploadSessions.delete(key);
+        cleanedCount++;
+      }
+    }
+
+    if (cleanedCount > 0) {
+      this.logger.log(`Cleaned up ${cleanedCount} expired upload sessions`);
+    }
+  }
 
   async findOneById(id: number): Promise<User | null> {
     return this.userRepository.findOneById(id);
@@ -188,5 +237,148 @@ export class UserService {
       problems,
       totalCount: problems.length,
     };
+  }
+
+  async requestPresignedUrl(userId: number, contentType?: string) {
+    // Content-Type 허용 리스트
+    const allowedContentTypes = [
+      'image/jpeg',
+      'image/jpg',
+      'image/png',
+      'image/webp',
+    ];
+    const finalContentType = contentType || 'image/jpeg';
+
+    if (!allowedContentTypes.includes(finalContentType)) {
+      throw new BadRequestException(
+        `지원하지 않는 Content-Type입니다. 허용: ${allowedContentTypes.join(', ')}`,
+      );
+    }
+
+    const sessionId = randomUUID();
+    const objectKey = `profile-images/${sessionId}`;
+
+    this.uploadSessions.set(objectKey, {
+      userId,
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000),
+    });
+
+    try {
+      const { uploadUrl, expiresIn } =
+        await this.objectStorageService.createPresignedPutUrl(
+          objectKey,
+          finalContentType,
+        );
+
+      return {
+        uploadUrl,
+        objectKey,
+        expiresIn,
+      };
+    } catch (error) {
+      this.logger.error(
+        `Failed to create presigned URL for user ${userId}`,
+        error,
+      );
+      throw new InternalServerErrorException(
+        '프로필 이미지 업로드 URL 생성에 실패했습니다.',
+      );
+    }
+  }
+
+  async editUser(
+    userId: number,
+    editUserRequestDto: EditUserRequestDto,
+  ): Promise<User> {
+    if (!editUserRequestDto.nickname && !editUserRequestDto.objectKey) {
+      throw new BadRequestException('수정할 정보를 입력해주세요.');
+    }
+
+    const userInfo = await this.findOneById(userId);
+    if (!userInfo) {
+      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    }
+
+    let hasChanges = false;
+
+    if (editUserRequestDto.objectKey) {
+      const session = this.uploadSessions.get(editUserRequestDto.objectKey);
+
+      if (
+        !session ||
+        session.userId !== userId ||
+        session.expiresAt <= new Date()
+      ) {
+        throw new BadRequestException(
+          '유효하지 않은 프로필 이미지 업로드 세션입니다.',
+        );
+      }
+
+      try {
+        const { exists } = await this.objectStorageService.verifyFileExists(
+          editUserRequestDto.objectKey,
+        );
+        if (!exists) {
+          throw new BadRequestException('이미지가 업로드되지 않았습니다.');
+        }
+      } catch (error) {
+        if (error instanceof BadRequestException) {
+          throw error;
+        }
+        this.logger.error(
+          `Failed to verify file: ${editUserRequestDto.objectKey}`,
+          error,
+        );
+        throw new InternalServerErrorException('이미지 검증에 실패했습니다.');
+      }
+
+      const profileImageUrl = this.objectStorageService.getPublicUrl(
+        editUserRequestDto.objectKey,
+      );
+
+      userInfo.profileImage = profileImageUrl;
+      this.uploadSessions.delete(editUserRequestDto.objectKey);
+      hasChanges = true;
+    }
+
+    if (
+      editUserRequestDto.nickname &&
+      editUserRequestDto.nickname !== userInfo.nickname
+    ) {
+      const existingUser = await this.userRepository.findOneByNickname(
+        editUserRequestDto.nickname,
+      );
+
+      if (existingUser) {
+        throw new ConflictException('이미 사용 중인 닉네임입니다.');
+      }
+
+      userInfo.nickname = editUserRequestDto.nickname;
+      hasChanges = true;
+    }
+
+    if (hasChanges) {
+      try {
+        return await this.userRepository.save(userInfo);
+      } catch (error) {
+        // 레이스 컨디션 처리
+        if (error instanceof QueryFailedError) {
+          const driverError = error.driverError as {
+            code?: unknown;
+            detail?: unknown;
+          };
+          if (driverError?.code === '23505') {
+            const detail =
+              typeof driverError.detail === 'string' ? driverError.detail : '';
+            if (detail.includes('(nickname)')) {
+              throw new ConflictException('이미 사용 중인 닉네임입니다.');
+            }
+          }
+        }
+        throw error;
+      }
+    }
+
+    return userInfo;
   }
 }

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -158,6 +158,14 @@ export class UserService implements OnModuleInit, OnModuleDestroy {
     if (!user) {
       throw new NotFoundException('사용자를 찾을 수 없습니다.');
     }
+
+    // profileImage의 objectKey를 S3 URL로 변환
+    if (user.profileImage) {
+      user.profileImage = this.objectStorageService.getPublicUrl(
+        user.profileImage,
+      );
+    }
+
     return user;
   }
 
@@ -290,7 +298,10 @@ export class UserService implements OnModuleInit, OnModuleDestroy {
     userId: number,
     editUserRequestDto: EditUserRequestDto,
   ): Promise<User> {
-    if (!editUserRequestDto.nickname && !editUserRequestDto.objectKey) {
+    if (
+      !editUserRequestDto.nickname &&
+      editUserRequestDto.objectKey === undefined
+    ) {
       throw new BadRequestException('수정할 정보를 입력해주세요.');
     }
 
@@ -300,47 +311,25 @@ export class UserService implements OnModuleInit, OnModuleDestroy {
     }
 
     let hasChanges = false;
+    const oldProfileImageKey = userInfo.profileImage;
 
-    if (editUserRequestDto.objectKey) {
-      const session = this.uploadSessions.get(editUserRequestDto.objectKey);
+    // 이미지 변경시
+    if (editUserRequestDto.objectKey !== undefined) {
+      if (editUserRequestDto.objectKey === null) {
+        // 삭제 처리 -> DB의 profileImage ObjectKey = null
+        userInfo.profileImage = null;
+        hasChanges = true;
+      } else {
+        // 새로운 이미지 -> 업로드 확인
+        await this.verifyNewProfileImage(editUserRequestDto.objectKey, userId);
 
-      if (
-        !session ||
-        session.userId !== userId ||
-        session.expiresAt <= new Date()
-      ) {
-        throw new BadRequestException(
-          '유효하지 않은 프로필 이미지 업로드 세션입니다.',
-        );
+        userInfo.profileImage = editUserRequestDto.objectKey;
+        this.uploadSessions.delete(editUserRequestDto.objectKey);
+        hasChanges = true;
       }
-
-      try {
-        const { exists } = await this.objectStorageService.verifyFileExists(
-          editUserRequestDto.objectKey,
-        );
-        if (!exists) {
-          throw new BadRequestException('이미지가 업로드되지 않았습니다.');
-        }
-      } catch (error) {
-        if (error instanceof BadRequestException) {
-          throw error;
-        }
-        this.logger.error(
-          `Failed to verify file: ${editUserRequestDto.objectKey}`,
-          error,
-        );
-        throw new InternalServerErrorException('이미지 검증에 실패했습니다.');
-      }
-
-      const profileImageUrl = this.objectStorageService.getPublicUrl(
-        editUserRequestDto.objectKey,
-      );
-
-      userInfo.profileImage = profileImageUrl;
-      this.uploadSessions.delete(editUserRequestDto.objectKey);
-      hasChanges = true;
     }
 
+    // 닉네임 변경시
     if (
       editUserRequestDto.nickname &&
       editUserRequestDto.nickname !== userInfo.nickname
@@ -359,7 +348,25 @@ export class UserService implements OnModuleInit, OnModuleDestroy {
 
     if (hasChanges) {
       try {
-        return await this.userRepository.save(userInfo);
+        const savedUser = await this.userRepository.save(userInfo);
+
+        // DB 저장 성공 후 오래된 이미지 cleanup
+        if (
+          editUserRequestDto.objectKey !== undefined &&
+          oldProfileImageKey &&
+          oldProfileImageKey !== savedUser.profileImage
+        ) {
+          this.cleanupOldProfileImage(oldProfileImageKey);
+        }
+
+        // profileImage를 objectKey에서 URL로 변환
+        if (savedUser.profileImage) {
+          savedUser.profileImage = this.objectStorageService.getPublicUrl(
+            savedUser.profileImage,
+          );
+        }
+
+        return savedUser;
       } catch (error) {
         // 레이스 컨디션 처리
         if (error instanceof QueryFailedError) {
@@ -379,6 +386,55 @@ export class UserService implements OnModuleInit, OnModuleDestroy {
       }
     }
 
+    // profileImage를 objectKey에서 URL로 변환
+    if (userInfo.profileImage) {
+      userInfo.profileImage = this.objectStorageService.getPublicUrl(
+        userInfo.profileImage,
+      );
+    }
+
     return userInfo;
+  }
+
+  /**
+   * presigned URL로 이미지가 업로드 되었는지 확인
+   */
+  private async verifyNewProfileImage(objectKey: string, userId: number) {
+    const session = this.uploadSessions.get(objectKey);
+
+    if (
+      !session ||
+      session.userId !== userId ||
+      session.expiresAt <= new Date()
+    ) {
+      throw new BadRequestException('유효하지 않은 이미지 세션입니다.');
+    }
+
+    try {
+      const { exists } =
+        await this.objectStorageService.verifyFileExists(objectKey);
+      if (!exists) {
+        throw new BadRequestException('이미지가 업로드되지 않았습니다.');
+      }
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+      this.logger.error(`Failed to verify file: ${objectKey}`, error);
+      throw new InternalServerErrorException('이미지 검증에 실패하였습니다.');
+    }
+  }
+
+  /**
+   * 오래된 프로필 이미지를 S3에서 삭제
+   */
+  private cleanupOldProfileImage(oldImageKey: string): void {
+    // await 하지 않고 사용자 요청은 빠르게 처리될 수 있게 하기
+    void this.objectStorageService.deleteObject(oldImageKey).catch((err) => {
+      this.logger.error(
+        `Failed to delete old profile image: ${oldImageKey}`,
+        err,
+      );
+    });
   }
 }

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -161,7 +161,7 @@ export class UserService implements OnModuleInit, OnModuleDestroy {
 
     // profileImage의 objectKey를 S3 URL로 변환
     if (user.profileImage) {
-      user.profileImage = this.objectStorageService.getPublicUrl(
+      user.profileImage = await this.objectStorageService.createPresignedGetUrl(
         user.profileImage,
       );
     }
@@ -361,9 +361,10 @@ export class UserService implements OnModuleInit, OnModuleDestroy {
 
         // profileImage를 objectKey에서 URL로 변환
         if (savedUser.profileImage) {
-          savedUser.profileImage = this.objectStorageService.getPublicUrl(
-            savedUser.profileImage,
-          );
+          savedUser.profileImage =
+            await this.objectStorageService.createPresignedGetUrl(
+              savedUser.profileImage,
+            );
         }
 
         return savedUser;
@@ -388,9 +389,10 @@ export class UserService implements OnModuleInit, OnModuleDestroy {
 
     // profileImage를 objectKey에서 URL로 변환
     if (userInfo.profileImage) {
-      userInfo.profileImage = this.objectStorageService.getPublicUrl(
-        userInfo.profileImage,
-      );
+      userInfo.profileImage =
+        await this.objectStorageService.createPresignedGetUrl(
+          userInfo.profileImage,
+        );
     }
 
     return userInfo;

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -249,12 +249,7 @@ export class UserService implements OnModuleInit, OnModuleDestroy {
 
   async requestPresignedUrl(userId: number, contentType?: string) {
     // Content-Type 허용 리스트
-    const allowedContentTypes = [
-      'image/jpeg',
-      'image/jpg',
-      'image/png',
-      'image/webp',
-    ];
+    const allowedContentTypes = ['image/jpeg', 'image/png', 'image/webp'];
     const finalContentType = contentType || 'image/jpeg';
 
     if (!allowedContentTypes.includes(finalContentType)) {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -5,6 +5,14 @@ const nextConfig: NextConfig = {
   /* config options here */
   reactCompiler: true,
   output: "standalone",
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "kr.object.ncloudstorage.com",
+      },
+    ],
+  },
 };
 
 export default withSentryConfig(nextConfig, {

--- a/apps/web/src/app/mypage/_components/user-stats-card/user-stats-card.tsx
+++ b/apps/web/src/app/mypage/_components/user-stats-card/user-stats-card.tsx
@@ -1,126 +1,286 @@
 "use client";
-import { User } from "lucide-react";
+import { User, X } from "lucide-react";
+import Image from "next/image";
 import * as React from "react";
+import toast from "react-hot-toast";
+import {
+  editUserAction,
+  EditUserActionState,
+} from "../../_lib/action/edit-user-action";
+import {
+  requestPresignedUrl,
+  uploadToStorage,
+} from "../../_lib/fetch/image-upload";
 
 interface UserStatsCardProps {
   nickname: string;
   email: string;
   consecutiveDayCount: number;
   totalPoint: number;
-  role: string;
+  profileImage: string | null;
 }
 
+const initialState: EditUserActionState = {
+  success: false,
+  message: "",
+  errors: {},
+};
 function UserStatsCard({
   nickname,
   email,
   consecutiveDayCount,
   totalPoint,
-  role,
+  profileImage,
 }: UserStatsCardProps) {
+  const [state, formAction, isPending] = React.useActionState(
+    editUserAction,
+    initialState,
+  );
+
   const [isEditing, setIsEditing] = React.useState(false);
   const [nicknameValue, setNicknameValue] = React.useState(nickname);
-  const [roleValue, setRoleValue] = React.useState(role);
+  const [profileImagePreview, setProfileImagePreview] = React.useState<
+    string | null
+  >(profileImage);
+  const [selectedFile, setSelectedFile] = React.useState<File | null>(null);
+  const [shouldDeleteImage, setShouldDeleteImage] = React.useState(false);
 
-  const onEditClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+
+  const onEditToggle = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    setIsEditing(!isEditing);
+    setIsEditing((prev) => !prev);
   };
 
+  const handleFormAction = async (formData: FormData) => {
+    // server action -> 1MB 이하의 파일만 처리가능
+    // presignedURL 받고 업로드 -> 클라이언트에서
+    // DB 반영 -> server action으로 처리
+    if (shouldDeleteImage) {
+      formData.set("removeImage", "true");
+    } else if (selectedFile) {
+      if (selectedFile.size > 5 * 1024 * 1024) {
+        toast.error("이미지는 5MB 이하만 업로드 가능합니다.");
+        return;
+      }
+
+      const uploadPromise = async () => {
+        const { uploadUrl, objectKey } = await requestPresignedUrl(
+          selectedFile.type,
+        );
+        await uploadToStorage(uploadUrl, selectedFile);
+        return objectKey;
+      };
+
+      try {
+        const objectKey = await uploadPromise();
+
+        formData.set("objectKey", objectKey);
+        formData.delete("profileImage");
+      } catch (error) {
+        console.error(error);
+        return;
+      }
+    }
+
+    React.startTransition(() => {
+      formAction(formData);
+    });
+  };
+
+  const handleRemoveImage = () => {
+    setShouldDeleteImage(true);
+    setProfileImagePreview(null);
+    setSelectedFile(null);
+  };
+
+  const handleImageClick = () => {
+    if (isEditing) {
+      fileInputRef.current?.click();
+    }
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setNicknameValue(nickname);
+    setProfileImagePreview(profileImage);
+    setSelectedFile(null);
+    setShouldDeleteImage(false);
+  };
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setSelectedFile(file);
+      setShouldDeleteImage(false);
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setProfileImagePreview(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  React.useEffect(() => {
+    if (state?.message) {
+      if (state.success) {
+        toast.success(state.message);
+        setIsEditing(false);
+        setSelectedFile(null);
+        setShouldDeleteImage(false);
+      } else {
+        toast.error(state.message);
+      }
+    }
+  }, [state]);
+
   return (
-    <div className="p-8 border border-slate-200 bg-white rounded-[12px] flex justify-between items-center">
-      <div className="flex justify-between gap-6 h-16 ">
-        <div className="rounded-full bg-slate-50 border-neutral-200 p-4 border inset-shadow-2xs">
-          <User className="w-8 h-8" stroke="#CBD5E1" />
-        </div>
-        <div className="flex flex-col gap-1">
-          {isEditing ? (
-            <form action="" className="flex flex-col gap-1">
-              {/*server action 만들어서 연결하기 */}
-              <section className="flex items-center gap-2">
-                <input
-                  name="nickname"
-                  placeholder="닉네임 입력"
-                  value={nicknameValue}
-                  onChange={(e) => setNicknameValue(e.target.value)}
-                  className="text-slate-900 font-bold text-2xl w-auto"
+    <form
+      action={handleFormAction}
+      className="p-8 border border-slate-200 bg-white rounded-[12px] flex flex-col gap-4"
+    >
+      <div className="flex justify-between items-center">
+        <div className="flex justify-between gap-6 h-16">
+          <div className="flex flex-col gap-1">
+            <div
+              className={`relative rounded-full ${profileImagePreview ? "bg-none border-none" : "bg-slate-50 border-neutral-200 border inset-shadow-2xs "}   w-16 h-16 flex items-center justify-center ${isEditing ? "cursor-pointer hover:bg-slate-100" : ""} ${profileImagePreview ? "p-0" : "p-4"}`}
+              onClick={handleImageClick}
+            >
+              {profileImagePreview ? (
+                <Image
+                  src={profileImagePreview}
+                  alt="profileImage"
+                  fill={true}
+                  className="rounded-full object-cover"
                 />
+              ) : (
+                <User className="w-8 h-8" stroke="#CBD5E1" />
+              )}
+              {isEditing && (profileImagePreview || selectedFile) && (
                 <button
-                  onClick={onEditClick}
-                  aria-label="수정 완료"
-                  className="bg-white border border-slate-200 px-2 h-6 flex items-center justify-center rounded-sm"
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleRemoveImage();
+                  }}
+                  className="absolute -bottom-1 -right-2  rounded-full p-1 shadow-md transition-colors"
+                  aria-label="이미지 제거"
                 >
-                  <span className="text-sm text-slate-500 font-medium">
-                    수정 완료
-                  </span>
+                  <X className="w-3 h-3 text-slate-600" />
                 </button>
-              </section>
-              <section>
-                <div className="flex gap-4 items-center">
-                  <div className="text-slate-900 font-semibold text-base">
-                    {email}
+              )}
+            </div>
+          </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            onChange={handleImageChange}
+            className="hidden"
+            name="profileImage"
+          />
+
+          <div className="flex flex-col gap-1">
+            {isEditing ? (
+              <>
+                <section className="flex flex-col gap-1">
+                  <div className="flex items-center gap-2">
+                    <input
+                      name="nickname"
+                      placeholder="닉네임 입력"
+                      value={nicknameValue}
+                      onChange={(e) => setNicknameValue(e.target.value)}
+                      className="text-slate-900 font-bold text-2xl w-auto border pl-1 border-teal-500 focus:border-teal-600 focus:outline-none rounded"
+                      autoFocus
+                      maxLength={20}
+                    />
+                    <button
+                      type="submit"
+                      disabled={isPending}
+                      className="bg-white border border-slate-200 px-2 h-6 flex items-center justify-center rounded-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      <span className="text-sm text-slate-500 font-medium">
+                        {isPending ? "수정 중..." : "수정 완료"}
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleCancel}
+                      aria-label="취소"
+                      className="bg-white border border-slate-200 px-2 h-6 flex items-center justify-center rounded-sm"
+                    >
+                      <span className="text-sm text-slate-500 font-medium">
+                        취소
+                      </span>
+                    </button>
                   </div>
-                  <input
-                    name="role"
-                    placeholder="역할 입력"
-                    value={roleValue}
-                    onChange={(e) => setRoleValue(e.target.value)}
-                    className="bg-slate-100 rounded-sm p-1 text-slate-500 font-bold text-base w-auto "
-                  />
-                </div>
-              </section>
-            </form>
-          ) : (
-            <>
-              <section className="flex items-center gap-2">
-                <div className="text-slate-900 font-bold text-2xl">
-                  {nicknameValue}
-                </div>
-                {/* <button
-                  onClick={onEditClick}
-                  aria-label="닉네임 편집"
-                  className="bg-white border border-slate-200 px-2 h-6 flex items-center justify-center rounded-sm"
-                >
-                  <Pencil className="w-3 h-3" stroke="#94A3B8" />
-                </button> */}
-              </section>
-              <section>
-                <div className="flex gap-4 items-center">
-                  <div className="text-slate-900 font-semibold text-base">
-                    {email}
+                </section>
+
+                <section>
+                  <div className="flex gap-4 items-center">
+                    <div className="text-slate-900 font-semibold text-base">
+                      {email}
+                    </div>
                   </div>
-                  {/* <div className="bg-slate-100 rounded-sm p-1 text-slate-500 font-bold text-base">
-                    {roleValue}
-                  </div> */}
-                </div>
-              </section>
-            </>
-          )}
+                </section>
+              </>
+            ) : (
+              <>
+                <section className="flex items-center gap-2">
+                  <div className="text-slate-900 font-bold text-2xl">
+                    {nicknameValue}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={onEditToggle}
+                    aria-label="닉네임 편집"
+                    className="bg-white border border-slate-200 px-2 h-6 flex items-center justify-center rounded-sm"
+                  >
+                    <span className="text-sm text-slate-500 font-medium">
+                      수정
+                    </span>
+                  </button>
+                </section>
+
+                <section>
+                  <div className="flex gap-4 items-center">
+                    <div className="text-slate-900 font-semibold text-base">
+                      {email}
+                    </div>
+                  </div>
+                </section>
+              </>
+            )}
+          </div>
         </div>
-      </div>
-      <div className="flex px-4 py-2 bg-teal-50 rounded-xl items-center gap-3">
-        <div className="flex flex-col items-center p-3">
-          <span className="text-sm text-slate-500 font-semibold">
-            연속 학습일
-          </span>
-          <div className="flex gap-1">
-            <span className="font-bold text-teal-600">
-              {consecutiveDayCount}
+
+        <div className="flex px-4 py-2 bg-teal-50 rounded-xl items-center gap-3">
+          <div className="flex flex-col items-center p-3">
+            <span className="text-sm text-slate-500 font-semibold">
+              연속 학습일
             </span>
-            <span className="font-medium text-slate-500">일째</span>
+            <div className="flex gap-1">
+              <span className="font-bold text-teal-600">
+                {consecutiveDayCount}
+              </span>
+              <span className="font-medium text-slate-500">일째</span>
+            </div>
           </div>
-        </div>
-        <hr className="w-px h-9 bg-slate-200" />
-        <div className="flex flex-col items-center p-3">
-          <span className="text-sm text-slate-500 font-semibold">
-            해결한 문제
-          </span>
-          <div className="flex gap-1">
-            <span className="font-bold text-teal-600">{totalPoint}</span>
-            <span className="font-medium text-slate-500">개</span>
+
+          <hr className="w-px h-9 bg-slate-200" />
+
+          <div className="flex flex-col items-center p-3">
+            <span className="text-sm text-slate-500 font-semibold">
+              해결한 문제
+            </span>
+            <div className="flex gap-1">
+              <span className="font-bold text-teal-600">{totalPoint}</span>
+              <span className="font-medium text-slate-500">개</span>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </form>
   );
 }
 

--- a/apps/web/src/app/mypage/_components/user-stats-card/user-stats-card.tsx
+++ b/apps/web/src/app/mypage/_components/user-stats-card/user-stats-card.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { User, X } from "lucide-react";
+import { Pencil, User, X } from "lucide-react";
 import Image from "next/image";
 import * as React from "react";
 import toast from "react-hot-toast";
@@ -118,6 +118,11 @@ function UserStatsCard({
       reader.onloadend = () => {
         setProfileImagePreview(reader.result as string);
       };
+      reader.onerror = () => {
+        toast.error("이미지를 읽는데 실패하였습니다.");
+        setSelectedFile(null);
+      };
+
       reader.readAsDataURL(file);
     }
   };
@@ -152,7 +157,7 @@ function UserStatsCard({
                   src={profileImagePreview}
                   alt="profileImage"
                   fill={true}
-                  className="rounded-full object-cover"
+                  className="rounded-full object-cover "
                 />
               ) : (
                 <User className="w-8 h-8" stroke="#CBD5E1" />
@@ -168,6 +173,19 @@ function UserStatsCard({
                   aria-label="이미지 제거"
                 >
                   <X className="w-3 h-3 text-slate-600" />
+                </button>
+              )}
+              {isEditing && !profileImagePreview && !selectedFile && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    fileInputRef.current?.click();
+                  }}
+                  className="absolute -bottom-1 -right-2  rounded-full p-1 shadow-md transition-colors"
+                  aria-label="이미지 추가"
+                >
+                  <Pencil className="w-3 h-3 text-slate-600" />
                 </button>
               )}
             </div>

--- a/apps/web/src/app/mypage/_components/user-stats-card/user-stats-card.tsx
+++ b/apps/web/src/app/mypage/_components/user-stats-card/user-stats-card.tsx
@@ -79,6 +79,7 @@ function UserStatsCard({
         formData.delete("profileImage");
       } catch (error) {
         console.error(error);
+        toast.error("이미지 업로드에 실패하였습니다.");
         return;
       }
     }

--- a/apps/web/src/app/mypage/_lib/action/edit-user-action.ts
+++ b/apps/web/src/app/mypage/_lib/action/edit-user-action.ts
@@ -1,0 +1,91 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { editUserInfo } from "../fetch/fetch-user-info";
+
+export interface EditUserActionState {
+  success: boolean;
+  message: string;
+  errors?: {
+    nickname?: string[];
+    profileImage?: string[];
+  };
+}
+
+const VALIDATION = {
+  NICKNAME: {
+    MIN_LENGTH: 1,
+    MAX_LENGTH: 20,
+  },
+} as const;
+
+async function editUserAction(
+  _prevState: EditUserActionState | null,
+  formData: FormData,
+): Promise<EditUserActionState> {
+  try {
+    const nickname = formData.get("nickname");
+    const removeImage = formData.get("removeImage");
+    const objectKeyFromClient = formData.get("objectKey");
+
+    const nicknameValue =
+      nickname && typeof nickname === "string" ? nickname.trim() : undefined;
+    const shouldRemoveImage = removeImage === "true";
+    const newObjectKey =
+      objectKeyFromClient && typeof objectKeyFromClient === "string"
+        ? objectKeyFromClient
+        : undefined;
+
+    if (!nicknameValue && !newObjectKey && !shouldRemoveImage) {
+      return {
+        success: false,
+        message: "변경할 정보를 입력해주세요.",
+      };
+    }
+
+    if (nicknameValue) {
+      if (
+        nicknameValue.length < VALIDATION.NICKNAME.MIN_LENGTH ||
+        nicknameValue.length > VALIDATION.NICKNAME.MAX_LENGTH
+      ) {
+        return {
+          success: false,
+          message: "입력값을 확인해주세요.",
+          errors: {
+            nickname: [
+              `닉네임은 ${VALIDATION.NICKNAME.MIN_LENGTH}-${VALIDATION.NICKNAME.MAX_LENGTH}자 사이여야 합니다.`,
+            ],
+          },
+        };
+      }
+    }
+
+    let objectKey: string | null | undefined;
+    if (shouldRemoveImage) {
+      objectKey = null;
+    } else if (newObjectKey) {
+      objectKey = newObjectKey;
+    }
+
+    await editUserInfo({
+      nickname: nicknameValue,
+      objectKey: objectKey,
+    });
+    revalidatePath("/mypage");
+    return {
+      success: true,
+      message: shouldRemoveImage
+        ? "프로필 이미지가 삭제되었습니다."
+        : "프로필이 성공적으로 업데이트되었습니다.",
+    };
+  } catch (error) {
+    console.error("Edit user action error:", error);
+
+    return {
+      success: false,
+      message: "프로필 업데이트 중 오류가 발생했습니다.",
+    };
+  }
+}
+
+export { editUserAction };

--- a/apps/web/src/app/mypage/_lib/action/edit-user-action.ts
+++ b/apps/web/src/app/mypage/_lib/action/edit-user-action.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { ApiError } from "@/lib/api-error";
 import { revalidatePath } from "next/cache";
 import { editUserInfo } from "../fetch/fetch-user-info";
 
@@ -80,6 +81,12 @@ async function editUserAction(
     };
   } catch (error) {
     console.error("Edit user action error:", error);
+    if (error instanceof ApiError) {
+      return {
+        success: false,
+        message: error.getUserMessage(),
+      };
+    }
 
     return {
       success: false,

--- a/apps/web/src/app/mypage/_lib/fetch/fetch-user-info.ts
+++ b/apps/web/src/app/mypage/_lib/fetch/fetch-user-info.ts
@@ -1,5 +1,5 @@
-import { apiGet } from "@/lib/api-client";
-import { UserInfoDTO } from "../../_types/user-info-dto";
+import { apiGet, apiPatch } from "@/lib/api-client";
+import { EditUserRequestDTO, UserInfoDTO } from "../../_types/user-info-dto";
 
 async function fetchUserInfo(): Promise<UserInfoDTO> {
   try {
@@ -10,4 +10,22 @@ async function fetchUserInfo(): Promise<UserInfoDTO> {
   }
 }
 
-export { fetchUserInfo };
+async function editUserInfo({
+  nickname,
+  objectKey,
+}: EditUserRequestDTO): Promise<UserInfoDTO | void> {
+  if (!nickname && objectKey === undefined) return;
+
+  try {
+    const body: Partial<EditUserRequestDTO> = {};
+    if (nickname !== undefined) body.nickname = nickname;
+    if (objectKey !== undefined) body.objectKey = objectKey;
+
+    return await apiPatch<UserInfoDTO>("/api/users/me", body);
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+}
+
+export { editUserInfo, fetchUserInfo };

--- a/apps/web/src/app/mypage/_lib/fetch/image-upload.ts
+++ b/apps/web/src/app/mypage/_lib/fetch/image-upload.ts
@@ -4,12 +4,7 @@ import { PresignedUrlDto } from "../../_types/presigned-url-dto";
 async function requestPresignedUrl(
   imageType: string,
 ): Promise<PresignedUrlDto> {
-  const allowedContentTypes = [
-    "image/jpeg",
-    "image/jpg",
-    "image/png",
-    "image/webp",
-  ];
+  const allowedContentTypes = ["image/jpeg", "image/png", "image/webp"];
   if (!allowedContentTypes.includes(imageType))
     throw new Error("허용되지 않는 데이터타입입니다.");
 

--- a/apps/web/src/app/mypage/_lib/fetch/image-upload.ts
+++ b/apps/web/src/app/mypage/_lib/fetch/image-upload.ts
@@ -1,0 +1,43 @@
+import { apiPost } from "@/lib/api-client";
+import { PresignedUrlDto } from "../../_types/presigned-url-dto";
+
+async function requestPresignedUrl(
+  imageType: string,
+): Promise<PresignedUrlDto> {
+  const allowedContentTypes = [
+    "image/jpeg",
+    "image/jpg",
+    "image/png",
+    "image/webp",
+  ];
+  if (!allowedContentTypes.includes(imageType))
+    throw new Error("허용되지 않는 데이터타입입니다.");
+
+  try {
+    return await apiPost<PresignedUrlDto>("/api/users/presigned-url", {
+      contentType: imageType,
+    });
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+}
+
+async function uploadToStorage(
+  uploadUrl: string,
+  imageBlob: Blob,
+): Promise<void> {
+  const response = await fetch(uploadUrl, {
+    method: "PUT",
+    headers: {
+      "Content-Type": imageBlob.type,
+    },
+    body: imageBlob,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to upload to storage: ${response.status}`);
+  }
+}
+
+export { requestPresignedUrl, uploadToStorage };

--- a/apps/web/src/app/mypage/_types/presigned-url-dto.ts
+++ b/apps/web/src/app/mypage/_types/presigned-url-dto.ts
@@ -1,0 +1,5 @@
+export interface PresignedUrlDto {
+  uploadUrl: string;
+  objectKey: string;
+  expiresIn: number;
+}

--- a/apps/web/src/app/mypage/_types/user-info-dto.ts
+++ b/apps/web/src/app/mypage/_types/user-info-dto.ts
@@ -1,9 +1,15 @@
 export interface UserInfoDTO {
   id: number;
   nickname: string;
+  email: string;
   role: string;
   totalPoint: number;
   totalScore: number;
   createdAt: string;
-  email?: string;
+  profileImage: string | null;
+}
+
+export interface EditUserRequestDTO {
+  nickname?: string;
+  objectKey?: string | null;
 }

--- a/apps/web/src/app/mypage/page.tsx
+++ b/apps/web/src/app/mypage/page.tsx
@@ -39,7 +39,7 @@ async function MyPage() {
         nickname={userData.nickname}
         email={userData.email || "@test123"} // 추후 작업에서 해당 부분 email 리턴하도록 수정 필요.
         totalPoint={totalCount}
-        role={userData.role}
+        profileImage={userData.profileImage}
         consecutiveDayCount={consecutiveDayCount}
       />
       <Tabs className="w-full" defaultValue="graph">

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -142,6 +142,26 @@ export async function apiPut<T>(endpoint: string, body?: unknown): Promise<T> {
 }
 
 /**
+ * PATCH 요청 헬퍼
+ */
+export async function apiPatch<T>(
+  endpoint: string,
+  body?: unknown,
+): Promise<T> {
+  logger.info(`PATCH ${endpoint} API 호출`);
+  const response = await apiClient(endpoint, {
+    method: "PATCH",
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!response.ok) {
+    await handleErrorResponse(response);
+  }
+
+  return response.json();
+}
+
+/**
  * DELETE 요청 헬퍼
  */
 export async function apiDelete<T>(endpoint: string): Promise<T> {


### PR DESCRIPTION
## 🔸 작업 내용
- #292
- 마이페이지에서 프로필 이미지 업로드할 수 있도록 수정
- 프로필 업로드시 Object Storage에 이미지 형태로 저장
- 새로운 이미지 업로드시 기존 Object Storage에 있는 객체 삭제
- 마이페이지 수정시 toast 메시지 띄우기
- PATCH용 유틸 헬퍼 추가

## 🔸 고민 했던 부분
### 프로필 이미지 삭제
- 프로필 이미지를 삭제하기 위한 방법을 고민하였습니다.
- DB에서 Object Key를 저장하고 있기 때문에 기존과 달라진 경우 삭제하는 시퀀스를 생각하고 진행하였습니다.
- 이때 Object Storage에서 해당 이미지 삭제가 실패하였더라도 프로필 이미지는 정상적으로 바뀌었기 때문에 따로 응답을 기다리지 않은채 삭제 요청만 보내는 식으로 진행하였습니다.
```mermaid
sequenceDiagram
    participant Client
    participant UserService
    participant Database
    participant ObjectStorage

    Client->>UserService: editUser(userId, { objectKey: null })
    activate UserService
    
    Note right of UserService: 1. 기존 유저 정보 조회
    UserService->>Database: findOneById(userId)
    Database-->>UserService: User Entity (oldImageKey 포함)
    
    Note right of UserService: 2. DB 업데이트
    UserService->>Database: save(profileImage = null)
    Database-->>UserService: Updated User Entity

    Note right of UserService: 3. 기존 이미지 비동기 삭제
    rect rgb(240, 248, 255)
        UserService-)ObjectStorage: deleteObject(oldImageKey)
    end

    UserService-->>Client: Updated User 반환
    deactivate UserService
```

### Next.config.ts 수정
- 파일을 전송할 때 계속해서 1MB Limit이 발생하는 문제를 마주쳤습니다.
- 해당 에러를 파악해보니 Server Action에서 사용하는 body 의 최대값이 1MB였습니다. (서버리소스 과부하 막고 Ddos 공격 막기위함)
- 따라서 기존에 server action에서 presigned URL을 발급받고 -> 이미지 업로드 -> Patch('/me') 요청 보내는 부분을 분리하였습니다.
- 브라우저에서 presigned URL발급 및 이미지 업로드를 진행하고, server action에서는 Patch('me') 요청을 보내도록 수정하였습니다.
- Next의 Image 컴포넌트 사용시 외부 이미지 사용이 거부됩니다.
- 이에 따라 images 설정을 추가하였고, remotePattern 설정을 통해 ncloudstorage의 호스트를 지정하여 문제를 해결하였습니다.


## 🔸 참고
### 이미지 및 닉네임 추가
![화면 기록 2026-01-28 오전 2 29 59](https://github.com/user-attachments/assets/c32e83f2-1abe-48bb-bad0-b46d5a465f37)

### 이미지 삭제
![화면 기록 2026-01-28 오전 2 30 52](https://github.com/user-attachments/assets/191e10af-3abe-474d-95c9-2c0c8b64142b)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 프로필 이미지 업로드를 위한 사전 서명 URL 발급 및 저장소 업로드 흐름 추가
  * 마이페이지에서 닉네임 및 프로필 이미지 편집(업로드/미리보기/삭제) 가능
  * 사용자 공개 정보에 프로필 이미지(URL) 노출 지원 및 즉시 반영(revalidate)

* **수정**
  * 이미지 원격 로드 허용 설정 추가(외부 스토리지 호스트)

* **잡일(Chores)**
  * 데이터베이스 스키마 관련 마이그레이션 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->