### PR TITLE
BoostAD 개인정보 약관 추가

### DIFF
--- a/apps/web/src/app/policy/privacy/page.tsx
+++ b/apps/web/src/app/policy/privacy/page.tsx
@@ -21,6 +21,11 @@ function PrivacyPage() {
                 음성 녹음 데이터
               </strong>
             </li>
+            <li>
+              서비스 이용 과정에서 자동으로 수집되는 항목: IP 주소,
+              쿠키(Cookie), 접속 로그, 서비스 이용 기록, 기기정보(기기종류,
+              OS버전 등)
+            </li>
           </ul>
         </section>
 
@@ -35,6 +40,8 @@ function PrivacyPage() {
             <br />-{" "}
             <strong>CS 지식 말하기 연습 기능 제공 및 AI 내용 분석</strong>
             <br />- 서비스 개선 및 신규 서비스 개발
+            <br />- 서비스 내 맞춤형 정보 제공 및 광고 게재 (문맥 기반 광고
+            포함)
           </p>
         </section>
 
@@ -56,6 +63,61 @@ function PrivacyPage() {
           <p>
             회원은 언제든지 회원 탈퇴를 통해 개인정보 수집 이용 동의를 철회할 수
             있으며, 이 경우 저장된 음성 데이터를 포함한 모든 정보는 파기됩니다.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-slate-900 mb-3">
+            5. 개인정보 처리 업무의 위탁
+          </h2>
+          <p className="mb-4">
+            회사는 원활한 서비스 제공 및 광고 송출을 위해 다음과 같이 개인정보
+            처리 업무를 위탁하고 있습니다.
+          </p>
+
+          <div className="overflow-hidden rounded-lg border border-slate-200 mb-4">
+            <table className="w-full text-left text-xs sm:text-sm">
+              <thead className="bg-slate-50 text-slate-700 font-semibold border-b border-slate-200">
+                <tr>
+                  <th className="p-3">수탁업체</th>
+                  <th className="p-3 border-l border-slate-200">
+                    위탁 업무 내용
+                  </th>
+                  <th className="p-3 border-l border-slate-200">공유 정보</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200 bg-white">
+                <tr>
+                  <td className="p-3 font-medium align-top">[BoostAd]</td>
+                  <td className="p-3 border-l border-slate-200 align-top">
+                    서비스 내 광고 지면 제공 및 운영
+                  </td>
+                  <td className="p-3 border-l border-slate-200 text-slate-500 align-top">
+                    맞춤형 광고 제공을 위해 다음 정보를 수집합니다:
+                    <ul className="list-disc pl-4 mt-1 space-y-1">
+                      <li>페이지 URL 및 콘텐츠 정보 (제목, 태그)</li>
+                      <li>
+                        페이지 내 행동 데이터 (스크롤, 체류시간, 복사, 클릭)
+                      </li>
+                      <li>
+                        쿠키를 통한 방문자 식별 정보(광고 노출 및 클릭 중복 방지
+                        목적)
+                      </li>
+                    </ul>
+                    <p className="mt-2 text-[11px] leading-snug">
+                      * 수집된 정보는 개인을 직접 식별하지 않으며, 광고 최적화
+                      목적으로만 사용됩니다.
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <p className="text-xs text-slate-500">
+            * 위탁 계약 시 개인정보보호의 안전을 기하기 위하여 개인정보보호 관련
+            법규의 준수, 개인정보에 관한 제3자 제공 금지 및 사고시의 책임부담
+            등을 명확히 규정하고 있습니다.
           </p>
         </section>
       </div>


### PR DESCRIPTION
## 🔸 작업 내용
fix: #355 
BoostAd 측에 문의해서 SDK가 수집하는 정보 목록을 개인정보 약관 페이지에 추가했습니다.

## 🔸 고민 했던 부분

## 🔸 참고


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **Documentation**
  * 개인정보 취급방침을 업데이트했습니다. 자동 수집 항목(IP 주소, 쿠키, 접근 로그, 기기 정보), 개인화된 정보 제공 및 광고 관련 내용을 추가했습니다. 또한 개인정보 처리 아웃소싱 및 제3자 데이터 처리에 관한 새로운 섹션을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->