### PR TITLE
접근성 개선

### DIFF
--- a/apps/web/src/app/daily/questions/[questionId]/_components/question-card.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/_components/question-card.tsx
@@ -24,6 +24,7 @@ export default function QuestionCard({
         onClick={() => setIsVisible(!isVisible)}
         className="absolute top-3 right-3 md:top-4 md:right-4 p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
         aria-label={isVisible ? "문제 숨기기" : "문제 보기"}
+        aria-expanded={isVisible}
         type="button"
       >
         {isVisible ? <ChevronUp size={20} /> : <ChevronDown size={20} />}

--- a/apps/web/src/app/daily/questions/[questionId]/_components/record-button.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/_components/record-button.tsx
@@ -22,6 +22,7 @@ function RecordButton({
   return (
     <motion.button
       aria-label={isRecording ? "녹음 중지" : "녹음 시작"}
+      aria-pressed={isRecording}
       onClick={handleClick}
       whileHover={disabled ? {} : { scale: 1.1 }}
       whileTap={disabled ? {} : { scale: 0.98 }}

--- a/apps/web/src/app/daily/questions/[questionId]/_components/text-input.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/_components/text-input.tsx
@@ -43,6 +43,7 @@ function TextInput({
           value={text}
           onChange={(e) => setText(e.target.value)}
           placeholder="면접 질문에 답하듯이 지식을 논리적으로 작성해 보세요."
+          aria-label="답변 작성"
           className="min-h-32 md:min-h-40 resize-none text-base"
           maxLength={maxLength}
           disabled={isSubmitting || disabled}

--- a/apps/web/src/app/daily/questions/[questionId]/others/page.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/others/page.tsx
@@ -90,9 +90,13 @@ async function OthersPage({ params, searchParams }: OthersPageProps) {
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>사용자</TableHead>
-              <TableHead className="text-center w-24">점수</TableHead>
-              <TableHead className="w-24 text-center">상세</TableHead>
+              <TableHead scope="col">사용자</TableHead>
+              <TableHead scope="col" className="text-center w-24">
+                점수
+              </TableHead>
+              <TableHead scope="col" className="w-24 text-center">
+                상세
+              </TableHead>
             </TableRow>
           </TableHeader>
 
@@ -134,6 +138,7 @@ async function OthersPage({ params, searchParams }: OthersPageProps) {
                     <Link
                       href={`/daily/questions/${questionId}/others/${submission.submissionId}`}
                       className="text-sm text-teal-600 hover:text-teal-700 hover:underline"
+                      aria-label={`${submission.nickname}의 답변 보기`}
                     >
                       답변 보기
                     </Link>
@@ -166,12 +171,16 @@ async function OthersPage({ params, searchParams }: OthersPageProps) {
                             href={buildPaginationUrl(currentPage)}
                             className="pointer-events-none opacity-50"
                             aria-disabled="true"
+                            tabIndex={-1}
                           />
                         )}
                       </PaginationItem>
 
                       <PaginationItem>
-                        <div className="px-2">
+                        <div
+                          className="px-2"
+                          aria-label={`현재 ${currentPage}페이지, 전체 ${totalPages}페이지`}
+                        >
                           {currentPage} / {totalPages}
                         </div>
                       </PaginationItem>
@@ -186,6 +195,7 @@ async function OthersPage({ params, searchParams }: OthersPageProps) {
                             href={buildPaginationUrl(currentPage)}
                             className="pointer-events-none opacity-50"
                             aria-disabled="true"
+                            tabIndex={-1}
                           />
                         )}
                       </PaginationItem>

--- a/apps/web/src/app/daily/questions/_components/mic-tester.tsx
+++ b/apps/web/src/app/daily/questions/_components/mic-tester.tsx
@@ -129,6 +129,7 @@ export default function MicrophoneTester() {
           <div className="flex items-center gap-3">
             <button
               aria-label={isPlaying ? "일시정지" : "재생"}
+              aria-pressed={isPlaying}
               onClick={isPlaying ? pausePlayback : playRecording}
               className="flex items-center justify-center w-10 h-10 rounded-full bg-teal-500 text-white hover:bg-teal-600 transition-colors shrink-0"
             >

--- a/apps/web/src/app/daily/questions/_components/question-filters.tsx
+++ b/apps/web/src/app/daily/questions/_components/question-filters.tsx
@@ -132,6 +132,7 @@ function QuestionFilters({
         <InputGroup>
           <InputGroupInput
             placeholder="문제 제목 검색"
+            aria-label="문제 제목 검색"
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
           />
@@ -146,6 +147,7 @@ function QuestionFilters({
             풀이 상태
           </div>
           <SegmentedControl
+            aria-label="풀이 상태"
             options={[
               { label: "전체", value: "" },
               { label: "푼 문제", value: "SOLVED" },
@@ -164,6 +166,7 @@ function QuestionFilters({
             중요도
           </div>
           <SegmentedControl
+            aria-label="중요도"
             options={[
               { label: "전체", value: "" },
               { label: "4.0 이상", value: "4" },

--- a/apps/web/src/app/daily/questions/_components/question-modal.tsx
+++ b/apps/web/src/app/daily/questions/_components/question-modal.tsx
@@ -16,14 +16,31 @@ interface QuestionModalProps {
 function QuestionModal({ question, onClose }: QuestionModalProps) {
   const [answerMode, setAnswerMode] = React.useState<string>("voice");
 
+  // Escape 키로 모달 닫기
+  React.useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleEscape);
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [onClose]);
+
   if (!question) return null;
 
   return (
     <div
+      role="presentation"
+      aria-hidden="true"
       onClick={onClose}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-in fade-in duration-200"
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="question-modal-title"
         onClick={(e) => e.stopPropagation()}
         className="bg-white rounded-2xl w-full min-w-62.5 max-w-lg shadow-xl relative flex flex-col max-h-[90vh] overflow-y-auto"
       >
@@ -41,7 +58,10 @@ function QuestionModal({ question, onClose }: QuestionModalProps) {
           </div>
 
           {/* 제목 및 내용 */}
-          <h2 className="text-xl sm:text-2xl font-bold text-gray-900 mb-3 sm:mb-4 leading-tight">
+          <h2
+            id="question-modal-title"
+            className="text-xl sm:text-2xl font-bold text-gray-900 mb-3 sm:mb-4 leading-tight"
+          >
             {question.title}
           </h2>
           <p className="text-gray-600 text-sm sm:text-base leading-relaxed mb-5 sm:mb-8 whitespace-pre-wrap">
@@ -52,6 +72,7 @@ function QuestionModal({ question, onClose }: QuestionModalProps) {
           <div className="grid grid-cols-2 gap-2 sm:gap-3 mb-3 sm:mb-6">
             <button
               onClick={() => setAnswerMode("voice")}
+              aria-pressed={answerMode === "voice"}
               className={cn(
                 "flex items-center justify-center gap-1 sm:gap-2 py-2 sm:py-4 rounded-lg sm:rounded-xl border transition-all duration-200",
                 answerMode === "voice"
@@ -64,6 +85,7 @@ function QuestionModal({ question, onClose }: QuestionModalProps) {
                   "w-3.5 h-3.5 sm:w-4 sm:h-4",
                   answerMode === "voice" ? "fill-teal-100" : "",
                 )}
+                aria-hidden="true"
               />
               <span className="font-bold text-[11px] sm:text-sm">
                 음성 답변
@@ -72,6 +94,7 @@ function QuestionModal({ question, onClose }: QuestionModalProps) {
 
             <button
               onClick={() => setAnswerMode("text")}
+              aria-pressed={answerMode === "text"}
               className={cn(
                 "flex items-center justify-center gap-1 sm:gap-2 py-2 sm:py-4 rounded-lg sm:rounded-xl border transition-all duration-200",
                 answerMode === "text"
@@ -79,7 +102,10 @@ function QuestionModal({ question, onClose }: QuestionModalProps) {
                   : "bg-slate-50 border-transparent text-slate-500 hover:bg-slate-100",
               )}
             >
-              <Keyboard className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
+              <Keyboard
+                className="w-3.5 h-3.5 sm:w-4 sm:h-4"
+                aria-hidden="true"
+              />
               <span className="font-bold text-[11px] sm:text-sm">
                 텍스트 답변
               </span>
@@ -94,7 +120,10 @@ function QuestionModal({ question, onClose }: QuestionModalProps) {
 
           {answerMode === "text" && (
             <div className=" h-65 mb-6 w-full bg-slate-50 border border-slate-100 rounded-2xl p-8 flex flex-col items-center justify-center text-center animate-in fade-in zoom-in-95 duration-300">
-              <Keyboard className="w-10 h-10 text-slate-300 mb-4" />
+              <Keyboard
+                className="w-10 h-10 text-slate-300 mb-4"
+                aria-hidden="true"
+              />
               <p className="text-slate-500 text-sm font-medium">
                 마이크가 아닌{" "}
                 <span className="text-teal-400 text-sm sm:text-base">

--- a/apps/web/src/app/daily/questions/_components/question-modal.tsx
+++ b/apps/web/src/app/daily/questions/_components/question-modal.tsx
@@ -33,7 +33,6 @@ function QuestionModal({ question, onClose }: QuestionModalProps) {
   return (
     <div
       role="presentation"
-      aria-hidden="true"
       onClick={onClose}
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-in fade-in duration-200"
     >

--- a/apps/web/src/app/daily/questions/page.tsx
+++ b/apps/web/src/app/daily/questions/page.tsx
@@ -98,13 +98,22 @@ async function QuestionListPage({ searchParams }: QuestionListPageProps) {
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead className="w-28 hidden md:table-cell">대분류</TableHead>
-            <TableHead className="w-32 hidden sm:table-cell">중분류</TableHead>
-            <TableHead>문제 제목</TableHead>
-            <TableHead className="w-20 text-center hidden sm:table-cell">
+            <TableHead scope="col" className="w-28 hidden md:table-cell">
+              대분류
+            </TableHead>
+            <TableHead scope="col" className="w-32 hidden sm:table-cell">
+              중분류
+            </TableHead>
+            <TableHead scope="col">문제 제목</TableHead>
+            <TableHead
+              scope="col"
+              className="w-20 text-center hidden sm:table-cell"
+            >
               중요도
             </TableHead>
-            <TableHead className="w-20 text-center">내 점수</TableHead>
+            <TableHead scope="col" className="w-20 text-center">
+              내 점수
+            </TableHead>
           </TableRow>
         </TableHeader>
         <Suspense fallback={<TableLoadingFallback />}>

--- a/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
+++ b/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
@@ -38,7 +38,15 @@ function GraphView({
   // 애니메이션 루프
   useAnimationFrame(drawGraph);
 
-  return <canvas ref={canvasRef} className="w-full h-full" {...bindEvents} />;
+  return (
+    <canvas
+      ref={canvasRef}
+      className="w-full h-full"
+      role="img"
+      aria-label={`지식 그래프: ${graphData.nodes.length}개의 질문, ${graphData.edges.length}개의 연결`}
+      {...bindEvents}
+    />
+  );
 }
 
 export default GraphView;

--- a/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.tsx
+++ b/apps/web/src/app/mypage/_components/voronoi-streak/voronoi-streak.tsx
@@ -228,7 +228,12 @@ function VoronoiStreak({
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
     >
-      <canvas className="w-full h-full" ref={canvasRef} />
+      <canvas
+        className="w-full h-full"
+        ref={canvasRef}
+        role="img"
+        aria-label={`연간 학습 스트릭 시각화: 총 ${streakCount}개의 문제 해결`}
+      />
       {hoveredInfo && (
         <div
           ref={tooltipRef}

--- a/apps/web/src/app/reports/[questionId]/_components/feedback/feedback-section.tsx
+++ b/apps/web/src/app/reports/[questionId]/_components/feedback/feedback-section.tsx
@@ -27,7 +27,12 @@ function FeedbackSection({
     return (
       <section className="p-5 md:p-9 transition-all duration-300">
         <div className="flex flex-col items-center justify-center py-8 md:py-12 gap-4 md:gap-6">
-          <div className="w-10 h-10 md:w-14 md:h-14 border-4 border-[#4FD1C5] border-t-transparent rounded-full animate-spin" />
+          <div
+            role="status"
+            aria-live="polite"
+            aria-label="분석 중"
+            className="w-10 h-10 md:w-14 md:h-14 border-4 border-[#4FD1C5] border-t-transparent rounded-full animate-spin"
+          />
 
           <div className="text-center px-4">
             <h2 className="text-lg md:text-xl font-bold text-slate-900 mb-2 md:mb-3">
@@ -56,7 +61,10 @@ function FeedbackSection({
       <section className="p-5 md:p-9 transition-all duration-300">
         <div className="flex flex-col items-center justify-center py-8 md:py-12 gap-4 md:gap-6">
           <div className="w-10 h-10 md:w-14 md:h-14 bg-red-50 rounded-full flex items-center justify-center">
-            <AlertCircle className="w-6 h-6 md:w-8 md:h-8 text-red-500" />
+            <AlertCircle
+              className="w-6 h-6 md:w-8 md:h-8 text-red-500"
+              aria-hidden="true"
+            />
           </div>
 
           <div className="text-center px-4">

--- a/apps/web/src/app/reports/[questionId]/_components/feedback/score-gauge.tsx
+++ b/apps/web/src/app/reports/[questionId]/_components/feedback/score-gauge.tsx
@@ -38,8 +38,16 @@ function ScoreGauge({ score }: ScoreGaugeProps) {
   const color = getScoreColor(clamped);
 
   return (
-    <div className="relative w-20 h-20 md:w-25 md:h-25 shrink-0">
-      <svg className="w-full h-full -rotate-90" viewBox="0 0 36 36">
+    <div
+      className="relative w-20 h-20 md:w-25 md:h-25 shrink-0"
+      role="img"
+      aria-label={`총점 ${clamped}점`}
+    >
+      <svg
+        className="w-full h-full -rotate-90"
+        viewBox="0 0 36 36"
+        aria-hidden="true"
+      >
         <circle
           className="fill-none stroke-slate-100 stroke-3"
           cx="18"

--- a/apps/web/src/app/reports/[questionId]/_components/history/collapsible-history.tsx
+++ b/apps/web/src/app/reports/[questionId]/_components/history/collapsible-history.tsx
@@ -50,7 +50,7 @@ function CollapsibleHistory({ history, selectedId }: CollapsibleHistoryProps) {
           aria-label="시도 히스토리 열기"
           aria-expanded={isOpen}
         >
-          <History className="w-4 h-4" />
+          <History className="w-4 h-4" aria-hidden="true" />
           <span className="text-sm font-semibold whitespace-nowrap">
             히스토리
           </span>
@@ -63,6 +63,8 @@ function CollapsibleHistory({ history, selectedId }: CollapsibleHistoryProps) {
       {/* 모바일 백드롭 */}
       {isOpen && (
         <div
+          role="presentation"
+          aria-hidden="true"
           className="lg:hidden fixed inset-0 bg-black/20 z-30"
           onClick={() => setIsOpen(false)}
         />
@@ -81,7 +83,7 @@ function CollapsibleHistory({ history, selectedId }: CollapsibleHistoryProps) {
         <div className="w-64 lg:w-60 h-full lg:h-fit lg:max-h-[calc(100vh-10rem)] flex flex-col bg-white rounded-l-2xl lg:rounded-2xl border border-slate-200 shadow-lg lg:shadow-none">
           <div className="p-4 border-b border-slate-200 flex justify-between items-center shrink-0">
             <div className="flex items-center gap-2">
-              <History className="w-4 h-4 text-teal-500" />
+              <History className="w-4 h-4 text-teal-500" aria-hidden="true" />
               <span className="font-bold text-sm text-slate-900">
                 시도 히스토리
               </span>
@@ -96,7 +98,7 @@ function CollapsibleHistory({ history, selectedId }: CollapsibleHistoryProps) {
               className="lg:hidden -mr-2 h-8 w-8"
               aria-label="닫기"
             >
-              <ChevronRight className="w-4 h-4" />
+              <ChevronRight className="w-4 h-4" aria-hidden="true" />
             </Button>
           </div>
 

--- a/apps/web/src/app/reports/[questionId]/_components/history/collapsible-history.tsx
+++ b/apps/web/src/app/reports/[questionId]/_components/history/collapsible-history.tsx
@@ -48,6 +48,7 @@ function CollapsibleHistory({ history, selectedId }: CollapsibleHistoryProps) {
           onClick={() => setIsOpen(true)}
           className="lg:hidden fixed right-0 top-20 z-30 flex items-center gap-2 bg-teal-500 hover:bg-teal-600 text-white pl-3 pr-2 py-3 rounded-l-xl shadow-lg transition-all hover:pr-3 group"
           aria-label="시도 히스토리 열기"
+          aria-expanded={isOpen}
         >
           <History className="w-4 h-4" />
           <span className="text-sm font-semibold whitespace-nowrap">

--- a/apps/web/src/app/reports/[questionId]/_components/report-header.tsx
+++ b/apps/web/src/app/reports/[questionId]/_components/report-header.tsx
@@ -26,9 +26,9 @@ function ReportHeader({ question, highestScore }: ReportHeaderProps) {
           나의 최고 점수 : {highestScore ?? 0}점
         </div>
       </div>
-      <h2 className="text-lg md:text-xl font-bold mb-2 md:mb-3">
+      <h1 className="text-lg md:text-xl font-bold mb-2 md:mb-3">
         {question.title}
-      </h2>
+      </h1>
       <p className="text-sm md:text-base text-gray-600 leading-relaxed mb-4 md:mb-6">
         {question.content}
       </p>
@@ -40,7 +40,7 @@ function ReportHeader({ question, highestScore }: ReportHeaderProps) {
           className="font-semibold text-slate-600"
         >
           <Link href={`/daily/questions/${question.id}/others`}>
-            <Users className="w-4 h-4" />
+            <Users className="w-4 h-4" aria-hidden="true" />
             다른 사람 답변 보기
           </Link>
         </Button>

--- a/apps/web/src/components/header/header.tsx
+++ b/apps/web/src/components/header/header.tsx
@@ -10,13 +10,18 @@ async function Header() {
   const isLoggedIn = await hasAccessToken();
 
   return (
-    <div className="sticky top-0 z-40 w-full h-16 flex justify-center items-center bg-white border-slate-200 border-b">
+    <header className="sticky top-0 z-40 w-full h-16 flex justify-center items-center bg-white border-slate-200 border-b">
       <div className="w-full h-full max-w-5xl px-4 md:px-8 flex justify-between items-center">
         <Link href={"/"} className="flex gap-2 items-center">
-          <Image width={32} height={32} src={"/mmh-logo.svg"} alt="logo" />
+          <Image
+            width={32}
+            height={32}
+            src={"/mmh-logo.svg"}
+            alt="말만해 로고"
+          />
           <div className="font-bold text-xl text-slate-700">말만해</div>
         </Link>
-        <section className="hidden md:flex gap-2.5 items-center">
+        <nav className="hidden md:flex gap-2.5 items-center">
           <Button
             variant="ghost"
             className="py-2 px-3.5 font-medium text-base text-slate-500 hover:bg-teal-50 hover:text-teal-500 hover:font-semibold"
@@ -33,8 +38,12 @@ async function Header() {
                 className="rounded-full bg-teal-50 hover:bg-teal-100"
                 asChild
               >
-                <Link href="/mypage">
-                  <User stroke="#14B8A6" className="w-6 h-6" />
+                <Link href="/mypage" aria-label="마이페이지">
+                  <User
+                    stroke="#14B8A6"
+                    className="w-6 h-6"
+                    aria-hidden="true"
+                  />
                 </Link>
               </Button>
             </>
@@ -43,10 +52,10 @@ async function Header() {
               <Link href="/login">로그인</Link>
             </Button>
           )}
-        </section>
+        </nav>
         <MobileNav isLoggedIn={isLoggedIn} />
       </div>
-    </div>
+    </header>
   );
 }
 

--- a/apps/web/src/components/header/mobile-nav.tsx
+++ b/apps/web/src/components/header/mobile-nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { Button } from "../button/button";
 import { logoutAction } from "@/app/(auth)/_utils/auth";
@@ -15,6 +15,18 @@ function MobileNav({ isLoggedIn }: MobileNavProps) {
   const toggleMenu = () => setIsOpen((prev) => !prev);
   const closeMenu = () => setIsOpen(false);
 
+  // Escape 키로 메뉴 닫기
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen) {
+        closeMenu();
+      }
+    };
+
+    window.addEventListener("keydown", handleEscape);
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [isOpen]);
+
   return (
     <>
       <Button
@@ -23,6 +35,8 @@ function MobileNav({ isLoggedIn }: MobileNavProps) {
         className="md:hidden relative"
         onClick={toggleMenu}
         aria-label={isOpen ? "메뉴 닫기" : "메뉴 열기"}
+        aria-expanded={isOpen}
+        aria-controls="mobile-menu"
         type="button"
       >
         <div className="w-6 h-6 flex flex-col justify-center items-center gap-1.5">
@@ -42,11 +56,18 @@ function MobileNav({ isLoggedIn }: MobileNavProps) {
       {isOpen && (
         <>
           <div
+            role="presentation"
+            aria-hidden="true"
             className="fixed inset-x-0 top-16 bottom-0 bg-black/40 z-50 md:hidden"
             onClick={closeMenu}
           />
 
-          <nav className="fixed top-16 left-0 right-0 bg-white z-50 md:hidden border-b border-slate-200 shadow-lg animate-in slide-in-from-top-2 duration-200">
+          <nav
+            id="mobile-menu"
+            role="navigation"
+            aria-label="모바일 메뉴"
+            className="fixed top-16 left-0 right-0 bg-white z-50 md:hidden border-b border-slate-200 shadow-lg animate-in slide-in-from-top-2 duration-200"
+          >
             <div className="flex flex-col p-4 gap-2">
               <Button
                 variant="ghost"

--- a/apps/web/src/components/toggle/toggle.tsx
+++ b/apps/web/src/components/toggle/toggle.tsx
@@ -64,6 +64,8 @@ function Toggle({
             key={option.value}
             type="button"
             onClick={() => onChange(option.value)}
+            aria-pressed={isSelected}
+            aria-label={option.label}
             className={cn(
               "flex-1 z-20 h-full text-center rounded-md text-sm font-bold transition-colors duration-200 bg-transparent",
               isSelected


### PR DESCRIPTION
## 🔸 작업 내용

- #331 

## 🔸 고민 했던 부분

- 키보드 테스트로 모든 페이지 탐색이 가능한지를 우선순위로 두었습니다. 나머지 부분은 AI와 함께 분석하고 수정했습니다.
- 주요 추가된 aria 속성: aria-pressed, aria-expanded, aria-label, aria-hidden, aria-live, aria-modal, scope
- 더 자세한 변경사항은 커밋 메시지로 작성했습니다.   
- 색상 대비 부분은 디자인을 건드린다고 생각해서 일단 수정하지 않았습니다!
- 모든 부분에서 개선이 된 것이 아니라서 리팩토링 과정에서 추가로 확인해주셔도 좋을 것 같습니다.

## 🔸 참고

### 테스트 방법
1. 키보드 테스트
```
1. 마우스 없이 Tab 키만으로 페이지 탐색
2. Enter/Space로 버튼 클릭
3. Escape로 모달 닫기
4. 화살표 키로 탭 탐색
```
2. 스크린 리더 테스트 (NVDA 설치)
```
1. Question Modal
   - 모달 열면 "Dialog, 질문 제목" 읽는지 확인
   - 답변 모드 버튼에서 "눌림" 또는 "눌리지 않음" 읽는지 확인

2. Report Page
   - 페이지 진입 시 h1 제목 읽는지 확인
   - 분석 중일 때 "분석 중" 자동 안내되는지 확인

3. Others Page
   - 테이블에서 "사용자 열, 홍길동" 형태로 읽는지 확인
   - 페이지네이션 "현재 1페이지, 전체 5페이지" 읽는지 확인

4. Header
   - H 키로 "헤더 랜드마크" 이동 가능한지 확인
   - D 키로 "네비게이션 랜드마크" 이동 가능한지 확인
```

- 변경사항이 기존 기능에 영향을 주지 않는지, Tab/Enter/Escape 키로 모든 기능이 작동하는지 천천히 확인해주시면 될 거 같습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **개선사항**
  * Escape 키로 모달과 모바일 메뉴 닫기 지원 추가
  * 버튼들의 상태 표시(확장/눌림) 및 입력 필드 레이블 강화
  * 테이블 헤더의 시맨틱 개선(열 범위 명시) 및 페이지네비게이션 접근성 향상
  * 차트/시각화 캔버스와 게이지에 설명 레이블 추가
  * 장식용 아이콘을 보조기술에서 숨기도록 조정
  * 헤더 구조와 로고 대체 텍스트 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->