### PR TITLE
다른 사람 답변 리스트에서 닉네임 중간 마스킹 처리

### DIFF
--- a/apps/web/src/app/daily/questions/[questionId]/others/[submissionId]/page.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/others/[submissionId]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { fetchOthersSubmission } from "../_lib/fetch-others-submission";
 import formatSubmittedAt from "../_lib/format-submitted-at";
 import ScoreGauge from "@/app/reports/[questionId]/_components/feedback/score-gauge";
+import { maskNickname } from "@/lib/mask-nickname";
 
 const parseIntOrNull = (value: string | undefined): number | null => {
   if (value === undefined) return null;
@@ -62,7 +63,7 @@ async function OthersDetailPage({ params }: OthersSubmissionDetailPageProps) {
                 </div>
                 <div className="flex flex-col">
                   <div className="text-lg font-semibold">
-                    {othersSubmissionData.nickname}
+                    {maskNickname(othersSubmissionData.nickname)}
                   </div>
                   <div className="text-sm font-medium text-muted-foreground">
                     제출 일시:{" "}

--- a/apps/web/src/app/daily/questions/[questionId]/others/page.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/others/page.tsx
@@ -19,6 +19,7 @@ import { User } from "lucide-react";
 import Link from "next/link";
 import { fetchOthersSubmissions } from "./_lib/fetch-others-submissions";
 import formatSubmittedAt from "./_lib/format-submitted-at";
+import { maskNickname } from "@/lib/mask-nickname";
 import parseIntOrNull from "@/lib/parse-int-or-null";
 import { notFound } from "next/navigation";
 import { ScoreBadge } from "@/components/score-badge/score-badge";
@@ -117,7 +118,7 @@ async function OthersPage({ params, searchParams }: OthersPageProps) {
 
                       <div className="min-w-0">
                         <div className="font-medium truncate">
-                          {submission.nickname}
+                          {maskNickname(submission.nickname)}
                         </div>
                         <div className="text-muted-foreground text-xs">
                           {formatSubmittedAt(submission.submittedAt)}

--- a/apps/web/src/lib/mask-nickname.ts
+++ b/apps/web/src/lib/mask-nickname.ts
@@ -1,0 +1,36 @@
+/**
+ * 닉네임 중간 부분을 마스킹합니다.
+ * 익명성 보장을 위해 목록 등에서 사용합니다.
+ *
+ * 마스킹 규칙:
+ * - 1글자: 그대로 노출
+ * - 2글자: 김수 → 김*
+ * - 3글자: 홍길동 → 홍*동
+ * - 4글자 이상: developer → de****er (앞 2글자 + 뒤 2글자 노출)
+ */
+function maskNickname(nickname: string): string {
+  const trimmed = nickname.trim();
+  if (!trimmed) return nickname;
+
+  const length = trimmed.length;
+
+  if (length === 1) {
+    return trimmed;
+  }
+
+  if (length === 2) {
+    return `${trimmed[0]}*`;
+  }
+
+  if (length === 3) {
+    return `${trimmed[0]}*${trimmed[2]}`;
+  }
+
+  // 4글자 이상: 앞 2글자 + 마스킹(고정 4개) + 뒤 2글자
+  const MASK_LENGTH = 4;
+  const asterisks = "*".repeat(MASK_LENGTH);
+
+  return `${trimmed.slice(0, 2)}${asterisks}${trimmed.slice(-2)}`;
+}
+
+export { maskNickname };

--- a/apps/web/src/lib/mask-nickname.ts
+++ b/apps/web/src/lib/mask-nickname.ts
@@ -26,6 +26,10 @@ function maskNickname(nickname: string): string {
     return `${trimmed[0]}*${trimmed[2]}`;
   }
 
+  if (length === 4) {
+    return `${trimmed[0]}*${trimmed[3]}`;
+  }
+
   // 4글자 이상: 앞 2글자 + 마스킹(고정 4개) + 뒤 2글자
   const MASK_LENGTH = 4;
   const asterisks = "*".repeat(MASK_LENGTH);


### PR DESCRIPTION
## 🔸 작업 내용

### **구현 내용**

**1. 닉네임 마스킹 유틸리티 추가**

`apps/web/src/lib/mask-nickname.ts`에 `maskNickname` 함수를 추가했습니다.


닉네임 길이 | 예시 입력 | 예시 출력
-- | -- | --
1글자 | 김 | 김
2글자 | 김수 | 김*
3글자 | 홍길동 | 홍*동
4글자 이상 | developer | de****er


**2. 다른 사람 답변 목록에 마스킹 적용**

`apps/web/src/app/daily/questions/[questionId]/others/page.tsx`의 목록에서 닉네임을 `maskNickname`으로 마스킹해 표시하도록 수정했습니다.

**3. 답변 상세보기 페이지에 마스킹 적용**

답변 상세 페이지(`/daily/questions/[questionId]/others/[submissionId]`)의 닉네임에도 마스킹을 적용했습니다. 

## 🔸 고민 했던 부분

- **4글자 초과 닉네임의 마스킹 기준**을 어떻게 가져갈지 고민했습니다.
    - 앞뒤 1글자씩만 노출할지
    - 앞뒤 2글자를 노출할지
- 최종적으로는 **닉네임 길이에 상관없이 “중간 4글자를 마스킹”** 하는 방식이
    - 구현 규칙이 단순하고
    - UI 상에서도 마스킹 강도가 과도하지 않다고 판단해 현재 방식으로 결정했습니다.

## 🔸 참고

### 다른 사람 답변 목록 

<img width="766" height="320" alt="스크린샷 2026-02-03 14 02 31" src="https://github.com/user-attachments/assets/c78f8847-f28a-45d4-943d-935b4dd0a8db" />


### 답변 상세보기

<img width="801" height="500" alt="스크린샷 2026-02-03 14 09 05" src="https://github.com/user-attachments/assets/399f0f7b-be68-485a-a89f-09a51d6e87e2" /

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 닉네임 마스킹 기능이 추가되어 사용자 닉네임의 가운데 부분이 별표로 대체됩니다. 개인정보 보호를 위해 여러 페이지에서 마스킹된 닉네임이 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->