### PR TITLE
Breadcrumb 컴포넌트 구현 및 다른 사람 답변 페이지에 적용

### DIFF
--- a/apps/web/src/app/daily/questions/[questionId]/others/[submissionId]/page.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/others/[submissionId]/page.tsx
@@ -44,7 +44,7 @@ async function OthersDetailPage({ params }: OthersSubmissionDetailPageProps) {
     <>
       <Header />
       <main className="w-full max-w-4xl mx-auto px-4 md:px-8 pt-6 md:pt-8 pb-8 md:pb-15 space-y-6 md:space-y-8 min-h-main">
-        <Breadcrumb className="mb-4 md:mb-6">
+        <Breadcrumb className="md:-ml-1.5 mb-4 md:mb-6">
           <BreadcrumbList>
             <BreadcrumbItem>
               <BreadcrumbLink href={`/reports/${questionId}`}>

--- a/apps/web/src/app/daily/questions/[questionId]/others/[submissionId]/page.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/others/[submissionId]/page.tsx
@@ -1,4 +1,12 @@
 import Header from "@/components/header/header";
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/breadcrumb/breadcrumb";
 import { User } from "lucide-react";
 import { notFound } from "next/navigation";
 import { fetchOthersSubmission } from "../_lib/fetch-others-submission";
@@ -35,7 +43,27 @@ async function OthersDetailPage({ params }: OthersSubmissionDetailPageProps) {
   return (
     <>
       <Header />
-      <main className="w-full max-w-4xl mx-auto px-4 md:px-8 py-8 md:py-15 space-y-6 md:space-y-8 min-h-main">
+      <main className="w-full max-w-4xl mx-auto px-4 md:px-8 pt-6 md:pt-8 pb-8 md:pb-15 space-y-6 md:space-y-8 min-h-main">
+        <Breadcrumb className="mb-4 md:mb-6">
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink href={`/reports/${questionId}`}>
+                나의 리포트
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbLink href={`/daily/questions/${questionId}/others`}>
+                다른 사람 답변
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>답변 상세</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+
         <div className="mb-8">
           <div className="flex items-center gap-2 text-base text-muted-foreground mb-2">
             <span className="font-medium">

--- a/apps/web/src/app/daily/questions/[questionId]/others/page.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/others/page.tsx
@@ -15,6 +15,14 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/table/table";
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/breadcrumb/breadcrumb";
 import { User } from "lucide-react";
 import Link from "next/link";
 import { fetchOthersSubmissions } from "./_lib/fetch-others-submissions";
@@ -71,7 +79,21 @@ async function OthersPage({ params, searchParams }: OthersPageProps) {
   return (
     <>
       <Header />
-      <main className="w-full max-w-4xl mx-auto px-4 md:px-8 py-8 md:py-15 space-y-6 md:space-y-8 min-h-main">
+      <main className="w-full max-w-4xl mx-auto px-4 md:px-8 pt-6 md:pt-8 pb-8 md:pb-15 space-y-6 md:space-y-8 min-h-main">
+        <Breadcrumb className="mb-4 md:mb-6">
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink href={`/reports/${questionId}`}>
+                나의 리포트
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>다른 사람 답변</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+
         <div className="mb-8">
           <div className="flex items-center gap-2 text-muted-foreground mb-2">
             <span className="font-medium">

--- a/apps/web/src/app/daily/questions/[questionId]/others/page.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/others/page.tsx
@@ -80,7 +80,7 @@ async function OthersPage({ params, searchParams }: OthersPageProps) {
     <>
       <Header />
       <main className="w-full max-w-4xl mx-auto px-4 md:px-8 pt-6 md:pt-8 pb-8 md:pb-15 space-y-6 md:space-y-8 min-h-main">
-        <Breadcrumb className="mb-4 md:mb-6">
+        <Breadcrumb className="md:-ml-1.5 mb-4 md:mb-6">
           <BreadcrumbList>
             <BreadcrumbItem>
               <BreadcrumbLink href={`/reports/${questionId}`}>

--- a/apps/web/src/components/breadcrumb/breadcrumb.stories.tsx
+++ b/apps/web/src/components/breadcrumb/breadcrumb.stories.tsx
@@ -1,0 +1,147 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Home, Slash } from "lucide-react";
+
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "./breadcrumb";
+
+const meta = {
+  title: "Components/Breadcrumb",
+  component: Breadcrumb,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-2xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Breadcrumb>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ReportExample: Story = {
+  name: "실제 사용 예시 (리포트)",
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/reports/1">나의 리포트</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>다른 사람 답변</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+};
+
+export const DetailExample: Story = {
+  name: "실제 사용 예시 (상세)",
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/reports/1">나의 리포트</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/daily/questions/1/others">
+            다른 사람 답변
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>답변 상세</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+};
+
+export const WithCustomSeparator: Story = {
+  name: "커스텀 구분자",
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/">홈</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator>
+          <Slash className="h-4 w-4" />
+        </BreadcrumbSeparator>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/category">카테고리</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator>
+          <Slash className="h-4 w-4" />
+        </BreadcrumbSeparator>
+        <BreadcrumbItem>
+          <BreadcrumbPage>현재 페이지</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+};
+
+export const WithIcon: Story = {
+  name: "아이콘 포함",
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/">
+            <Home className="h-4 w-4" />
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/category">카테고리</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>현재 페이지</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+};
+
+export const LongPath: Story = {
+  name: "긴 경로",
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/">홈</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/category">카테고리</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/subcategory">서브카테고리</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/item">항목</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>현재 페이지</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+};

--- a/apps/web/src/components/breadcrumb/breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumb/breadcrumb.tsx
@@ -53,7 +53,6 @@ function BreadcrumbLink({
 function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
   return (
     <span
-      role="link"
       aria-current="page"
       data-slot="breadcrumb-page"
       className={cn("font-medium text-teal-600", className)}

--- a/apps/web/src/components/breadcrumb/breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumb/breadcrumb.tsx
@@ -1,0 +1,90 @@
+import * as React from "react";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/cn";
+import Link from "next/link";
+
+function Breadcrumb({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      aria-label="breadcrumb"
+      data-slot="breadcrumb"
+      className={cn("", className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        "flex flex-wrap items-center gap-1 md:gap-1.5 text-xs md:text-sm text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn("inline-flex items-center gap-1.5", className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbLink({
+  className,
+  ...props
+}: React.ComponentProps<typeof Link>) {
+  return (
+    <Link
+      data-slot="breadcrumb-link"
+      className={cn("hover:underline", className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      role="link"
+      aria-current="page"
+      data-slot="breadcrumb-page"
+      className={cn("font-medium text-teal-600", className)}
+      {...props}
+    />
+  );
+}
+
+function BreadcrumbSeparator({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      role="presentation"
+      aria-hidden="true"
+      data-slot="breadcrumb-separator"
+      className={cn("", className)}
+      {...props}
+    >
+      {children ?? <ChevronRight className="h-3.5 w-3.5 md:h-4 md:w-4" />}
+    </li>
+  );
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+};


### PR DESCRIPTION
## 🔸 작업 내용

- #350 

## 🔸 고민 했던 부분

- 배치한 위치 괜찮은지, 표기되는 제목은 괜찮은지 확인 부탁드립니다.
- 내용보다 살짝 왼쪽으로 배치했는데 하단 내용과 정렬 맞추면 이런 아래 이미지 같은 느낌입니다!

<img width="700" alt="image" src="https://github.com/user-attachments/assets/8d039580-f24c-498d-8d91-f7bf915804e5" />


## 🔸 참고

https://github.com/user-attachments/assets/ad196fcb-9d31-42dc-a0c6-347f791afb86


- 모바일뷰

https://github.com/user-attachments/assets/01280001-ac16-4b13-aad4-40ada2f1f923


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 전역 Breadcrumb 내비게이션 추가 — 단계별 경로 표시 및 링크 제공
  * 페이지별로 Breadcrumb 적용되어 탐색성 향상

* **Style**
  * 메인 콘텐츠 상단/하단 여백 조정으로 Breadcrumb 공간 확보 및 레이아웃 정돈

* **Documentation**
  * Breadcrumb 사용 예시와 다양한 구성 사례를 문서화(스토리북 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->