### PR TITLE
feat: 다른 유저 답변 페이지 API 연동하기

### DIFF
--- a/apps/web/src/app/daily/questions/[questionId]/others/[submissionId]/page.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/others/[submissionId]/page.tsx
@@ -1,37 +1,51 @@
 import { User } from "lucide-react";
+import { notFound } from "next/navigation";
+import { fetchOthersSubmission } from "../_lib/fetch-others-submission";
+import formatSubmittedAt from "../_lib/format-submitted-at";
 
-const selectedAttempt = {
-  answerContent:
-    "브라우저 주소창에 www.google.com을 입력하고 엔터를 누르면 먼저 브라우저는 URL을 해석해 프로토콜과 호스트를 분리하고, 로컬 캐시·OS 캐시·라우터 캐시·DNS 서버 순으로 도메인에 대한 IP 주소를 질의해 DNS 해석을 수행한 뒤 해당 IP로 TCP 3-way 핸드셰이크를 맺고 HTTPS인 경우 TLS 핸드셰이크로 암호화 채널을 수립하며, 이후 HTTP 요청을 전송하면 서버는 HTML 문서를 응답으로 반환하고 브라우저는 이를 수신하는 즉시 HTML을 위에서 아래로 파싱하면서 DOM 트리를 구성하고 동시에 CSS를 다운로드·파싱해 CSSOM을 만들며, DOM과 CSSOM이 결합되어 렌더 트리가 생성된 다음 레이아웃 단계에서 각 노드의 위치와 크기를 계산하고 페인팅 단계에서 픽셀로 그린 뒤, 자바스크립트가 있다면 파싱·실행되면서 DOM이나 스타일을 변경할 수 있어 필요 시 리플로우와 리페인트가 발생하고, 이 모든 과정이 메인 스레드와 보조 스레드에서 병렬적으로 처리되며 최종적으로 사용자가 화면을 보게 됩니다.",
+const parseIntOrNull = (value: string | undefined): number | null => {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
 };
 
-const question = {
-  category: {
-    name: "Browser Rendering",
-    parent: {
-      name: "Web",
-    },
-  },
-  title: "웹 페이지 로딩의 여정",
-  description:
-    "브라우저 주소창에 www.google.com을 입력하고 엔터를 쳤을 때, 화면이 렌더링되기까지의 과정을 네트워크와 브라우저 렌더링 관점에서 설명해주세요.",
-};
+interface OthersSubmissionDetailPageProps {
+  params: Promise<{ questionId: string; submissionId: string }>;
+}
 
-const keywords = ["hello", "world"];
+async function OthersDetailPage({ params }: OthersSubmissionDetailPageProps) {
+  const { questionId, submissionId } = await params;
 
-function OthersDetailPage() {
+  const parsedQuestionId = parseIntOrNull(questionId);
+  const parsedSubmissionId = parseIntOrNull(submissionId);
+
+  if (!parsedQuestionId || !parsedSubmissionId) {
+    return notFound();
+  }
+
+  const othersSubmissionData = await fetchOthersSubmission({
+    questionId: parsedQuestionId,
+    submissionId: parsedSubmissionId,
+  });
+
   return (
     <main className="w-full max-w-4xl mx-auto px-8 py-15 space-y-8 min-h-main">
       <div className="mb-8">
         <div className="flex items-center gap-2 text-base text-muted-foreground mb-2">
-          <span className="font-medium">{question.category.parent.name}</span>
+          <span className="font-medium">
+            {othersSubmissionData.question.category?.parent?.name}
+          </span>
           <span>/</span>
           <span className="text-base font-medium">
-            {question.category.name}
+            {othersSubmissionData.question.category?.name}
           </span>
         </div>
-        <h1 className="text-2xl font-bold mb-2">{question.title}</h1>
-        <p className="text-muted-foreground">{question.description}</p>
+        <h1 className="text-2xl font-bold mb-2">
+          {othersSubmissionData.question.title}
+        </h1>
+        <p className="text-muted-foreground">
+          {othersSubmissionData.question.content}
+        </p>
       </div>
       <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
         <div className="p-9 bg-white">
@@ -41,9 +55,14 @@ function OthersDetailPage() {
                 <User className="w-8 h-8" stroke="#CBD5E1" />
               </div>
               <div className="flex flex-col">
-                <div className="text-lg font-semibold">user_1002</div>
+                <div className="text-lg font-semibold">
+                  {othersSubmissionData.nickname}
+                </div>
                 <div className="text-sm font-medium text-muted-foreground">
-                  제출 일시: 2025년 10월 20일
+                  제출 일시:{" "}
+                  {formatSubmittedAt(
+                    othersSubmissionData.submission.submittedAt,
+                  )}
                 </div>
               </div>
             </div>
@@ -58,9 +77,9 @@ function OthersDetailPage() {
               </h3>
             </div>
           </div>
-          {selectedAttempt.answerContent ? (
+          {othersSubmissionData.submission.answerContent ? (
             <p className="text-base leading-relaxed text-slate-700 whitespace-pre-wrap border-y border-slate-200 py-6">
-              {selectedAttempt.answerContent}
+              {othersSubmissionData.submission.answerContent}
             </p>
           ) : (
             <p className="py-4 text-sm text-center text-slate-400">
@@ -68,13 +87,13 @@ function OthersDetailPage() {
             </p>
           )}
 
-          {keywords.length > 0 && (
+          {othersSubmissionData.keywords.length > 0 && (
             <div className="mt-6">
               <h4 className="font-semibold text-sm text-slate-400 uppercase tracking-wider mb-3">
                 CORE KEYWORDS
               </h4>
               <div className="flex flex-wrap items-center gap-2">
-                {keywords.map((keyword, index) => (
+                {othersSubmissionData.keywords.map((keyword, index) => (
                   <span
                     key={index}
                     className="px-2 py-1.5 bg-slate-100 text-slate-700 text-sm font-medium rounded-md"

--- a/apps/web/src/app/daily/questions/[questionId]/others/[submissionId]/page.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/others/[submissionId]/page.tsx
@@ -67,7 +67,10 @@ async function OthersDetailPage({ params }: OthersSubmissionDetailPageProps) {
               </div>
             </div>
             <div className="px-4 py-2 rounded-md bg-teal-50 border border-teal-100 text-teal-500 font-semibold gap-1 text-2xl">
-              <span className="font-extrabold">60</span>점
+              <span className="font-extrabold">
+                {othersSubmissionData.submission.totalScore}
+              </span>
+              점
             </div>
           </div>
           <div className="flex justify-between items-center mb-6">

--- a/apps/web/src/app/daily/questions/[questionId]/others/[submissionId]/page.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/others/[submissionId]/page.tsx
@@ -4,9 +4,11 @@ import { fetchOthersSubmission } from "../_lib/fetch-others-submission";
 import formatSubmittedAt from "../_lib/format-submitted-at";
 
 const parseIntOrNull = (value: string | undefined): number | null => {
-  if (!value) return null;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
+  if (value === undefined) return null;
+  const trimmed = value.trim();
+  if (!/^-?\d+$/.test(trimmed)) return null;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) && Number.isInteger(parsed) ? parsed : null;
 };
 
 interface OthersSubmissionDetailPageProps {
@@ -19,7 +21,7 @@ async function OthersDetailPage({ params }: OthersSubmissionDetailPageProps) {
   const parsedQuestionId = parseIntOrNull(questionId);
   const parsedSubmissionId = parseIntOrNull(submissionId);
 
-  if (!parsedQuestionId || !parsedSubmissionId) {
+  if (parsedQuestionId === null || parsedSubmissionId === null) {
     return notFound();
   }
 

--- a/apps/web/src/app/daily/questions/[questionId]/others/_lib/fetch-others-submission.ts
+++ b/apps/web/src/app/daily/questions/[questionId]/others/_lib/fetch-others-submission.ts
@@ -1,0 +1,21 @@
+import { apiGet } from "@/lib/api-client";
+import { OthersSubmissionDTO } from "../_types/types";
+
+interface FetchOthersSubmissionsParams {
+  questionId: number;
+  submissionId: number;
+}
+
+async function fetchOthersSubmission(
+  params: FetchOthersSubmissionsParams,
+): Promise<OthersSubmissionDTO> {
+  const searchParams = new URLSearchParams();
+  const queryString = searchParams.toString();
+  const endpoint = `/questions/${params.questionId}/others/${params.submissionId}`;
+  const url = `${endpoint}${queryString ? `?${queryString}` : ""}`;
+
+  return apiGet<OthersSubmissionDTO>(url);
+}
+
+export { fetchOthersSubmission };
+export type { FetchOthersSubmissionsParams };

--- a/apps/web/src/app/daily/questions/[questionId]/others/_lib/fetch-others-submissions.ts
+++ b/apps/web/src/app/daily/questions/[questionId]/others/_lib/fetch-others-submissions.ts
@@ -11,10 +11,10 @@ async function fetchOthersSubmissions(
   params: FetchOthersSubmissionsParams,
 ): Promise<PaginatedSubmissionDTO> {
   const searchParams = new URLSearchParams();
-  if (params.page) {
+  if (params.page !== undefined) {
     searchParams.set("page", params.page.toString());
   }
-  if (params.size) {
+  if (params.size !== undefined) {
     searchParams.set("size", params.size.toString());
   }
 

--- a/apps/web/src/app/daily/questions/[questionId]/others/_lib/fetch-others-submissions.ts
+++ b/apps/web/src/app/daily/questions/[questionId]/others/_lib/fetch-others-submissions.ts
@@ -1,0 +1,29 @@
+import { apiGet } from "@/lib/api-client";
+import { PaginatedSubmissionDTO } from "../_types/types";
+
+interface FetchOthersSubmissionsParams {
+  page?: number;
+  size?: number;
+  questionId: number;
+}
+
+async function fetchOthersSubmissions(
+  params: FetchOthersSubmissionsParams,
+): Promise<PaginatedSubmissionDTO> {
+  const searchParams = new URLSearchParams();
+  if (params.page) {
+    searchParams.set("page", params.page.toString());
+  }
+  if (params.size) {
+    searchParams.set("size", params.size.toString());
+  }
+
+  const queryString = searchParams.toString();
+  const endpoint = `/questions/${params.questionId}/others`;
+  const url = `${endpoint}${queryString ? `?${queryString}` : ""}`;
+
+  return apiGet<PaginatedSubmissionDTO>(url);
+}
+
+export { fetchOthersSubmissions };
+export type { FetchOthersSubmissionsParams };

--- a/apps/web/src/app/daily/questions/[questionId]/others/_lib/format-submitted-at.ts
+++ b/apps/web/src/app/daily/questions/[questionId]/others/_lib/format-submitted-at.ts
@@ -1,7 +1,17 @@
 function formatSubmittedAt(dateString: string) {
   const date = new Date(dateString);
+
+  if (isNaN(date.getTime())) {
+    return "알 수 없음";
+  }
+
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
+
+  if (diffMs < 0) {
+    return "방금 전";
+  }
+
   const diffMinutes = Math.floor(diffMs / (1000 * 60));
   const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));

--- a/apps/web/src/app/daily/questions/[questionId]/others/_lib/format-submitted-at.ts
+++ b/apps/web/src/app/daily/questions/[questionId]/others/_lib/format-submitted-at.ts
@@ -1,0 +1,24 @@
+function formatSubmittedAt(dateString: string) {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMinutes = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMinutes < 60) {
+    return `${diffMinutes}분 전`;
+  } else if (diffHours < 24) {
+    return `${diffHours}시간 전`;
+  } else if (diffDays < 7) {
+    return `${diffDays}일 전`;
+  } else {
+    return date.toLocaleDateString("ko-KR", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  }
+}
+
+export default formatSubmittedAt;

--- a/apps/web/src/app/daily/questions/[questionId]/others/_types/types.ts
+++ b/apps/web/src/app/daily/questions/[questionId]/others/_types/types.ts
@@ -1,0 +1,56 @@
+export interface Category {
+  id: number;
+  name: string;
+  depth: number;
+  parentId: number | null;
+  parent?: Category;
+  children?: Category[];
+}
+
+export interface Question {
+  id: number;
+  title: string;
+  content: string;
+  ttsUrl: string | null;
+  avgScore: number;
+  avgImportance: number;
+  categoryId: number;
+  category?: Category;
+  score: number | null;
+}
+
+export interface Submission {
+  submissionId: number;
+  nickname: string;
+  totalScore: number;
+  submittedAt: string;
+}
+
+export interface OthersSubmissionDetail {
+  id: number;
+  questionId: number;
+  submittedAt: string;
+  audioAssetId: number;
+  evaluationStatus: string;
+  sttStatus: string;
+  inputType: string;
+  answerContent: string;
+  totalScore: number;
+  duration: number;
+}
+
+export interface PaginatedSubmissionDTO {
+  question: Question;
+  submissions: Submission[];
+  totalCount: number;
+  pageSize: number;
+  currentPage: number;
+  totalPages: number;
+}
+
+export interface OthersSubmissionDTO {
+  nickname: string;
+  question: Question;
+  submission: OthersSubmissionDetail;
+  keywords: string[];
+}

--- a/apps/web/src/app/daily/questions/[questionId]/others/page.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/others/page.tsx
@@ -16,120 +16,10 @@ import {
 } from "@/components/table/table";
 import { User } from "lucide-react";
 import Link from "next/link";
-
-// 목 데이터 타입
-interface Submission {
-  id: number;
-  user: {
-    id: number;
-    nickname: string;
-    avatarUrl?: string;
-  };
-  score: number;
-  submittedAt: string;
-}
-
-interface QuestionInfo {
-  id: number;
-  title: string;
-  category: {
-    id: number;
-    name: string;
-    parent: {
-      id: number;
-      name: string;
-    };
-  };
-}
-
-// 목 데이터 생성
-const mockQuestion: QuestionInfo = {
-  id: 1,
-  title: "REST API와 GraphQL의 차이점을 설명해주세요.",
-  category: {
-    id: 2,
-    name: "API 설계",
-    parent: {
-      id: 1,
-      name: "백엔드",
-    },
-  },
-};
-
-const mockSubmissions: Submission[] = [
-  {
-    id: 1,
-    user: { id: 1, nickname: "김철수" },
-    score: 95,
-    submittedAt: "2025-01-27T10:30:00Z",
-  },
-  {
-    id: 2,
-    user: { id: 2, nickname: "이영희" },
-    score: 88,
-    submittedAt: "2025-01-27T09:15:00Z",
-  },
-  {
-    id: 3,
-    user: { id: 3, nickname: "박민수" },
-    score: 92,
-    submittedAt: "2025-01-26T14:20:00Z",
-  },
-  {
-    id: 4,
-    user: { id: 4, nickname: "최지은" },
-    score: 78,
-    submittedAt: "2025-01-26T11:45:00Z",
-  },
-  {
-    id: 5,
-    user: { id: 5, nickname: "정하늘" },
-    score: 85,
-    submittedAt: "2025-01-25T16:30:00Z",
-  },
-  {
-    id: 6,
-    user: { id: 6, nickname: "강우진" },
-    score: 91,
-    submittedAt: "2025-01-25T13:00:00Z",
-  },
-  {
-    id: 7,
-    user: { id: 7, nickname: "윤서연" },
-    score: 82,
-    submittedAt: "2025-01-24T17:45:00Z",
-  },
-  {
-    id: 8,
-    user: { id: 8, nickname: "임동현" },
-    score: 76,
-    submittedAt: "2025-01-24T10:20:00Z",
-  },
-  {
-    id: 9,
-    user: { id: 9, nickname: "한소희" },
-    score: 89,
-    submittedAt: "2025-01-23T15:10:00Z",
-  },
-  {
-    id: 10,
-    user: { id: 10, nickname: "조민재" },
-    score: 94,
-    submittedAt: "2025-01-23T09:30:00Z",
-  },
-  {
-    id: 11,
-    user: { id: 11, nickname: "서지훈" },
-    score: 87,
-    submittedAt: "2025-01-22T14:00:00Z",
-  },
-  {
-    id: 12,
-    user: { id: 12, nickname: "노은비" },
-    score: 80,
-    submittedAt: "2025-01-22T11:30:00Z",
-  },
-];
+import { fetchOthersSubmissions } from "./_lib/fetch-others-submissions";
+import formatSubmittedAt from "./_lib/format-submitted-at";
+import parseIntOrNull from "@/lib/parse-int-or-null";
+import { notFound } from "next/navigation";
 
 interface OthersPageProps {
   params: Promise<{ questionId: string }>;
@@ -140,15 +30,26 @@ async function OthersPage({ params, searchParams }: OthersPageProps) {
   const { questionId } = await params;
   const { page } = await searchParams;
 
+  const parsedQuestionId = parseIntOrNull(questionId);
+  const parsedPage = parseIntOrNull(page) ?? 1;
+
+  if (!parsedQuestionId) {
+    return notFound();
+  }
+
+  const submissionsData = await fetchOthersSubmissions({
+    questionId: parsedQuestionId,
+    page: parsedPage,
+  });
+
   // 목 데이터 사용 (실제로는 API 호출)
-  const question = mockQuestion;
-  const allSubmissions = mockSubmissions;
+  const question = submissionsData.question;
+  const allSubmissions = submissionsData.submissions;
 
   const pageSize = 10;
   const totalCount = allSubmissions.length;
   const totalPages = Math.ceil(totalCount / pageSize);
 
-  const parsedPage = page ? parseInt(page, 10) : 1;
   const currentPage =
     Number.isFinite(parsedPage) && parsedPage >= 1 ? parsedPage : 1;
 
@@ -165,37 +66,14 @@ async function OthersPage({ params, searchParams }: OthersPageProps) {
     return `/daily/questions/${questionId}/others?${params.toString()}`;
   };
 
-  const formatSubmittedAt = (dateString: string) => {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMinutes = Math.floor(diffMs / (1000 * 60));
-    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-    if (diffMinutes < 60) {
-      return `${diffMinutes}분 전`;
-    } else if (diffHours < 24) {
-      return `${diffHours}시간 전`;
-    } else if (diffDays < 7) {
-      return `${diffDays}일 전`;
-    } else {
-      return date.toLocaleDateString("ko-KR", {
-        year: "numeric",
-        month: "long",
-        day: "numeric",
-      });
-    }
-  };
-
   return (
     <main className="w-full max-w-4xl mx-auto px-8 py-15 space-y-8 min-h-main">
       <div className="mb-8">
         <div className="flex items-center gap-2 text-base text-muted-foreground mb-2">
-          <span className="font-medium">{question.category.parent.name}</span>
+          <span className="font-medium">{question.category?.parent?.name}</span>
           <span>/</span>
           <span className="text-base font-medium">
-            {question.category.name}
+            {question.category?.name}
           </span>
         </div>
         <h1 className="text-2xl font-bold mb-2">{question.title}</h1>
@@ -226,14 +104,14 @@ async function OthersPage({ params, searchParams }: OthersPageProps) {
             </TableRow>
           ) : (
             submissions.map((submission) => (
-              <TableRow key={submission.id}>
+              <TableRow key={submission.submissionId}>
                 <TableCell>
                   <div className="flex items-center gap-3">
                     <div className="w-10 h-10 rounded-full bg-slate-100 flex items-center justify-center">
                       <User className="w-5 h-5 text-slate-400" />
                     </div>
                     <div className="font-medium text-base">
-                      {submission.user.nickname}
+                      {submission.nickname}
                     </div>
                   </div>
                 </TableCell>
@@ -242,12 +120,12 @@ async function OthersPage({ params, searchParams }: OthersPageProps) {
                 </TableCell>
                 <TableCell className="text-center">
                   <span className="text-teal-600 font-medium text-base bg-teal-50 px-2 py-1 rounded-sm">
-                    {submission.score}점
+                    {submission.totalScore}점
                   </span>
                 </TableCell>
                 <TableCell className="text-center">
                   <Link
-                    href={`/daily/questions/${questionId}/others/${submission.id}`}
+                    href={`/daily/questions/${questionId}/others/${submission.submissionId}`}
                     className="text-sm text-teal-600 hover:text-teal-700 hover:underline"
                   >
                     답변 보기

--- a/apps/web/src/lib/parse-int-or-null.ts
+++ b/apps/web/src/lib/parse-int-or-null.ts
@@ -1,7 +1,9 @@
 function parseIntOrNull(value: string | undefined): number | null {
-  if (!value) return null;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
+  if (value === undefined) return null;
+  const trimmed = value.trim();
+  if (!/^-?\d+$/.test(trimmed)) return null;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) && Number.isInteger(parsed) ? parsed : null;
 }
 
 export default parseIntOrNull;

--- a/apps/web/src/lib/parse-int-or-null.ts
+++ b/apps/web/src/lib/parse-int-or-null.ts
@@ -1,0 +1,7 @@
+function parseIntOrNull(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export default parseIntOrNull;


### PR DESCRIPTION
## 🔸 작업 내용

- 다른 유저 답변 리스트 페이지를 백엔드 연동했습니다.
- 다른 유저 답변 상세 페이지 백엔드 연동했습니다.

<img width="1082" height="948" alt="Screenshot 2026-01-28 at 8 33 02 PM" src="https://github.com/user-attachments/assets/32ef64d4-9760-4b32-80ec-44f28e3dbf0f" />

<img width="1015" height="820" alt="Screenshot 2026-01-28 at 8 34 02 PM" src="https://github.com/user-attachments/assets/f9d2a2bf-a80c-498b-bef6-c059cfbd34d2" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 다른 사용자 제출의 상세 조회가 실시간 데이터로 제공됩니다(제목, 내용, 작성자, 점수, 키워드 포함).
  * 제출 목록의 페이지네이션과 개별 제출 상세로 이동 기능이 추가되었습니다.
  * 제출 시간이 상대적 형식(예: "5분 전", "2시간 전", 날짜)으로 표시됩니다.

* **Bug Fixes / Improvements**
  * 입력 검증이 강화되어 잘못된 요청은 적절히 처리됩니다.
  * 빈 데이터 처리와 조건부 렌더링이 개선되어 UI가 안정적으로 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->