### PR TITLE
grafana에서 loki 설정을 위해 임시적으로 auth 제거

### DIFF
--- a/apps/web/src/app/(auth)/_components/signup-form.tsx
+++ b/apps/web/src/app/(auth)/_components/signup-form.tsx
@@ -224,54 +224,30 @@ function SignUpForm({ signupAction }: SignUpFormProps) {
             id="terms"
             name="terms"
             onCheckedChange={(checked: boolean) => setAgreed(checked)}
+            required
           />
-        </InputGroup>
-        <p
-          className={`text-[11px] mt-1.5 ml-1 font-medium text-red-500 ${
-            formData.passwordConfirm && !validation.passwordConfirm
-              ? "block"
-              : "hidden"
-          }`}
-        >
-          * 비밀번호가 일치하지 않습니다.
-        </p>
-      </div>
-
-      <div className="flex items-center gap-2 py-2 mb-4">
-        <Checkbox
-          id="terms"
-          name="terms"
-          onCheckedChange={(checked: boolean) => setAgreed(checked)}
-          required
-        />
-        <label htmlFor="terms" className="text-xs text-muted-foreground">
-          <Link
-            href="/policy/service-terms"
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={(e) => e.stopPropagation()}
-            className="text-teal-600 font-semibold hover:underline"
-          >
-            서비스 이용약관
-          </Link>
-          및{" "}
-          <Link
-            href="/policy/privacy"
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={(e) => e.stopPropagation()}
-            className="text-teal-600 font-semibold hover:underline"
-          >
-            개인정보 처리방침
-          </Link>
-          에 동의합니다.
-        </label>
-      </div>
-
-      {serverErrorMessage && (
-        <div className="flex items-center gap-2 mb-4 p-3 rounded-md bg-red-50 text-red-600 text-xs font-medium animate-in fade-in slide-in-from-top-1">
-          <AlertCircle className="w-4 h-4 shrink-0" />
-          <span>{serverErrorMessage}</span>
+          <label htmlFor="terms" className="text-xs text-muted-foreground">
+            <Link
+              href="/policy/service-terms"
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              className="text-teal-600 font-semibold hover:underline"
+            >
+              서비스 이용약관
+            </Link>
+            및{" "}
+            <Link
+              href="/policy/privacy"
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              className="text-teal-600 font-semibold hover:underline"
+            >
+              개인정보 처리방침
+            </Link>
+            에 동의합니다.
+          </label>
         </div>
 
         {serverErrorMessage && (

--- a/apps/web/src/app/daily/questions/[questionId]/others/page.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/others/page.tsx
@@ -147,43 +147,47 @@ async function OthersPage({ params, searchParams }: OthersPageProps) {
             </TableCell>
 
             <TableCell colSpan={2} className="text-right">
-              <Pagination className="justify-end">
-                <PaginationContent>
-                  <PaginationItem>
-                    {currentPage > 1 ? (
-                      <PaginationPrevious
-                        href={buildPaginationUrl(currentPage - 1)}
-                      />
-                    ) : (
-                      <PaginationPrevious
-                        href={buildPaginationUrl(currentPage)}
-                        className="pointer-events-none opacity-50"
-                        aria-disabled="true"
-                      />
-                    )}
-                  </PaginationItem>
+              {totalPages > 0 ? (
+                <Pagination className="justify-end">
+                  <PaginationContent>
+                    <PaginationItem>
+                      {currentPage > 1 ? (
+                        <PaginationPrevious
+                          href={buildPaginationUrl(currentPage - 1)}
+                        />
+                      ) : (
+                        <PaginationPrevious
+                          href={buildPaginationUrl(currentPage)}
+                          className="pointer-events-none opacity-50"
+                          aria-disabled="true"
+                        />
+                      )}
+                    </PaginationItem>
 
-                  <PaginationItem>
-                    <div className="px-2">
-                      {currentPage} / {totalPages}
-                    </div>
-                  </PaginationItem>
+                    <PaginationItem>
+                      <div className="px-2">
+                        {currentPage} / {totalPages}
+                      </div>
+                    </PaginationItem>
 
-                  <PaginationItem>
-                    {currentPage < totalPages ? (
-                      <PaginationNext
-                        href={buildPaginationUrl(currentPage + 1)}
-                      />
-                    ) : (
-                      <PaginationNext
-                        href={buildPaginationUrl(currentPage)}
-                        className="pointer-events-none opacity-50"
-                        aria-disabled="true"
-                      />
-                    )}
-                  </PaginationItem>
-                </PaginationContent>
-              </Pagination>
+                    <PaginationItem>
+                      {currentPage < totalPages ? (
+                        <PaginationNext
+                          href={buildPaginationUrl(currentPage + 1)}
+                        />
+                      ) : (
+                        <PaginationNext
+                          href={buildPaginationUrl(currentPage)}
+                          className="pointer-events-none opacity-50"
+                          aria-disabled="true"
+                        />
+                      )}
+                    </PaginationItem>
+                  </PaginationContent>
+                </Pagination>
+              ) : (
+                <span className="text-muted-foreground text-sm">—</span>
+              )}
             </TableCell>
           </TableRow>
         </TableFooter>

--- a/infra/loki-config.yaml
+++ b/infra/loki-config.yaml
@@ -1,4 +1,4 @@
-auth_enabled: true
+auth_enabled: false
 
 server:
   http_listen_port: 3100


### PR DESCRIPTION
## 🔸 작업 내용

- Loki 데이터소스 연결 이슈 해결을 위해 `auth_enabled` 설정을 **임시적으로 비활성화**
- Grafana ↔ Loki 간 health check 및 메타데이터 API 호출 실패 문제 해소
- 로그 수집/조회 정상 동작 확인

## 🔸 고민 했던 부분

- Grafana에서 Loki 멀티테넌시(`auth_enabled: true`) 사용 시 일부 내부 요청에 `X-Scope-OrgID` 헤더가 포함되지 않는 구조적 제약이 존재
- Gateway 도입 등 대안도 고려했으나, 현재는 **단일 프로젝트 + 내부 네트워크 환경**이므로 복잡도를 줄이기 위해 인증을 임시 제거하는 방향으로 결정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 시스템 인증 설정(auth_enabled)이 비활성화되었습니다.

* **Bug Fixes / UI 개선**
  * 회원가입 폼에서 이용약관 동의 체크박스가 필수로 설정되고, 약관 링크가 체크박스 레이블에 통합되어 접근성이 개선되었습니다.
  * 비밀번호 불일치 관련 중복 오류 문구가 제거되어 폼 표시가 간소화되었습니다.
  * 목록의 페이지가 없을 때 페이지네이션 대신 음영 처리된 대시(—)를 표시하도록 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->