### PR TITLE
리포트 페이지 통합 테스트 작성

### DIFF
--- a/apps/web/e2e/reports.spec.ts
+++ b/apps/web/e2e/reports.spec.ts
@@ -1,0 +1,406 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("리포트 페이지", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/reports/1");
+  });
+
+  // 에러 처리
+  test("존재하지 않는 리포트에 접근하는 경우 404 에러 페이지가 표시되어야 한다.", async ({
+    page,
+  }) => {
+    // 존재하지 않는 questionId로 접근
+    await page.goto("/reports/99999", { waitUntil: "domcontentloaded" });
+
+    // not-found.tsx 페이지 내용 확인
+    await expect(page.getByText("404")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "요청하신 리포트를 찾을 수 없습니다" }),
+    ).toBeVisible();
+
+    // 안내 문구 확인
+    await expect(
+      page.getByText(
+        "존재하지 않는 문제이거나, 유효하지 않은 제출 기록입니다. URL을 다시 확인해 주세요.",
+      ),
+    ).toBeVisible();
+
+    // 버튼 확인
+    await expect(
+      page.getByRole("link", { name: "문제 목록으로 가기" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "홈으로 돌아가기" }),
+    ).toBeVisible();
+  });
+
+  // 페이지 헤더
+  test("페이지 상단에서 문제 정보를 확인할 수 있어야 한다.", async ({
+    page,
+  }) => {
+    // 문제 제목 확인
+    await expect(
+      page.getByRole("heading", { name: "TCP와 UDP의 차이점을 설명하세요" }),
+    ).toBeVisible();
+
+    // 문제 내용 확인
+    await expect(
+      page.getByText("네트워크 프로토콜인 TCP와 UDP의 차이점을 설명해주세요."),
+    ).toBeVisible();
+  });
+
+  test("페이지 상단에서 나의 최고 점수를 확인할 수 있어야 한다.", async ({
+    page,
+  }) => {
+    // 최고 점수 표시 확인 (mockSubmissions 중 최고 점수는 85점)
+    await expect(page.getByText("나의 최고 점수 : 85점")).toBeVisible();
+  });
+
+  test("다른 사람 답변 보기 버튼을 클릭하면 다른 사람 답변 리스트 페이지로 이동해야 한다.", async ({
+    page,
+  }) => {
+    // 버튼 확인
+    const othersButton = page.getByRole("link", {
+      name: "다른 사람 답변 보기",
+    });
+    await expect(othersButton).toBeVisible();
+
+    // 올바른 href 속성을 가지고 있는지 확인
+    await expect(othersButton).toHaveAttribute(
+      "href",
+      "/daily/questions/1/others",
+    );
+  });
+
+  test("다시 도전하기 버튼을 클릭하면 문제 풀이 모달이 열려야 한다.", async ({
+    page,
+  }) => {
+    // 버튼 확인 및 클릭
+    const retryButton = page.getByRole("button", { name: "다시 도전하기" });
+    await expect(retryButton).toBeVisible();
+    await retryButton.click();
+
+    // QuestionModal이 열렸는지 확인
+    await expect(page.getByRole("dialog")).toBeVisible();
+  });
+
+  // 분석 리포트 탭 - 기본 정보
+  test("리포트 상단에 TRIAL # 시도 번호가 표시되어야 한다.", async ({
+    page,
+  }) => {
+    // TRIAL # 형식으로 표시 (메인 콘텐츠 영역)
+    await expect(
+      page
+        .getByRole("tabpanel", { name: "분석 리포트" })
+        .getByText(/TRIAL #\d+/),
+    ).toBeVisible();
+  });
+
+  test("리포트 상단에 제출 완료 날짜가 표시되어야 한다.", async ({ page }) => {
+    // 완료 텍스트가 포함된 날짜 표시 확인
+    await expect(page.getByText(/완료/)).toBeVisible();
+  });
+
+  test("평가 완료 시 원형 점수 게이지가 표시되어야 한다.", async ({ page }) => {
+    // SVG 게이지가 표시되는지 확인
+    const scoreGauge = page.locator("svg").first();
+    await expect(scoreGauge).toBeVisible();
+  });
+
+  // 분석 리포트 탭 - 평가 완료
+  test("평가가 완료된 경우 리포트 페이지 하단에서 분석 리포트를 확인할 수 있어야 한다.", async ({
+    page,
+  }) => {
+    // 분석 리포트 제목 확인
+    await expect(
+      page.getByRole("heading", { name: "분석 리포트" }),
+    ).toBeVisible();
+
+    // "성취도 상세 분석" 섹션 확인
+    await expect(
+      page.getByRole("heading", { name: "성취도 상세 분석" }),
+    ).toBeVisible();
+  });
+
+  test("평가 완료 시 AI MENTOR'S FEEDBACK 섹션이 표시되어야 한다.", async ({
+    page,
+  }) => {
+    // AI MENTOR'S FEEDBACK 라벨 확인
+    await expect(page.getByText("AI MENTOR'S FEEDBACK")).toBeVisible();
+
+    // 피드백 메시지 확인 (mock 데이터의 일부)
+    await expect(
+      page.getByText(/TCP와 UDP의 핵심 차이점을 잘 설명했습니다/),
+    ).toBeVisible();
+  });
+
+  test("성취도 상세 분석에서 핵심 개념, 완성도, 심층성, 논리성 항목이 모두 표시되어야 한다.", async ({
+    page,
+  }) => {
+    // 4가지 평가 항목 확인
+    await expect(page.getByText("핵심 개념")).toBeVisible();
+    await expect(page.getByText("완성도")).toBeVisible();
+    await expect(page.getByText("심층성")).toBeVisible();
+    await expect(page.getByText("논리성")).toBeVisible();
+
+    // 점수 표시 확인
+    await expect(page.getByText("45")).toBeVisible();
+    await expect(page.getByText("18")).toBeVisible();
+  });
+
+  // 분석 리포트 탭 - 평가 진행 중
+  test("평가가 진행 중인 경우 리포트 페이지 하단에서 로딩 스피너가 표시되어야 한다.", async ({
+    page,
+  }) => {
+    // STT 진행 중인 submission으로 접근
+    await page.goto("/reports/1?attempt=3");
+
+    // 로딩 스피너 확인 (메인 콘텐츠의 것만)
+    const spinner = page
+      .locator('[role="status"][aria-label="분석 중"]')
+      .first();
+    await expect(spinner).toBeVisible();
+  });
+
+  test("STT 진행 중일 때 '음성을 텍스트로 변환하고 있습니다' 메시지가 표시되어야 한다.", async ({
+    page,
+  }) => {
+    // STT 진행 중인 submission
+    await page.goto("/reports/1?attempt=3");
+
+    // STT 진행 중 메시지 확인
+    await expect(
+      page.getByRole("heading", { name: "음성을 텍스트로 변환하고 있습니다" }),
+    ).toBeVisible();
+
+    await expect(page.getByText("음성 인식 중입니다.")).toBeVisible();
+  });
+
+  test("채점 진행 중일 때 '답변을 분석하고 있습니다' 메시지가 표시되어야 한다.", async ({
+    page,
+  }) => {
+    // 채점 진행 중인 submission
+    await page.goto("/reports/1?attempt=4");
+
+    // 채점 진행 중 메시지 확인
+    await expect(
+      page.getByRole("heading", { name: "답변을 분석하고 있습니다" }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByText("AI 면접관이 5가지 핵심 지표를 기반으로 채점 중 입니다."),
+    ).toBeVisible();
+  });
+
+  test("평가 진행 중일 때 '약 5~10초 소요' 안내 문구가 표시되어야 한다.", async ({
+    page,
+  }) => {
+    // 채점 진행 중인 submission
+    await page.goto("/reports/1?attempt=4");
+
+    // 예상 시간 안내 확인
+    await expect(
+      page.getByText("잠시만 기다려주세요. (약 5~10초 소요)"),
+    ).toBeVisible();
+  });
+
+  // 분석 리포트 탭 - 평가 실패
+  test("채점이 실패하는 경우 '채점 다시하기' 버튼을 통해서 재채점 요청을 보낼 수 있어야 한다.", async ({
+    page,
+  }) => {
+    // 채점 실패한 submission
+    await page.goto("/reports/1?attempt=6");
+
+    // 실패 메시지 확인
+    await expect(
+      page.getByRole("heading", { name: "채점에 실패했습니다" }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByText("채점 처리 중 오류가 발생했습니다. 다시 시도해주세요."),
+    ).toBeVisible();
+
+    // 채점 다시하기 버튼 확인 및 클릭
+    const reEvaluateButton = page.getByRole("button", {
+      name: /채점 다시하기/,
+    });
+    await expect(reEvaluateButton).toBeVisible();
+    await reEvaluateButton.click();
+
+    // URL이 변경되지 않았는지 확인 (같은 페이지)
+    await expect(page).toHaveURL("/reports/1?attempt=6");
+  });
+
+  test("음성 인식에 실패하는 경우 '재시도하기' 버튼을 통해서 다시 도전할 수 있어야 한다.", async ({
+    page,
+  }) => {
+    // STT 실패한 submission
+    await page.goto("/reports/1?attempt=5");
+
+    // 실패 메시지 확인
+    await expect(
+      page.getByRole("heading", { name: "음성 인식에 실패했습니다" }),
+    ).toBeVisible();
+
+    await expect(
+      page.getByText("오디오 파일 형식이 손상되어 분석할 수 없습니다."),
+    ).toBeVisible();
+
+    // 다시 도전하기 버튼 확인 (실패 섹션 내의 것)
+    const retryButton = page
+      .getByRole("tabpanel", { name: "분석 리포트" })
+      .getByRole("button", { name: /다시 도전하기/ });
+    await expect(retryButton).toBeVisible();
+
+    // 버튼 클릭 시 모달 열림
+    await retryButton.click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+  });
+
+  // 탭 전환
+  test("분석 리포트 탭과 답변 스크립트 탭 간 전환이 정상 동작해야 한다.", async ({
+    page,
+  }) => {
+    // 초기: 분석 리포트 탭 활성화
+    const feedbackTab = page.getByRole("tab", { name: /분석 리포트/ });
+    const answerTab = page.getByRole("tab", { name: /답변 스크립트/ });
+
+    await expect(feedbackTab).toHaveAttribute("data-state", "active");
+    await expect(answerTab).toHaveAttribute("data-state", "inactive");
+
+    // 분석 리포트 내용 확인
+    await expect(
+      page.getByRole("heading", { name: "분석 리포트" }),
+    ).toBeVisible();
+
+    // 답변 스크립트 탭 클릭
+    await answerTab.click();
+
+    // 탭 상태 변경 확인
+    await expect(feedbackTab).toHaveAttribute("data-state", "inactive");
+    await expect(answerTab).toHaveAttribute("data-state", "active");
+
+    // 답변 스크립트 내용 확인
+    await expect(
+      page.getByRole("heading", { name: "나의 답변 원문" }),
+    ).toBeVisible();
+
+    // 다시 분석 리포트 탭으로 전환
+    await feedbackTab.click();
+
+    await expect(feedbackTab).toHaveAttribute("data-state", "active");
+    await expect(
+      page.getByRole("heading", { name: "분석 리포트" }),
+    ).toBeVisible();
+  });
+
+  // 답변 스크립트 탭
+  test("답변 스크립트 탭에서 내가 제출한 답변 스크립트를 확인할 수 있어야 한다.", async ({
+    page,
+  }) => {
+    // 답변 스크립트 탭 클릭
+    await page.getByRole("tab", { name: /답변 스크립트/ }).click();
+
+    // 나의 답변 원문 제목 확인
+    await expect(
+      page.getByRole("heading", { name: "나의 답변 원문" }),
+    ).toBeVisible();
+
+    // 답변 내용 확인 (mock 데이터: Submission ID 1)
+    await expect(
+      page.getByText(/TCP는 연결 지향적이고 신뢰성 있는 프로토콜입니다/),
+    ).toBeVisible();
+  });
+
+  test("음성 입력으로 제출한 경우 'AI 음성 복원 완료' 배지가 표시되어야 한다.", async ({
+    page,
+  }) => {
+    // 답변 스크립트 탭 클릭
+    await page.getByRole("tab", { name: /답변 스크립트/ }).click();
+
+    // VOICE 입력 제출 (Submission ID 1)이므로 배지 확인
+    await expect(page.getByText("AI 음성 복원 완료")).toBeVisible();
+  });
+
+  test("점수가 30점 이상인 경우 답변 스크립트 탭의 하단에서 코어 키워드를 확인할 수 있어야 한다.", async ({
+    page,
+  }) => {
+    // 답변 스크립트 탭 클릭
+    await page.getByRole("tab", { name: /답변 스크립트/ }).click();
+
+    // CORE KEYWORDS 섹션 확인
+    await expect(page.getByText("CORE KEYWORDS")).toBeVisible();
+
+    // 키워드 태그 확인 (mock 데이터의 extractedKeywords)
+    await expect(page.getByText(/# TCP/)).toBeVisible();
+    await expect(page.getByText(/# UDP/)).toBeVisible();
+    await expect(page.getByText(/# 연결 지향/)).toBeVisible();
+  });
+
+  test("점수가 30점 미만인 경우 코어 키워드가 표시되지 않아야 한다.", async ({
+    page,
+  }) => {
+    // 25점 제출 (Submission ID 2)로 이동
+    await page.goto("/reports/1?attempt=2");
+
+    // 답변 스크립트 탭 클릭
+    await page.getByRole("tab", { name: /답변 스크립트/ }).click();
+
+    // CORE KEYWORDS 섹션이 표시되지 않아야 함
+    await expect(page.getByText("CORE KEYWORDS")).not.toBeVisible();
+  });
+
+  // 시도 히스토리 사이드바
+  test("리포트 페이지 사이드에서 문제 시도 히스토리를 확인할 수 있어야 한다.", async ({
+    page,
+  }) => {
+    // 히스토리 항목들이 표시되는지 확인
+    await expect(page.getByText(/TRIAL #\d+/).first()).toBeVisible();
+
+    // 여러 TRIAL 항목 확인
+    const trialItems = page.getByText(/TRIAL #\d+/);
+    const count = await trialItems.count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test("히스토리에서 완료된 시도는 점수를, 진행 중인 시도는 스피너를, 실패한 시도는 에러 아이콘을 표시해야 한다.", async ({
+    page,
+  }) => {
+    // 완료된 시도 - 점수 표시 (Submission ID 1: 85점)
+    await expect(page.getByText("85").first()).toBeVisible();
+
+    // 진행 중인 시도 - 스피너 (Submission ID 3, 4)
+    const spinnerCount = await page
+      .locator('[role="status"][aria-label="분석 중"]')
+      .count();
+    expect(spinnerCount).toBeGreaterThan(0);
+
+    // 실패한 시도 - 에러 아이콘 (Submission ID 5, 6)
+    const failedCount = await page.locator('[aria-label="실패"]').count();
+    expect(failedCount).toBeGreaterThan(0);
+  });
+
+  test("문제 시도 히스토리에서 특정 기록을 클릭하면 해당 리포트 페이지로 이동해야 한다.", async ({
+    page,
+  }) => {
+    // 명시적으로 첫 번째 submission으로 이동
+    await page.goto("/reports/1?attempt=1");
+    await page.waitForLoadState("networkidle");
+
+    // 현재 URL 확인
+    expect(page.url()).toContain("attempt=1");
+
+    // 히스토리에서 다른 TRIAL 항목 찾기 (두 번째 항목)
+    const historyLinks = page.getByRole("link", { name: /TRIAL #/ });
+    const secondTrial = historyLinks.nth(1);
+
+    // 클릭하고 URL 변경 대기
+    await secondTrial.click();
+    await page.waitForURL(/\?attempt=(?!1\b)\d+/);
+
+    // URL이 변경되었는지 확인 (attempt=1이 아닌 다른 값)
+    const currentUrl = page.url();
+    expect(currentUrl).toContain("attempt=");
+    expect(currentUrl).not.toContain("attempt=1");
+  });
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -17,6 +17,7 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  transpilePackages: ["msw"],
 };
 
 export default withSentryConfig(nextConfig, {

--- a/apps/web/src/app/reports/[questionId]/_lib/services/question-data.ts
+++ b/apps/web/src/app/reports/[questionId]/_lib/services/question-data.ts
@@ -4,7 +4,7 @@ async function getReportQuestion(questionId: string) {
   const question = await getQuestion(questionId);
 
   if (!question) {
-    throw new Error(`질문 데이터가 존재하지 않습니다. (id=${questionId})`);
+    return null;
   }
 
   return {

--- a/apps/web/src/mocks/data/reports.ts
+++ b/apps/web/src/mocks/data/reports.ts
@@ -1,0 +1,181 @@
+import type { SubmissionDTO } from "@/app/reports/[questionId]/_types/submission-dto";
+import type { EvaluationDTO } from "@/app/reports/[questionId]/_types/evaluation-dto";
+
+export const mockSubmissions: SubmissionDTO[] = [
+  // 1. 평가 완료 - 높은 점수 (85점) - VOICE 입력
+  {
+    id: 1,
+    questionId: 1,
+    submittedAt: "2024-01-29T10:30:00Z",
+    duration: 180,
+    answerContent:
+      "TCP는 연결 지향적이고 신뢰성 있는 프로토콜입니다. 3-way handshake를 통해 연결을 수립하고, 데이터 전송 시 순서를 보장하며 오류를 검출하고 재전송합니다. 반면 UDP는 비연결형 프로토콜로 빠른 전송이 가능하지만 신뢰성을 보장하지 않습니다.",
+    evaluationStatus: "COMPLETED",
+    sttStatus: "DONE",
+    inputType: "VOICE",
+    totalScore: 85,
+    audioAssetId: 1,
+  },
+  // 2. 평가 완료 - 낮은 점수 (25점) - TEXT 입력 (코어 키워드 미표시)
+  {
+    id: 2,
+    questionId: 1,
+    submittedAt: "2024-01-26T14:20:00Z",
+    duration: 120,
+    answerContent: "TCP는 연결형이고 UDP는 비연결형입니다.",
+    evaluationStatus: "COMPLETED",
+    sttStatus: "DONE",
+    inputType: "TEXT",
+    totalScore: 25,
+    audioAssetId: null,
+  },
+  // 3. 평가 진행 중 - STT 진행 중
+  {
+    id: 3,
+    questionId: 1,
+    submittedAt: "2024-01-28T09:15:00Z",
+    duration: 150,
+    answerContent: "",
+    evaluationStatus: "PENDING",
+    sttStatus: "IN_PROGRESS",
+    inputType: "VOICE",
+    totalScore: null,
+    audioAssetId: 2,
+  },
+  // 4. 평가 진행 중 - 채점 진행 중
+  {
+    id: 4,
+    questionId: 1,
+    submittedAt: "2024-01-28T11:00:00Z",
+    duration: 200,
+    answerContent:
+      "TCP는 전송 제어 프로토콜로 연결 지향적이며 신뢰성을 보장합니다.",
+    evaluationStatus: "PENDING",
+    sttStatus: "DONE",
+    inputType: "TEXT",
+    totalScore: null,
+    audioAssetId: null,
+  },
+  // 5. 평가 실패 - STT 실패
+  {
+    id: 5,
+    questionId: 1,
+    submittedAt: "2024-01-25T16:45:00Z",
+    duration: 100,
+    answerContent: "",
+    evaluationStatus: "PENDING",
+    sttStatus: "FAILED",
+    inputType: "VOICE",
+    totalScore: null,
+    audioAssetId: 3,
+  },
+  // 6. 평가 실패 - 채점 실패
+  {
+    id: 6,
+    questionId: 1,
+    submittedAt: "2024-01-24T13:30:00Z",
+    duration: 160,
+    answerContent: "TCP와 UDP는 전송 계층 프로토콜입니다.",
+    evaluationStatus: "FAILED",
+    sttStatus: "DONE",
+    inputType: "TEXT",
+    totalScore: null,
+    audioAssetId: null,
+  },
+];
+
+// Mock Evaluations
+export const mockEvaluations: Record<number, EvaluationDTO> = {
+  // Submission ID 1의 평가 결과 (85점)
+  1: {
+    id: 1,
+    submissionId: 1,
+    feedbackMessage:
+      "TCP와 UDP의 핵심 차이점을 잘 설명했습니다. 연결 지향성, 신뢰성, 3-way handshake 등 중요한 개념을 정확하게 다뤘습니다. 다만 흐름 제어나 혼잡 제어 등의 추가적인 차이점을 언급했다면 더 완벽했을 것입니다.",
+    coreConceptEval: "CORRECT",
+    coverageEval: "COMPLETE",
+    logicEval: "CLEAR",
+    depthEval: "ADVANCED",
+    detailAnalysis: {
+      coreConcept:
+        "TCP의 연결 지향성과 신뢰성, UDP의 비연결형 특성을 정확하게 설명했습니다. 3-way handshake, 순서 보장, 오류 검출 등 핵심 메커니즘을 구체적으로 언급했습니다.",
+      coverage:
+        "주요 차이점인 연결 방식, 신뢰성, 속도, 오류 처리를 모두 다뤘습니다. 실무에서 필요한 핵심 내용을 충분히 커버했습니다.",
+      logic:
+        "TCP와 UDP를 대조하며 각각의 특징을 논리적으로 설명했습니다. 연결성 → 신뢰성 → 성능 순서로 자연스럽게 전개되었습니다.",
+      depth:
+        "단순 나열을 넘어 3-way handshake, 순서 보장, 재전송 등 구체적인 메커니즘을 언급하여 깊이 있는 이해를 보여줬습니다.",
+    },
+    scoreDetails: {
+      coreConcept: 45,
+      coverage: 18,
+      logic: 9,
+      depth: 13,
+    },
+    extractedKeywords: [
+      "TCP",
+      "UDP",
+      "연결 지향",
+      "신뢰성",
+      "3-way handshake",
+      "순서 보장",
+      "오류 검출",
+      "재전송",
+      "비연결형",
+      "빠른 전송",
+    ],
+    createdAt: "2024-01-27T10:31:00Z",
+  },
+  // Submission ID 2의 평가 결과 (25점)
+  2: {
+    id: 2,
+    submissionId: 2,
+    feedbackMessage:
+      "TCP와 UDP의 가장 기본적인 차이점만 언급했습니다. 연결형과 비연결형이라는 구분은 맞지만, 왜 그런 차이가 있는지, 각각 어떤 상황에서 사용되는지에 대한 설명이 부족합니다. 좀 더 구체적인 메커니즘과 사용 사례를 추가하면 좋겠습니다.",
+    coreConceptEval: "MINOR_ERROR",
+    coverageEval: "MINIMAL",
+    logicEval: "WEAK",
+    depthEval: "NONE",
+    detailAnalysis: {
+      coreConcept:
+        "연결형과 비연결형이라는 기본 구분은 정확하지만, 신뢰성, 순서 보장, 오류 처리 등 핵심 차이점이 누락되었습니다.",
+      coverage:
+        "가장 기본적인 차이점만 언급했습니다. 신뢰성, 속도, 헤더 구조, 사용 사례 등 중요한 내용이 빠져있습니다.",
+      logic: "단순히 두 프로토콜을 구분만 했을 뿐, 논리적인 설명이 부족합니다.",
+      depth:
+        "표면적인 차이만 언급했습니다. 구체적인 메커니즘이나 원리에 대한 설명이 없습니다.",
+    },
+    scoreDetails: {
+      coreConcept: 15,
+      coverage: 5,
+      logic: 3,
+      depth: 2,
+    },
+    extractedKeywords: [],
+    createdAt: "2024-01-26T14:21:00Z",
+  },
+};
+
+// Mock Question (리포트 페이지에서 사용)
+export const mockReportQuestion = {
+  id: 1,
+  title: "TCP와 UDP의 차이점을 설명하세요",
+  content:
+    "네트워크 프로토콜인 TCP와 UDP의 차이점을 설명해주세요. 각각의 특징과 사용 사례를 포함하여 답변해주세요.",
+  categoryId: 11,
+  category: {
+    id: 11,
+    name: "TCP/IP",
+    depth: 1,
+    parentId: 1,
+    parent: {
+      id: 1,
+      name: "네트워크",
+      depth: 0,
+      parentId: null,
+    },
+  },
+  avgScore: 75,
+  avgImportance: 4.5,
+  ttsUrl: null,
+};

--- a/apps/web/src/mocks/handlers/evaluation-handlers.ts
+++ b/apps/web/src/mocks/handlers/evaluation-handlers.ts
@@ -23,20 +23,13 @@ export const evaluationHandlers = [
   http.post(`${API_URL}/answer-evaluation`, async ({ request }) => {
     const body = (await request.json()) as { submissionId: number };
 
-    if (!body.submissionId) {
-      return HttpResponse.json(
-        { message: "submissionId is required" },
-        { status: 400 },
-      );
-    }
-
     // 재평가 요청 성공 응답
     return HttpResponse.json(
       {
         message: "Re-evaluation started",
         submissionId: body.submissionId,
       },
-      { status: 200 },
+      { status: 202 },
     );
   }),
 ];

--- a/apps/web/src/mocks/handlers/evaluation-handlers.ts
+++ b/apps/web/src/mocks/handlers/evaluation-handlers.ts
@@ -1,0 +1,42 @@
+import { http, HttpResponse } from "msw";
+import { mockEvaluations } from "../data/reports";
+
+const API_URL = process.env.API_URL || "http://localhost:8000";
+
+export const evaluationHandlers = [
+  // 평가 결과 조회
+  http.get(`${API_URL}/answer-evaluation/:submissionId`, ({ params }) => {
+    const { submissionId } = params;
+    const evaluation = mockEvaluations[Number(submissionId)];
+
+    if (!evaluation) {
+      return HttpResponse.json(
+        { message: "Evaluation not found" },
+        { status: 404 },
+      );
+    }
+
+    return HttpResponse.json(evaluation);
+  }),
+
+  // 재평가 요청
+  http.post(`${API_URL}/answer-evaluation`, async ({ request }) => {
+    const body = (await request.json()) as { submissionId: number };
+
+    if (!body.submissionId) {
+      return HttpResponse.json(
+        { message: "submissionId is required" },
+        { status: 400 },
+      );
+    }
+
+    // 재평가 요청 성공 응답
+    return HttpResponse.json(
+      {
+        message: "Re-evaluation started",
+        submissionId: body.submissionId,
+      },
+      { status: 200 },
+    );
+  }),
+];

--- a/apps/web/src/mocks/handlers/index.ts
+++ b/apps/web/src/mocks/handlers/index.ts
@@ -1,4 +1,11 @@
 import { categoryHandlers } from "./category-handlers";
 import { questionHandlers } from "./question-handlers";
+import { submissionHandlers } from "./submission-handlers";
+import { evaluationHandlers } from "./evaluation-handlers";
 
-export const handlers = [...categoryHandlers, ...questionHandlers];
+export const handlers = [
+  ...categoryHandlers,
+  ...questionHandlers,
+  ...submissionHandlers,
+  ...evaluationHandlers,
+];

--- a/apps/web/src/mocks/handlers/question-handlers.ts
+++ b/apps/web/src/mocks/handlers/question-handlers.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 import { mockQuestions } from "../data/questions";
+import { mockReportQuestion } from "../data/reports";
 
 const API_URL = process.env.API_URL || "http://localhost:8000";
 
@@ -12,5 +13,27 @@ export const questionHandlers = [
   // 인증된 사용자 문제 목록
   http.get(`${API_URL}/questions/auth`, () => {
     return HttpResponse.json(mockQuestions);
+  }),
+
+  // 단일 문제 조회
+  http.get(`${API_URL}/questions/:id`, ({ params }) => {
+    const { id } = params;
+
+    // 리포트 페이지용 mock 데이터
+    if (Number(id) === 1) {
+      return HttpResponse.json(mockReportQuestion);
+    }
+
+    // 기본 mock 문제 목록에서 검색
+    const question = mockQuestions.questions.find((q) => q.id === Number(id));
+
+    if (!question) {
+      return HttpResponse.json(
+        { message: "Question not found" },
+        { status: 404 },
+      );
+    }
+
+    return HttpResponse.json(question);
   }),
 ];

--- a/apps/web/src/mocks/handlers/submission-handlers.ts
+++ b/apps/web/src/mocks/handlers/submission-handlers.ts
@@ -1,0 +1,44 @@
+import { http, HttpResponse } from "msw";
+import { mockSubmissions } from "../data/reports";
+
+const API_URL = process.env.API_URL || "http://localhost:8000";
+
+export const submissionHandlers = [
+  // 제출 목록 조회
+  http.get(`${API_URL}/answer-submissions`, ({ request }) => {
+    const url = new URL(request.url);
+    const questionId = url.searchParams.get("questionId");
+
+    if (!questionId) {
+      return HttpResponse.json(
+        { message: "questionId is required" },
+        { status: 400 },
+      );
+    }
+
+    // questionId로 필터링 후 날짜순 정렬 (오래된 것 -> 최신 순)
+    const submissions = mockSubmissions
+      .filter((s) => s.questionId === Number(questionId))
+      .sort(
+        (a, b) =>
+          new Date(a.submittedAt).getTime() - new Date(b.submittedAt).getTime(),
+      );
+
+    return HttpResponse.json(submissions);
+  }),
+
+  // 단일 제출 조회
+  http.get(`${API_URL}/answer-submissions/:id`, ({ params }) => {
+    const { id } = params;
+    const submission = mockSubmissions.find((s) => s.id === Number(id));
+
+    if (!submission) {
+      return HttpResponse.json(
+        { message: "Submission not found" },
+        { status: 404 },
+      );
+    }
+
+    return HttpResponse.json(submission);
+  }),
+];


### PR DESCRIPTION
## 🔸 작업 내용

- 리포트 페이지 통합 테스트 작성
- reports mock 데이터 추가
- 핸들러 추가
  - /answer-submissions/:id 
  - /answer-submissions 
  - /answer-evaluation/:submissionId 
  - /answer-evaluation
  - /questions/:id
- POM 모델로 리팩토링 하려 했는데 테스트가 실패해서 추후에 해보려고 합니다...!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 테스트
* 보고서 페이지의 UI, 네비게이션, 탭 동작, 로딩 상태 및 성공/실패 흐름에 대한 포괄적인 E2E 테스트 스위트 추가

## 기타
* 개발 환경 모의 데이터 및 API 핸들러 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->