### PR TITLE
fix: interceptor, middleware에서 requestId 중복 생성 수정

### DIFF
--- a/apps/api/src/common/interceptors/logging.interceptor.ts
+++ b/apps/api/src/common/interceptors/logging.interceptor.ts
@@ -22,7 +22,9 @@ export class LoggingInterceptor implements NestInterceptor {
   private readonly excludedPaths = ['/health', '/api-docs', '/api-docs-json'];
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
-    const request = context.switchToHttp().getRequest<Request>();
+    const request = context
+      .switchToHttp()
+      .getRequest<Request & { requestId?: string; userId?: number }>();
     const response = context.switchToHttp().getResponse<Response>();
 
     // 제외된 경로는 로깅하지 않음
@@ -35,8 +37,8 @@ export class LoggingInterceptor implements NestInterceptor {
     const startTime = Date.now();
 
     // 요청 정보 추출
-    const userId = (request as Request & { userId?: number }).userId;
-    const requestId = this.generateRequestId();
+    const userId = request.userId;
+    const requestId = request.requestId || 'unknown';
 
     // 요청 로그
     this.logger.log(
@@ -74,13 +76,6 @@ export class LoggingInterceptor implements NestInterceptor {
         },
       }),
     );
-  }
-
-  /**
-   * 요청 추적을 위한 고유 ID 생성
-   */
-  private generateRequestId(): string {
-    return `req-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
   }
 
   private extractStatusCode(

--- a/apps/api/src/common/middlewares/request-id.middleware.ts
+++ b/apps/api/src/common/middlewares/request-id.middleware.ts
@@ -1,6 +1,5 @@
 import { Injectable, NestMiddleware } from '@nestjs/common';
 import { Request, Response, NextFunction } from 'express';
-import { randomUUID } from 'crypto';
 
 /**
  * Request ID Middleware
@@ -18,7 +17,7 @@ export class RequestIdMiddleware implements NestMiddleware {
   ) {
     // 요청 헤더에서 X-Request-ID 읽기 (없으면 생성)
     const requestId =
-      (req.headers['x-request-id'] as string) || `req-${randomUUID()}`;
+      (req.headers['x-request-id'] as string) || this.generateRequestId();
 
     // Request 객체에 requestId 추가 (필터에서 사용)
     req.requestId = requestId;
@@ -27,5 +26,12 @@ export class RequestIdMiddleware implements NestMiddleware {
     res.setHeader('X-Request-ID', requestId);
 
     next();
+  }
+
+  /**
+   * 요청 추적을 위한 고유 ID 생성
+   */
+  private generateRequestId(): string {
+    return `req-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
   }
 }

--- a/apps/api/src/common/middlewares/request-id.middleware.ts
+++ b/apps/api/src/common/middlewares/request-id.middleware.ts
@@ -16,8 +16,9 @@ export class RequestIdMiddleware implements NestMiddleware {
     next: NextFunction,
   ) {
     // 요청 헤더에서 X-Request-ID 읽기 (없으면 생성)
-    const requestId =
-      (req.headers['x-request-id'] as string) || this.generateRequestId();
+    const headerValue = req.headers['x-request-id'];
+    const incoming = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+    const requestId = (incoming && incoming.trim()) || this.generateRequestId();
 
     // Request 객체에 requestId 추가 (필터에서 사용)
     req.requestId = requestId;


### PR DESCRIPTION
## 🔸 작업 내용

- #274 #279 
  중복 작업 해결하는 과정에서 놓친 부분 수정

## 🔸 고민 했던 부분

- interceptor와 middleware에서 중복으로 생성하고 있어서 nest 생명 주기 상 먼저 실행되는 미들웨어에서 생성하도록 수정했습니다.
- 생성하는 방식은 interceptor에서 사용하던 함수를 사용했습니다.

## 🔸 참고

- 스크린샷이나 영상이 있다면 공유합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 요청 추적 및 로깅을 개선했습니다. 수신된 요청의 ID(헤더 또는 페이로드)를 우선 사용하고, 없을 경우 일관된 방식으로 생성해 응답 헤더에 설정합니다. 로그에 요청 및 사용자 식별자가 보다 안정적으로 반영되어 추적성과 분석이 향상됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->