### PR TITLE
그래프 노드 초기 수렴 단계 개선하기

### DIFF
--- a/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
+++ b/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useCanvas2D } from "@/hooks/use-canvas-2d";
 import * as React from "react";
+import { addRandomEdgeDistance } from "../../_lib/graph-view/add-random-edge-distance";
 import drawGraphView from "../../_lib/graph-view/draw-graph-view";
 import { GraphData } from "../../_types/graph-view";
 import NodeMap from "./node-map";
@@ -19,6 +20,10 @@ function GraphView({
   nodeMap,
   changeNodeMap,
 }: GraphViewProps) {
+  const graphDataRef = React.useRef<GraphData>({
+    ...graphData,
+    edges: addRandomEdgeDistance(graphData.edges),
+  });
   // canvasRef: Canvas DOM 참조
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
   // ctx: Canvas 2D 렌더링 컨텍스트, width/height: 캔버스 크기
@@ -33,8 +38,8 @@ function GraphView({
     // nodeMap을 props로 받았았을 때 초기화 안되게
     // nodeMap이 존재할 때 width, height이 변경되도 초기화안되게
     if (nodeMap || nodeMapRef.current) return;
-    nodeMapRef.current = new NodeMap(graphData.nodes, width, height);
-  }, [width, height, graphData.nodes, nodeMap]);
+    nodeMapRef.current = new NodeMap(graphDataRef.current.nodes, width, height);
+  }, [width, height, graphDataRef, nodeMap]);
 
   // 캔버스 인터랙션 훅에서 반환된 값들
   // offset: 캔버스 이동 오프셋, scale: 줌 레벨
@@ -48,15 +53,21 @@ function GraphView({
     handleMouseDown,
     handleMouseMove,
     handleMouseUp,
-  } = useGraphInteraction(canvasRef, clickEventDisabled, {
-    getNodeValues: () => nodeMapRef.current?.getNodeValues() ?? [].values(),
-    setNodeFixedCoords: (nodeId, x, y) =>
-      nodeMapRef.current?.setNodeFixedCoords(nodeId, x, y),
-    clearNodeFixedCoords: (nodeId) =>
-      nodeMapRef.current?.clearNodeFixedCoords(nodeId),
-    getNodeQuestionId: (nodeId) =>
-      nodeMapRef?.current?.nodeMap.get(nodeId)?.questionId ?? null,
-  });
+  } = useGraphInteraction(
+    canvasRef,
+    clickEventDisabled,
+    {
+      getNodeValues: () => nodeMapRef.current?.getNodeValues() ?? [].values(),
+      setNodeFixedCoords: (nodeId, x, y) =>
+        nodeMapRef.current?.setNodeFixedCoords(nodeId, x, y),
+      clearNodeFixedCoords: (nodeId) =>
+        nodeMapRef.current?.clearNodeFixedCoords(nodeId),
+      getNodeQuestionId: (nodeId) =>
+        nodeMapRef?.current?.nodeMap.get(nodeId)?.questionId ?? null,
+    },
+    { x: 0, y: 0 }, // initialOffset
+    0.5, // initialScale - 초기 줌 레벨을 0.7로 설정
+  );
 
   // 물리 엔진 기반 그래프 애니메이션 루프
   // 기대동작: 물리 시뮬레이션을 통해 노드들이 안정적인 위치로 이동하며, 수렴 또는 인터랙션이 있을 때만 애니메이션 실행
