### PR TITLE
그래프뷰에 scale 조정하는 슬라이더 추가

### DIFF
--- a/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
+++ b/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
@@ -13,6 +13,8 @@ interface GraphViewProps {
   zoomEnabled?: boolean;
   showLabels?: boolean;
   initialScale?: number;
+  scale?: number;
+  onScaleChange?: (scale: number) => void;
 }
 
 function GraphView({
@@ -22,6 +24,8 @@ function GraphView({
   zoomEnabled = true,
   showLabels = true,
   initialScale,
+  scale,
+  onScaleChange,
 }: GraphViewProps) {
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
   const { ctx, getWidth, getHeight } = useCanvas2D(canvasRef);
@@ -38,6 +42,8 @@ function GraphView({
     textRenderScale,
     showLabels,
     initialScale,
+    scale,
+    onScaleChange,
   });
 
   // 휠 이벤트 바인딩 (passive: false 필요)

--- a/apps/web/src/app/mypage/_components/graph-view/scale-slider.tsx
+++ b/apps/web/src/app/mypage/_components/graph-view/scale-slider.tsx
@@ -15,7 +15,7 @@ function ScaleSlider({
   minScale = GRAPH_NUMBER_CONSTANT.MIN_SCALE,
   maxScale = GRAPH_NUMBER_CONSTANT.MAX_SCALE,
 }: ScaleSliderProps) {
-  const scaleStep = 0.2;
+  const scaleStep = GRAPH_NUMBER_CONSTANT.BUTTON_SCALE_STEP;
 
   const handleZoomIn = () => {
     const newScale = Math.min(maxScale, scale + scaleStep);
@@ -48,7 +48,7 @@ function ScaleSlider({
           onValueChange={handleSliderChange}
           min={minScale}
           max={maxScale}
-          step={0.05}
+          step={GRAPH_NUMBER_CONSTANT.SLIDER_SCALE_STEP}
           className="h-28"
         />
       </div>

--- a/apps/web/src/app/mypage/_components/graph-view/scale-slider.tsx
+++ b/apps/web/src/app/mypage/_components/graph-view/scale-slider.tsx
@@ -1,0 +1,67 @@
+import { Slider } from "@/components/slider/slider";
+import { Minus, Plus } from "lucide-react";
+import { GRAPH_NUMBER_CONSTANT } from "../../_constants/graph-view-constant";
+
+interface ScaleSliderProps {
+  scale: number;
+  onScaleChange: (scale: number) => void;
+  minScale?: number;
+  maxScale?: number;
+}
+
+function ScaleSlider({
+  scale,
+  onScaleChange,
+  minScale = GRAPH_NUMBER_CONSTANT.MIN_SCALE,
+  maxScale = GRAPH_NUMBER_CONSTANT.MAX_SCALE,
+}: ScaleSliderProps) {
+  const scaleStep = 0.2;
+
+  const handleZoomIn = () => {
+    const newScale = Math.min(maxScale, scale + scaleStep);
+    onScaleChange(newScale);
+  };
+
+  const handleZoomOut = () => {
+    const newScale = Math.max(minScale, scale - scaleStep);
+    onScaleChange(newScale);
+  };
+
+  const handleSliderChange = (value: number[]) => {
+    onScaleChange(value[0]);
+  };
+
+  return (
+    <div className="flex flex-col gap-2 border rounded-md p-1">
+      <button
+        onClick={handleZoomIn}
+        disabled={scale >= maxScale}
+        className="p-2 rounded-xl hover:bg-teal-50 hover:text-teal-600 transition-all duration-200 disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-gray-700 active:scale-95"
+        aria-label="확대"
+      >
+        <Plus className="w-4 h-4" strokeWidth={2.5} />
+      </button>
+      <div>
+        <Slider
+          orientation="vertical"
+          value={[scale]}
+          onValueChange={handleSliderChange}
+          min={minScale}
+          max={maxScale}
+          step={0.05}
+          className="h-28"
+        />
+      </div>
+      <button
+        onClick={handleZoomOut}
+        disabled={scale <= minScale}
+        className="p-2 rounded-xl hover:bg-teal-50 hover:text-teal-600 transition-all duration-200 disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-gray-700 active:scale-95"
+        aria-label="축소"
+      >
+        <Minus className="w-4 h-4" strokeWidth={2.5} />
+      </button>
+    </div>
+  );
+}
+
+export default ScaleSlider;

--- a/apps/web/src/app/mypage/_components/graph-view/use-graph-renderer.ts
+++ b/apps/web/src/app/mypage/_components/graph-view/use-graph-renderer.ts
@@ -84,6 +84,7 @@ function useGraphRenderer({
   const offset = React.useRef({ x: 0, y: 0 });
   const scale = React.useRef(initialScale);
   const initializedOffset = React.useRef(false);
+  const isInternalScaleChange = React.useRef(false);
 
   // 인터랙션 상태
   const isDraggingCanvas = React.useRef(false);
@@ -119,7 +120,20 @@ function useGraphRenderer({
     if (externalScale !== undefined) {
       scale.current = externalScale;
     }
-  }, [externalScale]);
+
+    // 내부에서 변경한 scale인 경우 offset 재조정 스킵
+    if (isInternalScaleChange.current) {
+      isInternalScaleChange.current = false;
+      return;
+    }
+
+    const width = getWidth();
+    const height = getHeight();
+    offset.current = {
+      x: (width * (1 - scale.current)) / 2,
+      y: (height * (1 - scale.current)) / 2,
+    };
+  }, [externalScale, getWidth, getHeight]);
 
   // 초기 스케일이 0.5일 때 중앙 정렬을 위한 offset 조정
   React.useEffect(() => {
@@ -258,8 +272,9 @@ function useGraphRenderer({
 
       scale.current = newScale;
 
-      // 외부 scale 상태 업데이트
+      // 외부 scale 상태 업데이트 (내부 변경임을 표시)
       if (onScaleChange) {
+        isInternalScaleChange.current = true;
         onScaleChange(newScale);
       }
     },

--- a/apps/web/src/app/mypage/_components/graph-view/use-graph-renderer.ts
+++ b/apps/web/src/app/mypage/_components/graph-view/use-graph-renderer.ts
@@ -1,5 +1,7 @@
 import * as React from "react";
 import { GRAPH_NUMBER_CONSTANT } from "../../_constants/graph-view-constant";
+import { addRandomEdgeDistance } from "../../_lib/graph-view/add-random-edge-distance";
+import drawGraphView from "../../_lib/graph-view/draw-graph-view";
 import {
   GraphData,
   GraphEdge,
@@ -7,8 +9,6 @@ import {
   NodePosition,
 } from "../../_types/graph-view";
 import NodeMap from "./node-map";
-import drawGraphView from "../../_lib/graph-view/draw-graph-view";
-import { addRandomEdgeDistance } from "../../_lib/graph-view/add-random-edge-distance";
 
 // 호버된 노드와 연결된 모든 노드 ID를 반환
 function getConnectedNodeIds(
@@ -40,7 +40,9 @@ export interface UseGraphRendererOptions {
   onClickNode?: (questionId: number) => void;
   textRenderScale?: number;
   showLabels?: boolean;
-  initialScale?: number;
+  initialScale?: number; // scale의 초기값만 저장
+  scale?: number; // 외부에서 scale 조정할 때 사용
+  onScaleChange?: (scale: number) => void;
 }
 
 export interface GraphRendererReturn {
@@ -69,6 +71,8 @@ function useGraphRenderer({
   textRenderScale = 0.5,
   showLabels = true,
   initialScale = 0.5,
+  scale: externalScale,
+  onScaleChange,
 }: UseGraphRendererOptions): GraphRendererReturn {
   // 엣지에 랜덤 거리 적용 (한 번만 계산)
   const processedEdges = React.useMemo(
@@ -109,6 +113,13 @@ function useGraphRenderer({
 
     nodeMapRef.current = newNodeMap;
   }, [getWidth, getHeight, graphData.nodes, externalNodeMap, processedEdges]);
+
+  // 외부 scale과 동기화
+  React.useEffect(() => {
+    if (externalScale !== undefined) {
+      scale.current = externalScale;
+    }
+  }, [externalScale]);
 
   // 초기 스케일이 0.5일 때 중앙 정렬을 위한 offset 조정
   React.useEffect(() => {
@@ -229,6 +240,32 @@ function useGraphRenderer({
     [onClickNode],
   );
 
+  // 줌 처리 함수 (마우스 위치 기준)
+  const handleZoom = React.useCallback(
+    (mouseX: number, mouseY: number, scaleAmount: number) => {
+      const newScale = Math.max(
+        GRAPH_NUMBER_CONSTANT.MIN_SCALE,
+        Math.min(GRAPH_NUMBER_CONSTANT.MAX_SCALE, scale.current + scaleAmount),
+      );
+
+      const adjustedMouseX = mouseX - offset.current.x;
+      const adjustedMouseY = mouseY - offset.current.y;
+
+      offset.current.x -=
+        (adjustedMouseX / scale.current) * (newScale - scale.current);
+      offset.current.y -=
+        (adjustedMouseY / scale.current) * (newScale - scale.current);
+
+      scale.current = newScale;
+
+      // 외부 scale 상태 업데이트
+      if (onScaleChange) {
+        onScaleChange(newScale);
+      }
+    },
+    [onScaleChange],
+  );
+
   // 휠 이벤트 바인딩
   const bindWheelEvent = React.useCallback(() => {
     const canvas = canvasRef.current;
@@ -239,25 +276,14 @@ function useGraphRenderer({
 
       const { offsetX, offsetY, deltaY } = e;
       const scaleAmount = -deltaY * 0.001;
-      const newScale = Math.max(
-        GRAPH_NUMBER_CONSTANT.MIN_SCALE,
-        Math.min(GRAPH_NUMBER_CONSTANT.MAX_SCALE, scale.current + scaleAmount),
-      );
-
-      const mouseX = offsetX - offset.current.x;
-      const mouseY = offsetY - offset.current.y;
-
-      offset.current.x -= (mouseX / scale.current) * (newScale - scale.current);
-      offset.current.y -= (mouseY / scale.current) * (newScale - scale.current);
-
-      scale.current = newScale;
+      handleZoom(offsetX, offsetY, scaleAmount);
     };
 
     canvas.addEventListener("wheel", handleWheel, { passive: false });
     return () => {
       canvas.removeEventListener("wheel", handleWheel);
     };
-  }, [canvasRef]);
+  }, [canvasRef, handleZoom]);
 
   // drawGraph 함수
   const drawGraph = React.useCallback(

--- a/apps/web/src/app/mypage/_constants/graph-view-constant.ts
+++ b/apps/web/src/app/mypage/_constants/graph-view-constant.ts
@@ -7,6 +7,8 @@ export const GRAPH_NUMBER_CONSTANT = {
   EDGE_STROKE_WIDTH: 2,
   MIN_EDGE_STROKE_WIDTH: 2, // 줌 아웃 시 최소 시각적 굵기 (픽셀 단위)
   MAX_EDGE_STROKE_WIDTH: 2, // 줌 인 시 최대 시각적 굵기 (픽셀 단위)
+  BUTTON_SCALE_STEP: 0.2, // 슬라이더 버튼 클릭시 동작 범위
+  SLIDER_SCALE_STEP: 0.05, // 슬라이더 내부 슬라이드 기능시 동작 범위
 } as const;
 
 export const GRAPH_COLOR_CONSTANT = {

--- a/apps/web/src/app/mypage/_contents/graph-content.tsx
+++ b/apps/web/src/app/mypage/_contents/graph-content.tsx
@@ -4,10 +4,14 @@ import { Button } from "@/components/button/button";
 import { BarChart3, Expand } from "lucide-react";
 import * as React from "react";
 import GraphView from "../_components/graph-view/graph-view";
+import ScaleSlider from "../_components/graph-view/scale-slider";
 import { GraphData } from "../_types/graph-view";
+
+const INITIAL_GRAPH_SCALE = 0.5;
 
 function GraphContent({ graphData }: { graphData: GraphData }) {
   const [openModalStatus, setOpenModalStatus] = React.useState(false);
+  const [scale, setScale] = React.useState(INITIAL_GRAPH_SCALE);
   const handleModalToggle = React.useCallback(() => {
     setOpenModalStatus((prev) => !prev);
   }, []);
@@ -28,16 +32,22 @@ function GraphContent({ graphData }: { graphData: GraphData }) {
         </div>
       ) : (
         <div className="relative w-full h-120">
-          <Button
-            onClick={handleModalToggle}
-            size="icon"
-            variant="outline"
-            className="absolute right-0 top-6 md:top-8"
-            aria-label="그래프 확대"
-          >
-            <Expand className="text-muted-foreground" />
-          </Button>
-          <GraphView graphData={graphData} />
+          <div className="absolute right-0 top-6 md:top-8 z-10 flex flex-col items-center gap-5">
+            <Button
+              onClick={handleModalToggle}
+              size="icon"
+              variant="outline"
+              aria-label="그래프 확대"
+            >
+              <Expand className="text-muted-foreground" />
+            </Button>
+            <ScaleSlider scale={scale} onScaleChange={setScale} />
+          </div>
+          <GraphView
+            graphData={graphData}
+            scale={scale}
+            onScaleChange={setScale}
+          />
         </div>
       )}
       {openModalStatus && (
@@ -53,8 +63,15 @@ function GraphContent({ graphData }: { graphData: GraphData }) {
             onClick={(e) => e.stopPropagation()}
             className="bg-white rounded-xl md:rounded-2xl w-full h-full max-w-5xl max-h-[90vh] md:max-h-5/6 shadow-xl overflow-hidden relative"
           >
+            <div className="absolute right-4 top-4 z-10">
+              <ScaleSlider scale={scale} onScaleChange={setScale} />
+            </div>
             <div className="w-full h-full">
-              <GraphView graphData={graphData} />
+              <GraphView
+                graphData={graphData}
+                scale={scale}
+                onScaleChange={setScale}
+              />
             </div>
           </div>
         </div>

--- a/apps/web/src/app/mypage/_contents/graph-content.tsx
+++ b/apps/web/src/app/mypage/_contents/graph-content.tsx
@@ -7,7 +7,7 @@ import GraphView from "../_components/graph-view/graph-view";
 import ScaleSlider from "../_components/graph-view/scale-slider";
 import { GraphData } from "../_types/graph-view";
 
-const INITIAL_GRAPH_SCALE = 0.5;
+const INITIAL_GRAPH_SCALE = 1;
 
 function GraphContent({ graphData }: { graphData: GraphData }) {
   const [openModalStatus, setOpenModalStatus] = React.useState(false);

--- a/apps/web/src/components/slider/slider.tsx
+++ b/apps/web/src/components/slider/slider.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import * as React from "react";
-import { Slider as SliderPrimitive } from "radix-ui";
 import { cn } from "@/lib/cn";
+import { Slider as SliderPrimitive } from "radix-ui";
+import * as React from "react";
 
 function Slider({
   className,
@@ -30,18 +30,18 @@ function Slider({
       min={min}
       max={max}
       className={cn(
-        "data-vertical:min-h-40 relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-vertical:h-full data-vertical:w-auto data-vertical:flex-col",
+        "data-vertical:min-h-40 relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-vertical:h-full data-vertical:w-auto data-vertical:flex-col justify-center",
         className,
       )}
       {...props}
     >
       <SliderPrimitive.Track
         data-slot="slider-track"
-        className="rounded-full data-[orientation=horizontal]:h-1 data-[orientation=horizontal]:w-full data-vertical:h-full data-vertical:w-1 bg-muted relative grow overflow-hidden"
+        className="rounded-full data-[orientation=horizontal]:h-1 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1 bg-muted relative overflow-hidden"
       >
         <SliderPrimitive.Range
           data-slot="slider-range"
-          className="bg-primary absolute select-none data-[orientation=horizontal]:h-full data-vertical:w-full"
+          className="bg-primary absolute select-none data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full data-[orientation=vertical]:bottom-0"
         />
       </SliderPrimitive.Track>
       {Array.from({ length: _values.length }, (_, index) => (


### PR DESCRIPTION
## 🔸 작업 내용
- scale-slider 컴포넌트 구현
- graph-content에 slider 적용

## 🔸 고민 했던 부분

### use-graph-renderer에서 initialScale과 외부 주입 scale의 통합 여부
- useGraphRender 훅에서 initialScale과 scale을 두 개 받습니다.
- 이 둘을 통합해야할까 말아야할까에 대해 고민하였습니다.
- `initialScale`-> 랜딩 페이지에서 초기 줌 스케일을 조작하기 위해 적용 / `scale` -> 마이페이지에서 scale Slider 컴포넌트를 통해 줌 스케일을 조작하기 위해 적용
- 둘을 결합하여 props로 받는 개수를 줄일지 분리하여 defalutValue와 value 차이를 명확하게 구분할지에 대해 고민하였습니다.
- 사용 의도를 명확히 구분짓는 것이 현재 상황에서 더 나을 것이라 판단하고 분리하는 방향으로 구현하였습니다.


## 🔸 참고

### 스케일 슬라이더 컴포넌트 동작 예시

https://github.com/user-attachments/assets/0d8d87e7-d125-4bda-83f8-5bbf1d86879a


### 모달 내부에도 적용된 컴포넌트 예시

<img width="1083" height="789" alt="스크린샷 2026-02-03 오후 2 33 11" src="https://github.com/user-attachments/assets/b353a47a-203d-417f-85a0-b31a01e363b0" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 그래프 스케일 제어 추가: 줌 인/아웃 버튼과 수직 슬라이더로 배율을 조절할 수 있습니다.
  * 외부 제어 및 변경 알림 지원: 외부에서 스케일을 설정하고 변경을 받을 수 있어 다른 뷰와 실시간 동기화됩니다.
* **스타일/컴포넌트 개선**
  * 슬라이더의 세로 방향 레이아웃 지원이 강화되어 수직 슬라이더 동작 및 접근성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->