### PR TITLE
fix: BoostAD의 광고 배너가 모바일(좁은 너비)환경에서 컨텐츠가 오버플로우되는 문제를 해결함

### DIFF
--- a/apps/web/src/app/daily/questions/[questionId]/page.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/page.tsx
@@ -37,7 +37,7 @@ async function DailyQuestionPage({
           parentCategoryName={question.category?.parent?.name}
         />
         <InputSection initialInputMode={mode} questionId={question.id} />
-        <div data-boostad-zone className="h-20"></div>
+        <div data-boostad-zone className="h-20 overflow-x-hidden"></div>
       </main>
     </>
   );

--- a/apps/web/src/app/daily/questions/page.tsx
+++ b/apps/web/src/app/daily/questions/page.tsx
@@ -135,7 +135,7 @@ async function QuestionListPage({ searchParams }: QuestionListPageProps) {
             />
           </Suspense>
         </Table>
-        <div data-boostad-zone></div>
+        <div data-boostad-zone className="overflow-x-hidden"></div>
       </main>
     </>
   );

--- a/apps/web/src/app/mypage/page.tsx
+++ b/apps/web/src/app/mypage/page.tsx
@@ -86,7 +86,7 @@ async function MyPage() {
             <SolvedContent solvedProblems={problems} />
           </TabsContent>
         </Tabs>
-        <div data-boostad-zone></div>
+        <div data-boostad-zone className="overflow-x-hidden"></div>
       </div>
     </>
   );

--- a/apps/web/src/app/reports/[questionId]/page.tsx
+++ b/apps/web/src/app/reports/[questionId]/page.tsx
@@ -54,7 +54,7 @@ async function ReportPage({ params, searchParams }: ReportPageProps) {
               .filter((h) => h.status === "PENDING")
               .map((h) => h.submissionId)}
           />
-          <div data-boostad-zone className="h-20"></div>
+          <div data-boostad-zone className="h-20 overflow-x-hidden"></div>
         </div>
 
         <CollapsibleHistory


### PR DESCRIPTION
## 🔸 작업 내용

- 모바일 환경에서 광고 배너가 오버플로우되는 문제를 해결했습니다.
- overflow-x-hidden을 두어서, 부모 컨테이너 요소의 너비를 침범하지 않게 강제했습니다.

## 🔸 참고


https://github.com/user-attachments/assets/dcd79d98-f73a-4395-9be2-fe95f66c780c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 여러 페이지의 광고 영역에서 가로 스크롤 오버플로우 처리를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->