@@ -72,14 +83,18 @@ function GraphView({
       if (!nodeMapRef.current) return;
 
       // 1. 물리 엔진 단계: 힘 적용 및 위치 업데이트
-      nodeMapRef.current.applyPhysics(graphData.edges, centerX, centerY);
+      nodeMapRef.current.applyPhysics(
+        graphDataRef.current.edges,
+        centerX,
+        centerY,
+      );
 
       // 2. 렌더링 단계: 캔버스 지우고 그래프 그리기
       ctx.clearRect(0, 0, width, height);
       drawGraphView(
         ctx,
         nodeMapRef.current.nodeMap,
-        graphData.edges,
+        graphDataRef.current.edges,
         offset.current,
         scale.current,
         hoveredNodeId.current,
@@ -108,7 +123,7 @@ function GraphView({
     ctx,
     width,
     height,
-    graphData.edges,
+    graphDataRef,
     offset,
     scale,
     activeInteraction,

--- a/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
+++ b/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
@@ -66,7 +66,7 @@ function GraphView({
         nodeMapRef?.current?.nodeMap.get(nodeId)?.questionId ?? null,
     },
     { x: 0, y: 0 }, // initialOffset
-    0.5, // initialScale - 초기 줌 레벨을 0.7로 설정
+    0.5, // initialScale - 초기 줌 레벨을 0.5로 설정
   );
 
   // 물리 엔진 기반 그래프 애니메이션 루프

--- a/apps/web/src/app/mypage/_components/graph-view/node-map.ts
+++ b/apps/web/src/app/mypage/_components/graph-view/node-map.ts
@@ -15,12 +15,22 @@ class NodeMap {
 
   constructor(nodes: GraphNode[], width: number, height: number) {
     this._nodeMap = new Map();
-    const radius = GRAPH_NUMBER_CONSTANT.NODE_RADIUS;
-    nodes.forEach((node) => {
+    const centerX = width / 2;
+    const centerY = height / 2;
+    const nodeCount = nodes.length;
+    // 화면 크기에 비례하는 원의 반지름 (화면의 50% 정도)
+    const circleRadius = Math.min(width, height) * 0.5;
+
+    nodes.forEach((node, index) => {
+      // 원형으로 균등하게 배치
+      const angle = (index / nodeCount) * 2 * Math.PI;
+      const x = centerX + circleRadius * Math.cos(angle);
+      const y = centerY + circleRadius * Math.sin(angle);
+
       this._nodeMap.set(node.id, {
         ...node,
-        x: Math.random() * (width - radius * 2) + radius,
-        y: Math.random() * (height - radius * 2) + radius,
+        x,
+        y,
         vx: 0,
         vy: 0,
         fx: null,

--- a/apps/web/src/app/mypage/_components/graph-view/use-graph-interaction.ts
+++ b/apps/web/src/app/mypage/_components/graph-view/use-graph-interaction.ts
@@ -29,6 +29,18 @@ function useGraphInteraction(
   // scale: 캔버스에서 휠움직임을 통해 줌을 할 때 줌 단계
   const scale = React.useRef(initialScale);
 
+  // 초기 스케일이 1이 아닐 때 중앙 정렬을 위한 offset 조정
+  React.useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || initialScale === 1) return;
+
+    const rect = canvas.getBoundingClientRect();
+    offset.current = {
+      x: (rect.width * (1 - initialScale)) / 2,
+      y: (rect.height * (1 - initialScale)) / 2,
+    };
+  }, [canvasRef, initialScale]);
+
   const hoveredNodeId = React.useRef<number | null>(null);
   const hoverTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(
     null,

--- a/apps/web/src/app/mypage/_components/graph-view/use-graph-interaction.ts
+++ b/apps/web/src/app/mypage/_components/graph-view/use-graph-interaction.ts
@@ -100,6 +100,7 @@ function useGraphInteraction(
   // 기대동작 2. 노드 클릭 o -> 해당 노드 고정
   const handleMouseDown = React.useCallback(
     (e: React.MouseEvent<HTMLCanvasElement>) => {
+      document.body.style.cursor = "grabbing";
       setActiveInteraction(true);
       // 클릭 판정을 위해 항상 시작 위치 저장
       setDragStartOffset({ x: e.clientX, y: e.clientY });
@@ -175,7 +176,7 @@ function useGraphInteraction(
       setDraggedNodeId(null);
       setIsDraggingCanvas(false);
       setActiveInteraction(false);
-
+      document.body.style.cursor = "default";
       // 클릭 이벤트 처리 (드래그 없이 같은 위치에서 마우스 업)
       if (dragStartOffset.x === e.clientX && dragStartOffset.y === e.clientY) {
         if (clickEventDisabled || !clickedNodeId) return;

--- a/apps/web/src/app/mypage/_constants/graph-view-constant.ts
+++ b/apps/web/src/app/mypage/_constants/graph-view-constant.ts
@@ -20,8 +20,8 @@ export const GRAPH_COLOR_CONSTANT = {
 
 export const PHISICS_CONSTANT = {
   REPULSION: 2000, //척력 강도. 크면 더 멀리 밀어냄
-  SPRING_STRENGTH: 0.1, //인력 강도. 크면 빨리 목표 자리로 옴
-  DAMPING: 0.5, // 마찰력 강도. 프레임마다 속도에 곱해져서 느려지게
-  MAX_SPEED: 3.0, //최대 속도
+  SPRING_STRENGTH: 0.8, //인력 강도. 크면 빨리 목표 자리로 옴
+  DAMPING: 0.6, // 마찰력 강도. 프레임마다 속도에 곱해져서 느려지게
+  MAX_SPEED: 8.0, //최대 속도
   CENTER_GRAVITY: 0.005, // 중앙중력강도. 화면 밖으로 흩어지는거 막기
 } as const;

--- a/apps/web/src/app/mypage/_contents/graph-content.tsx
+++ b/apps/web/src/app/mypage/_contents/graph-content.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import * as React from "react";
+import { Button } from "@/components/button/button";
 import { BarChart3, Expand } from "lucide-react";
+import * as React from "react";
 import GraphView from "../_components/graph-view/graph-view";
 import NodeMap from "../_components/graph-view/node-map";
 import { GraphData } from "../_types/graph-view";
-import { Button } from "@/components/button/button";
 
 function GraphContent({ graphData }: { graphData: GraphData }) {
   const [openModalStatus, setOpenModalStatus] = React.useState(false);
@@ -39,7 +39,7 @@ function GraphContent({ graphData }: { graphData: GraphData }) {
             onClick={handleModalToggle}
             size="icon"
             variant="outline"
-            className="absolute right-0 top-8"
+            className="absolute right-8 top-8"
             aria-label="그래프 확대"
           >
             <Expand className="text-muted-foreground" />
@@ -49,13 +49,14 @@ function GraphContent({ graphData }: { graphData: GraphData }) {
       )}
       {openModalStatus && (
         <div
-          onClick={handleModalToggle}
+          onMouseDown={(e) => {
+            if (e.target === e.currentTarget) {
+              handleModalToggle();
+            }
+          }}
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-in fade-in duration-200"
         >
-          <div
-            onClick={(e) => e.stopPropagation()}
-            className="bg-white rounded-2xl w-full h-full max-w-5xl max-h-5/6 shadow-xl overflow-hidden relative"
-          >
+          <div className="bg-white rounded-2xl w-full h-full max-w-5xl max-h-5/6 shadow-xl overflow-hidden relative">
             <div className="w-full h-full">
               <GraphView graphData={graphData} nodeMap={nodeMap} />
             </div>

--- a/apps/web/src/app/mypage/_lib/graph-view/add-random-edge-distance.ts
+++ b/apps/web/src/app/mypage/_lib/graph-view/add-random-edge-distance.ts
@@ -1,0 +1,16 @@
+import { GRAPH_NUMBER_CONSTANT } from "../../_constants/graph-view-constant";
+import { GraphEdge } from "../../_types/graph-view";
+
+export function addRandomEdgeDistance(
+  edges: GraphEdge[],
+  minRatio: number = 0.7,
+  maxRatio: number = 1.3,
+): GraphEdge[] {
+  const baseDistance = GRAPH_NUMBER_CONSTANT.EDGE_DISTANCE;
+
+  return edges.map((edge) => ({
+    ...edge,
+    targetDistance:
+      baseDistance * (minRatio + Math.random() * (maxRatio - minRatio)),
+  }));
+}

--- a/apps/web/src/app/mypage/_lib/graph-view/apply-spring-force.ts
+++ b/apps/web/src/app/mypage/_lib/graph-view/apply-spring-force.ts
@@ -18,10 +18,13 @@ function applySpringForce(edges: GraphEdge[], nodes: NodeMapType) {
     let distance = Math.sqrt(dx * dx + dy * dy);
     if (distance < 1) distance = 1;
 
-    const targetDistance = GRAPH_NUMBER_CONSTANT.EDGE_DISTANCE;
+    // edge에 targetDistance가 있으면 사용, 없으면 기본값 사용
+    const targetDistance =
+      edge.targetDistance ?? GRAPH_NUMBER_CONSTANT.EDGE_DISTANCE;
 
     const force =
       PHISICS_CONSTANT.SPRING_STRENGTH * (distance - targetDistance);
+
     const forceX = (dx / distance) * force;
     const forceY = (dy / distance) * force;
 

--- a/apps/web/src/app/mypage/_types/graph-view.ts
+++ b/apps/web/src/app/mypage/_types/graph-view.ts
@@ -16,6 +16,7 @@ export interface GraphEdge {
   id: number;
   sourceId: number;
   targetId: number;
+  targetDistance?: number;
 }
 
 export interface GraphData {

--- a/apps/web/src/app/mypage/layout.tsx
+++ b/apps/web/src/app/mypage/layout.tsx
@@ -1,4 +1,4 @@
 function MyPageLayout({ children }: { children: React.ReactNode }) {
-  return <section className="w-screen flex justify-center">{children}</section>;
+  return <section className="w-full flex justify-center">{children}</section>;
 }
 export default MyPageLayout;

--- a/apps/web/src/app/mypage/page.tsx
+++ b/apps/web/src/app/mypage/page.tsx
@@ -60,7 +60,7 @@ async function MyPage() {
             내가 푼 문제
           </TabsTrigger>
         </TabsList>
-        <TabsContent className="w-full px-8 pb-8" value="graph">
+        <TabsContent className="w-full" value="graph">
           <GraphContent graphData={graphData} />
         </TabsContent>
         <TabsContent className="bg-white w-full px-8 pb-8" value="streak">


### PR DESCRIPTION
## 🔸 작업 내용
- #317 
- 빠른 수렴을 위해 물리 상수 값 증가
- 엣지 길이 고정 길이에서 가변 길이로 적용
- 그래프 노드 초기 배치시 캔버스의 좁은 길이 *0.5 의 반지름을 가지는 원의 호에 노드 배치
- 초기 캔버스 스케일 0.5로 조정

## 🔸 고민 했던 부분

### 초기 배치와 관련하여
- 기존 코드에서 그래프뷰 초기 배치는 캔버스 내에서 랜덤으로 되어있어서 초기 수렴시 많은 물리엔진 동작이 필요했다.
- 물리엔진 동작을 줄이기 위해서 화면 렌더링 이전에 50~100번 사이로 미리 물리엔진을 동작시키고 화면에 렌더링하는 계획을 세웠다.
- 노드가 100개일 때 CPU 4x slowdown에서 해당 로직이 4초 이상 걸렸다.
- 옵시디언 그래프뷰를 참고했을 때 중앙 굉장히 좁은 공간에서 퍼져나오는 듯한 애니메이션 틱을 봤고 이를 참고했다.
- 그래프뷰에서 이상적인 형태가 원형으로 퍼져있는 그래프라는 생각이 들었고, 캔버스의 50% 공간에서 원을 그리고, 해당 원에서 현의 위치에 그래프 노드를 놓는 방식을 적용하였다.
- 완전 랜덤 배치 방식보다 어느정도 노드들이 퍼져있기 때문에 초기 빠른 변화가 덜하게 되었다.

### 캔버스 스케일 관련하여
- 기존 초기 단계에서 복잡함 + 어지러움을 느끼는건 복잡한 캔버스 내부가 원인이라고 생각했다.
- 좁은 캔버스 공간에 노드 + 텍스트 + 엣지가 함께 있기 때문에 사용자 눈에 많은 내용이 들어오기 때문에 어지러움을 느낀다고 생각했다.
- 줌 스케일을 낮게 하여 노드 + 엣지만 사용자에게 노출시키는 것이 사용자가 어지러움을 덜 느낄 수 있을 것이라 생각했다.
- 노드 수가 적을 때 캔버스 스케일을 동적으로 적용하는 방법을 생각해보았지만 사용자가 푸는 문제수는 빠르게 증가할텐데 많은 문제들이 빠르게 채워질 것이기 때문에 큰 문제는 아니라고 판단하고 초기 렌더링 스케일을 0.5로 고정시켰다.

## 🔸 참고
### 수정전

https://github.com/user-attachments/assets/eceed68f-8701-4420-b199-5eb9c05d9cc3


### 수정 후 - 노드 50개


https://github.com/user-attachments/assets/93a3400a-15db-4ac3-b57f-a249081ff469


### 수정 후 - 노드 100개

https://github.com/user-attachments/assets/bc8cc2a6-89cc-4c3c-afb6-dfb18422a8cf




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 엣지마다 목표 거리(targetDistance) 옵션이 추가되었습니다.
  * 엣지 거리를 랜덤 비율로 변형해 다양성을 주는 기능이 도입되었습니다.

* **개선 사항**
  * 노드가 원형으로 균일 배치되어 가독성이 향상되었습니다.
  * 물리 엔진 파라미터 조정으로 애니메이션 반응성과 속도 한계가 개선되었습니다.
  * 초기 줌 레벨에 맞춘 자동 중앙 오프셋 계산 및 드래그 커서 피드백이 추가되어 초기 보기 및 상호작용이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->