### PR TITLE
리포트 페이지에 새롭게 생긴 그래프 노드 표시

### DIFF
--- a/apps/api/src/answer-evaluation/answer-evaluation.service.spec.ts
+++ b/apps/api/src/answer-evaluation/answer-evaluation.service.spec.ts
@@ -274,6 +274,7 @@ describe('AnswerEvaluationService', () => {
         10, // questionId
         'Test Question', // questionTitle
         ['React', 'Hook'], // keywords
+        1, // submissionId
       );
     });
 

--- a/apps/api/src/answer-evaluation/answer-evaluation.service.ts
+++ b/apps/api/src/answer-evaluation/answer-evaluation.service.ts
@@ -277,6 +277,7 @@ export class AnswerEvaluationService {
             submission.questionId,
             questionEntity.title,
             result.extractedKeywords,
+            submission.id,
           )
           .catch((error) => {
             this.logger.error(

--- a/apps/api/src/graph/entities/graph-edge.entity.ts
+++ b/apps/api/src/graph/entities/graph-edge.entity.ts
@@ -39,6 +39,12 @@ export class GraphEdge {
   targetId: number;
 
   /**
+   * 이 엣지를 생성한 제출 ID (제출별 그래프 스냅샷 조회용)
+   */
+  @Column({ name: 'submission_id', type: 'int', nullable: true })
+  submissionId: number | null;
+
+  /**
    * 출발 노드 관계
    */
   @ManyToOne(() => GraphNode)

--- a/apps/api/src/graph/entities/graph-edge.entity.ts
+++ b/apps/api/src/graph/entities/graph-edge.entity.ts
@@ -16,6 +16,7 @@ import { GraphNode } from './graph-node.entity';
  */
 @Entity('graph_edges')
 @Index(['userId', 'sourceId', 'targetId'], { unique: true })
+@Index(['submissionId'])
 export class GraphEdge {
   @PrimaryGeneratedColumn()
   id: number;

--- a/apps/api/src/graph/graph.controller.ts
+++ b/apps/api/src/graph/graph.controller.ts
@@ -1,4 +1,14 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Query,
+  UseGuards,
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
@@ -6,16 +16,25 @@ import {
   ApiOkResponse,
   ApiUnauthorizedResponse,
   ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
 } from '@nestjs/swagger';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { GraphService } from './graph.service';
 import { GraphResponseDto } from './dtos/graph-response.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { UserId } from '../auth/decorators/user-id.decorator';
+import { AnswerSubmission } from '../answer-submission/entities/answer-submission.entity';
 
 @ApiTags('graph')
 @Controller('graph')
 export class GraphController {
-  constructor(private readonly graphService: GraphService) {}
+  constructor(
+    private readonly graphService: GraphService,
+    @InjectRepository(AnswerSubmission)
+    private readonly answerSubmissionRepository: Repository<AnswerSubmission>,
+  ) {}
 
   @Get()
   @UseGuards(JwtAuthGuard)
@@ -43,5 +62,108 @@ export class GraphController {
   })
   async getGraph(@UserId() userId: number): Promise<GraphResponseDto> {
     return await this.graphService.getGraphByUserId(userId);
+  }
+
+  @Get('submission/:submissionId')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: '제출별 추가된 그래프 조회',
+    description:
+      '해당 제출에서 추가된 그래프 노드·엣지만 조회합니다. 본인의 제출에만 접근 가능합니다.',
+  })
+  @ApiParam({ name: 'submissionId', description: '제출 ID' })
+  @ApiOkResponse({
+    description: '제출별 그래프 조회 성공',
+    type: GraphResponseDto,
+  })
+  @ApiUnauthorizedResponse({ description: '로그인이 필요합니다' })
+  @ApiResponse({
+    status: 404,
+    description: '제출을 찾을 수 없습니다',
+  })
+  @ApiResponse({
+    status: 403,
+    description: '본인의 제출이 아닙니다',
+  })
+  async getGraphBySubmissionId(
+    @Param('submissionId', ParseIntPipe) submissionId: number,
+    @UserId() userId: number,
+  ): Promise<GraphResponseDto> {
+    const submission = await this.answerSubmissionRepository.findOne({
+      where: { id: submissionId },
+    });
+
+    if (!submission) {
+      throw new NotFoundException('제출을 찾을 수 없습니다.');
+    }
+
+    if (submission.userId !== userId) {
+      throw new ForbiddenException('본인의 제출만 조회할 수 있습니다.');
+    }
+
+    return await this.graphService.getGraphBySubmissionId(submissionId);
+  }
+
+  @Get('submissions')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: '여러 제출까지의 누적 그래프 조회',
+    description:
+      '지정한 제출 ID들에 해당하는 누적 그래프(그 시점까지 추가된 노드·엣지)를 조회합니다. 이전 제출을 볼 때 그 시점의 그래프 모양을 표시할 때 사용합니다. 본인의 제출에만 접근 가능합니다.',
+  })
+  @ApiQuery({
+    name: 'ids',
+    description: '제출 ID 목록 (쉼표 구분, 시간순)',
+    example: '1,2,3',
+  })
+  @ApiOkResponse({
+    description: '누적 그래프 조회 성공',
+    type: GraphResponseDto,
+  })
+  @ApiUnauthorizedResponse({ description: '로그인이 필요합니다' })
+  @ApiResponse({
+    status: 400,
+    description: 'ids 파라미터가 없거나 잘못됨',
+  })
+  @ApiResponse({
+    status: 403,
+    description: '본인의 제출이 아닌 ID가 포함됨',
+  })
+  async getGraphBySubmissionIds(
+    @Query('ids') idsParam: string | undefined,
+    @UserId() userId: number,
+  ): Promise<GraphResponseDto> {
+    if (!idsParam?.trim()) {
+      throw new BadRequestException('ids 쿼리 파라미터가 필요합니다.');
+    }
+
+    const rawIds = idsParam
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const submissionIds = rawIds
+      .map((s) => parseInt(s, 10))
+      .filter((n) => Number.isFinite(n));
+
+    if (submissionIds.length === 0) {
+      throw new BadRequestException('유효한 제출 ID가 없습니다.');
+    }
+
+    const submissions = await this.answerSubmissionRepository.find({
+      where: submissionIds.map((id) => ({ id })),
+    });
+
+    if (submissions.length !== submissionIds.length) {
+      throw new NotFoundException('일부 제출을 찾을 수 없습니다.');
+    }
+
+    const allOwned = submissions.every((s) => s.userId === userId);
+    if (!allOwned) {
+      throw new ForbiddenException('본인의 제출만 조회할 수 있습니다.');
+    }
+
+    return await this.graphService.getGraphBySubmissionIds(submissionIds);
   }
 }

--- a/apps/api/src/graph/graph.controller.ts
+++ b/apps/api/src/graph/graph.controller.ts
@@ -143,19 +143,26 @@ export class GraphController {
       .split(',')
       .map((s) => s.trim())
       .filter(Boolean);
-    const submissionIds = rawIds
-      .map((s) => parseInt(s, 10))
-      .filter((n) => Number.isFinite(n));
+    if (rawIds.some((s) => !/^\d+$/.test(s))) {
+      throw new BadRequestException(
+        '유효하지 않은 제출 ID가 포함되어 있습니다.',
+      );
+    }
+    const submissionIds = rawIds.map((s) => Number(s));
+    const uniqueIds = Array.from(new Set(submissionIds));
 
-    if (submissionIds.length === 0) {
+    if (uniqueIds.length === 0) {
       throw new BadRequestException('유효한 제출 ID가 없습니다.');
+    }
+    if (uniqueIds.length !== submissionIds.length) {
+      throw new BadRequestException('중복된 제출 ID가 포함되어 있습니다.');
     }
 
     const submissions = await this.answerSubmissionRepository.find({
-      where: submissionIds.map((id) => ({ id })),
+      where: uniqueIds.map((id) => ({ id })),
     });
 
-    if (submissions.length !== submissionIds.length) {
+    if (submissions.length !== uniqueIds.length) {
       throw new NotFoundException('일부 제출을 찾을 수 없습니다.');
     }
 
@@ -164,6 +171,6 @@ export class GraphController {
       throw new ForbiddenException('본인의 제출만 조회할 수 있습니다.');
     }
 
-    return await this.graphService.getGraphBySubmissionIds(submissionIds);
+    return await this.graphService.getGraphBySubmissionIds(uniqueIds);
   }
 }

--- a/apps/api/src/graph/graph.module.ts
+++ b/apps/api/src/graph/graph.module.ts
@@ -5,9 +5,13 @@ import { GraphEdge } from './entities/graph-edge.entity';
 import { GraphController } from './graph.controller';
 import { GraphService } from './graph.service';
 import { AuthModule } from '../auth/auth.module';
+import { AnswerSubmission } from '../answer-submission/entities/answer-submission.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([GraphNode, GraphEdge]), AuthModule],
+  imports: [
+    TypeOrmModule.forFeature([GraphNode, GraphEdge, AnswerSubmission]),
+    AuthModule,
+  ],
   controllers: [GraphController],
   providers: [GraphService],
   exports: [GraphService, TypeOrmModule],

--- a/apps/api/src/graph/graph.service.spec.ts
+++ b/apps/api/src/graph/graph.service.spec.ts
@@ -115,7 +115,7 @@ describe('GraphService', () => {
 
   describe('createGraphFromEvaluation', () => {
     it('키워드가 없으면 트랜잭션을 실행하지 않고 조기 반환해야 한다', async () => {
-      await service.createGraphFromEvaluation(1, 10, '제목', []);
+      await service.createGraphFromEvaluation(1, 10, '제목', [], 100);
 
       expect(mockTransactionFn).not.toHaveBeenCalled();
     });
@@ -188,6 +188,7 @@ describe('GraphService', () => {
         questionId,
         questionTitle,
         keywords,
+        100, // submissionId
       );
 
       expect(mockTransactionFn).toHaveBeenCalled();

--- a/apps/api/src/graph/graph.service.ts
+++ b/apps/api/src/graph/graph.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { GraphNode } from './entities/graph-node.entity';
 import { GraphEdge } from './entities/graph-edge.entity';
 import {
@@ -79,6 +79,105 @@ export class GraphService {
   }
 
   /**
+   * 특정 제출에서 추가된 그래프(노드·엣지)만 조회한다.
+   * 해당 제출 시 생성된 엣지와 그 엣지의 양 끝 노드를 반환한다.
+   *
+   * @param submissionId - 제출 ID
+   * @returns 해당 제출에서 추가된 서브그래프 (nodes, edges)
+   */
+  async getGraphBySubmissionId(
+    submissionId: number,
+  ): Promise<GraphResponseDto> {
+    const edges = await this.graphEdgeRepository.find({
+      where: { submissionId },
+    });
+
+    if (edges.length === 0) {
+      return { nodes: [], edges: [] };
+    }
+
+    const nodeIds = new Set<number>();
+    for (const edge of edges) {
+      nodeIds.add(edge.sourceId);
+      nodeIds.add(edge.targetId);
+    }
+
+    const nodes = await this.graphNodeRepository.find({
+      where: { id: In(Array.from(nodeIds)) },
+    });
+
+    const nodeDtos: GraphNodeDto[] = nodes.map((node) => ({
+      id: node.id,
+      type: node.type,
+      label: node.label,
+      questionId: node.questionId,
+    }));
+
+    const edgeDtos: GraphEdgeDto[] = edges.map((edge) => ({
+      id: edge.id,
+      sourceId: edge.sourceId,
+      targetId: edge.targetId,
+    }));
+
+    return {
+      nodes: nodeDtos,
+      edges: edgeDtos,
+    };
+  }
+
+  /**
+   * 여러 제출 ID에 해당하는 누적 그래프를 조회한다.
+   * 해당 제출들에서 추가된 모든 엣지와 그 엣지의 양 끝 노드를 반환한다.
+   * (이전 제출을 볼 때 "그 시점까지의 그래프 모양" 표시용)
+   *
+   * @param submissionIds - 제출 ID 배열 (시간순으로 정렬된 것이어야 함)
+   * @returns 누적 서브그래프 (nodes, edges)
+   */
+  async getGraphBySubmissionIds(
+    submissionIds: number[],
+  ): Promise<GraphResponseDto> {
+    if (!submissionIds?.length) {
+      return { nodes: [], edges: [] };
+    }
+
+    const edges = await this.graphEdgeRepository.find({
+      where: { submissionId: In(submissionIds) },
+    });
+
+    if (edges.length === 0) {
+      return { nodes: [], edges: [] };
+    }
+
+    const nodeIds = new Set<number>();
+    for (const edge of edges) {
+      nodeIds.add(edge.sourceId);
+      nodeIds.add(edge.targetId);
+    }
+
+    const nodes = await this.graphNodeRepository.find({
+      where: { id: In(Array.from(nodeIds)) },
+    });
+
+    const nodeDtos: GraphNodeDto[] = nodes.map((node) => ({
+      id: node.id,
+      type: node.type,
+      label: node.label,
+      questionId: node.questionId,
+    }));
+
+    const edgeDtos: GraphEdgeDto[] = edges.map((edge) => ({
+      id: edge.id,
+      sourceId: edge.sourceId,
+      targetId: edge.targetId,
+    }));
+
+    return {
+      nodes: nodeDtos,
+      edges: edgeDtos,
+    };
+  }
+
+  /**
    * userId로 학습한 question_id 목록을 조회한다
    * @param userId - 유저 ID
    * @returns question_id 배열
@@ -104,18 +203,20 @@ export class GraphService {
    * 로직:
    * 1. 문제 노드 생성 또는 재사용 (userId, questionId로 기존 노드 확인)
    * 2. 각 키워드에 대해 키워드 노드 생성 또는 재사용 (userId, label로 유니크 제약 활용)
-   * 3. 문제-키워드 간 엣지 생성 (중복 방지)
+   * 3. 문제-키워드 간 엣지 생성 (중복 방지, submissionId 기록)
    *
    * @param userId - 사용자 ID
    * @param questionId - 문제 ID
    * @param questionTitle - 문제 제목
    * @param keywords - 추출된 키워드 배열
+   * @param submissionId - 이 평가에 해당하는 제출 ID (제출별 그래프 조회용)
    */
   async createGraphFromEvaluation(
     userId: number,
     questionId: number,
     questionTitle: string,
     keywords: string[],
+    submissionId: number,
   ): Promise<void> {
     // 키워드가 없으면 그래프 생성하지 않음
     if (!keywords || keywords.length === 0) {
@@ -215,6 +316,7 @@ export class GraphService {
               userId: userId,
               sourceId: sourceId,
               targetId: targetId,
+              submissionId: submissionId,
             });
             await manager.save(GraphEdge, edge);
           }

--- a/apps/web/src/app/daily/questions/_lib/fetch-categories.ts
+++ b/apps/web/src/app/daily/questions/_lib/fetch-categories.ts
@@ -1,11 +1,12 @@
 import { Category } from "../_types/types";
 
-async function fetchRootCategories(): Promise<Category[]> {
-  const apiUrl = process.env.API_URL;
-  if (!apiUrl) {
-    throw new Error("API_URL environment variable is not defined");
-  }
+const getApiUrl = (): string =>
+  process.env.API_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "http://localhost:8000";
 
+async function fetchRootCategories(): Promise<Category[]> {
+  const apiUrl = getApiUrl();
   const response = await fetch(`${apiUrl}/categories/roots`, {
     cache: "no-store",
   });
@@ -18,11 +19,7 @@ async function fetchRootCategories(): Promise<Category[]> {
 }
 
 async function fetchCategoryTree(categoryId: number): Promise<Category | null> {
-  const apiUrl = process.env.API_URL;
-  if (!apiUrl) {
-    throw new Error("API_URL environment variable is not defined");
-  }
-
+  const apiUrl = getApiUrl();
   const response = await fetch(
     `${apiUrl}/categories/tree-by-id/${categoryId}`,
     {

--- a/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
+++ b/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
@@ -15,6 +15,9 @@ interface GraphViewProps {
   initialScale?: number;
   scale?: number;
   onScaleChange?: (scale: number) => void;
+  /** 이 제출에서 추가된 노드·엣지 ID (기존 그래프 위에 하이라이트) */
+  highlightNodeIds?: number[];
+  highlightEdgeIds?: number[];
 }
 
 function GraphView({
@@ -26,9 +29,21 @@ function GraphView({
   initialScale,
   scale,
   onScaleChange,
+  highlightNodeIds,
+  highlightEdgeIds,
 }: GraphViewProps) {
   const canvasRef = React.useRef<HTMLCanvasElement>(null);
   const { ctx, getWidth, getHeight } = useCanvas2D(canvasRef);
+
+  const highlight = React.useMemo(() => {
+    if (highlightNodeIds == null && highlightEdgeIds == null) {
+      return null;
+    }
+    return {
+      nodeIds: new Set(highlightNodeIds ?? []),
+      edgeIds: new Set(highlightEdgeIds ?? []),
+    };
+  }, [highlightNodeIds, highlightEdgeIds]);
 
   const { bindEvents, bindWheelEvent, drawGraph } = useGraphRenderer({
     canvasRef,
@@ -44,6 +59,7 @@ function GraphView({
     initialScale,
     scale,
     onScaleChange,
+    highlight,
   });
 
   // 휠 이벤트 바인딩 (passive: false 필요)

--- a/apps/web/src/app/mypage/_components/graph-view/use-graph-renderer.ts
+++ b/apps/web/src/app/mypage/_components/graph-view/use-graph-renderer.ts
@@ -1,7 +1,9 @@
 import * as React from "react";
 import { GRAPH_NUMBER_CONSTANT } from "../../_constants/graph-view-constant";
 import { addRandomEdgeDistance } from "../../_lib/graph-view/add-random-edge-distance";
-import drawGraphView from "../../_lib/graph-view/draw-graph-view";
+import drawGraphView, {
+  type GraphHighlightSets,
+} from "../../_lib/graph-view/draw-graph-view";
 import {
   GraphData,
   GraphEdge,
@@ -43,6 +45,8 @@ export interface UseGraphRendererOptions {
   initialScale?: number; // scale의 초기값만 저장
   scale?: number; // 외부에서 scale 조정할 때 사용
   onScaleChange?: (scale: number) => void;
+  /** 제출에서 추가된 노드·엣지 하이라이트용 (리포트 탭 등) */
+  highlight?: GraphHighlightSets | null;
 }
 
 export interface GraphRendererReturn {
@@ -73,6 +77,7 @@ function useGraphRenderer({
   initialScale = 0.5,
   scale: externalScale,
   onScaleChange,
+  highlight = null,
 }: UseGraphRendererOptions): GraphRendererReturn {
   // 엣지에 랜덤 거리 적용 (한 번만 계산)
   const processedEdges = React.useMemo(
@@ -94,6 +99,19 @@ function useGraphRenderer({
 
   // NodeMap 관리
   const nodeMapRef = React.useRef<NodeMap | null>(externalNodeMap || null);
+
+  // 그래프 데이터가 바뀌면 NodeMap 무효화 (다른 시도 선택 시 등)
+  const graphKey = React.useMemo(
+    () =>
+      `${graphData.nodes
+        .map((n) => n.id)
+        .sort((a, b) => a - b)
+        .join(",")}|${graphData.edges.length}`,
+    [graphData.nodes, graphData.edges],
+  );
+  React.useEffect(() => {
+    nodeMapRef.current = null;
+  }, [graphKey]);
 
   // NodeMap 변경 콜백 throttle 용
   const shouldNotify = React.useRef(true);
@@ -346,6 +364,7 @@ function useGraphRenderer({
         hoveredNodeId.current,
         textRenderScale,
         showLabels,
+        highlight,
       );
 
       // NodeMap 변경 콜백 (throttle 처리 - 100ms 마다)
@@ -367,6 +386,7 @@ function useGraphRenderer({
       textRenderScale,
       showLabels,
       onNodeMapChange,
+      highlight,
     ],
   );
 

--- a/apps/web/src/app/mypage/_components/graph-view/use-graph-renderer.ts
+++ b/apps/web/src/app/mypage/_components/graph-view/use-graph-renderer.ts
@@ -101,14 +101,19 @@ function useGraphRenderer({
   const nodeMapRef = React.useRef<NodeMap | null>(externalNodeMap || null);
 
   // 그래프 데이터가 바뀌면 NodeMap 무효화 (다른 시도 선택 시 등)
-  const graphKey = React.useMemo(
-    () =>
-      `${graphData.nodes
-        .map((n) => n.id)
-        .sort((a, b) => a - b)
-        .join(",")}|${graphData.edges.length}`,
-    [graphData.nodes, graphData.edges],
-  );
+  const graphKey = React.useMemo(() => {
+    const nodeKey = graphData.nodes
+      .map((n) => n.id)
+      .sort((a, b) => a - b)
+      .join(",");
+    const edgeKey = graphData.edges
+      .map((e) => e.id)
+      .sort((a, b) => a - b)
+      .join(",");
+    return `${nodeKey}|${edgeKey}`;
+  }, [graphData.nodes, graphData.edges]);
+
+  // graphKey가 변경되면 NodeMap 초기화 (새 그래프로 재시작)
   React.useEffect(() => {
     nodeMapRef.current = null;
   }, [graphKey]);

--- a/apps/web/src/app/mypage/_lib/graph-view/draw-graph-view.ts
+++ b/apps/web/src/app/mypage/_lib/graph-view/draw-graph-view.ts
@@ -12,6 +12,12 @@ function getNodeColor(type: NodeType) {
     : GRAPH_COLOR_CONSTANT.KEYWORD_NODE;
 }
 
+/** 하이라이트용: 이 제출에서 추가된 노드·엣지만 강조할 때 사용 */
+export interface GraphHighlightSets {
+  nodeIds: Set<number>;
+  edgeIds: Set<number>;
+}
+
 function drawGraphView(
   ctx: CanvasRenderingContext2D,
   nodes: NodeMapType,
@@ -21,6 +27,7 @@ function drawGraphView(
   hoveredNode: number | null,
   textRenderScale: number = 0.5,
   showLabels: boolean = true,
+  highlight: GraphHighlightSets | null = null,
 ) {
   ctx.save();
   ctx.translate(offset.x, offset.y);
@@ -36,36 +43,38 @@ function drawGraphView(
   );
   ctx.lineWidth = clampedVisualWidth / scale;
 
+  const isEdgeHighlighted = (edgeId: number) =>
+    highlight != null && highlight.edgeIds.has(edgeId);
+
   edges.forEach((edge) => {
     const source = nodes.get(edge.sourceId);
     const target = nodes.get(edge.targetId);
     if (!source || !target) return;
 
-    // 호버된 노드에 직접 연결된 엣지만 하이라이트
+    // 호버된 노드에 직접 연결된 엣지 또는 제출 하이라이트
     const isDirectlyConnected =
       source.id === hoveredNode || target.id === hoveredNode;
+    const isSubmissionHighlight = isEdgeHighlighted(edge.id);
 
-    // 직접 연결된 경우만 하이라이트 강도 사용
-    const edgeHighlight = isDirectlyConnected
-      ? Math.max(source.displayHighlight, target.displayHighlight)
-      : 0;
+    const edgeHighlight = isSubmissionHighlight
+      ? 1
+      : isDirectlyConnected
+        ? Math.max(source.displayHighlight, target.displayHighlight)
+        : 0;
 
-    // 3가지 상태에 따른 알파 계산
-    // - Normal (hoveredNode === null): 0.5
-    // - Active (직접 연결됨): 1.0
-    // - Inactive (연결 안됨): NOT_HOVERED_ALPHA
     const NORMAL_EDGE_ALPHA = 0.5;
     const INACTIVE_ALPHA = GRAPH_COLOR_CONSTANT.NOT_HOVERED_ALPHA;
 
     let finalAlpha: number;
-    if (hoveredNode === null) {
-      // Normal 상태
+    if (highlight != null) {
+      // 하이라이트 모드: 제출에서 추가된 엣지는 진하게, 나머지는 흐리게
+      finalAlpha = isSubmissionHighlight ? 0.9 : INACTIVE_ALPHA;
+    } else if (hoveredNode === null) {
       finalAlpha = NORMAL_EDGE_ALPHA;
     } else {
-      // Active 또는 Inactive 상태
-      // edgeHighlight로 Active(1.0)와 Inactive(0.2) 사이를 보간
       finalAlpha = INACTIVE_ALPHA + edgeHighlight * (1 - INACTIVE_ALPHA);
     }
+
     ctx.strokeStyle = lerpColorWithAlpha(
       GRAPH_COLOR_CONSTANT.EDGE,
       GRAPH_COLOR_CONSTANT.HOVERED,
@@ -86,24 +95,36 @@ function drawGraphView(
     1,
     Math.max(0, (scale - textRenderScale) / textRenderScale),
   );
+  const isNodeHighlighted = (nodeId: number) =>
+    highlight != null && highlight.nodeIds.has(nodeId);
+
   nodes.forEach((node) => {
     const isHovered = node.id === hoveredNode;
+    const isSubmissionHighlight = isNodeHighlighted(node.id);
 
-    // displayRadius와 displayAlpha 사용 (애니메이션된 값)
     const radius = node.displayRadius;
 
     ctx.beginPath();
     ctx.arc(node.x, node.y, radius, 0, Math.PI * 2);
 
-    const nodeColor = isHovered
+    let nodeColor = isHovered
       ? GRAPH_COLOR_CONSTANT.HOVERED
       : getNodeColor(node.type);
-    const nodeRgba = hexToRgba(nodeColor, node.displayAlpha);
+    if (isSubmissionHighlight && !isHovered) {
+      nodeColor = GRAPH_COLOR_CONSTANT.HOVERED;
+    }
+    const alpha =
+      highlight != null
+        ? isSubmissionHighlight
+          ? 1
+          : GRAPH_COLOR_CONSTANT.NOT_HOVERED_ALPHA
+        : node.displayAlpha;
+    const nodeRgba = hexToRgba(nodeColor, alpha);
     ctx.fillStyle = `rgba(${nodeRgba.r}, ${nodeRgba.g}, ${nodeRgba.b}, ${nodeRgba.a})`;
     ctx.fill();
 
     if (showLabels && textAlpha > 0) {
-      const labelAlpha = node.displayAlpha * textAlpha;
+      const labelAlpha = alpha * textAlpha;
       const labelRgba = hexToRgba(GRAPH_COLOR_CONSTANT.LABEL, labelAlpha);
       ctx.fillStyle = `rgba(${labelRgba.r}, ${labelRgba.g}, ${labelRgba.b}, ${labelRgba.a})`;
       ctx.fillText(node.label, node.x, node.y + radius + 10);

--- a/apps/web/src/app/reports/[questionId]/_components/report-tabs.tsx
+++ b/apps/web/src/app/reports/[questionId]/_components/report-tabs.tsx
@@ -4,10 +4,12 @@ import {
   TabsTrigger,
   TabsContent,
 } from "@/components/tabs/tabs";
-import { BookText, CircleCheckBig } from "lucide-react";
+import { BarChart3, BookText, CircleCheckBig } from "lucide-react";
 import FeedbackSection from "./feedback/feedback-section";
 import { AnalysisStatus, ReportDetail } from "../_types/report-detail";
 import { Question } from "@/app/daily/questions/_types/types";
+import type { GraphData } from "@/app/mypage/_types/graph-view";
+import GraphView from "@/app/mypage/_components/graph-view/graph-view";
 
 type ReportQuestion = Question & {
   categoryDisplay: string;
@@ -27,17 +29,45 @@ interface ReportTabsProps {
   selectedAttempt: HistoryItem;
   evaluation: ReportDetail;
   question: ReportQuestion;
+  /** 이 제출에서 추가된 그래프(노드·엣지). 없으면 null */
+  submissionGraph: GraphData | null;
+  /** 이 문제에 대한 전체 학습 그래프(서브그래프). 하이라이트 베이스용 */
+  fullGraphForQuestion: GraphData | null;
 }
 
 function ReportTabs({
   selectedAttempt,
   evaluation,
   question,
+  submissionGraph,
+  fullGraphForQuestion,
 }: ReportTabsProps) {
   const keywords =
     evaluation.status === "COMPLETED"
       ? evaluation.feedback.extractedKeywords
       : [];
+
+  // 베이스: 이 문제 전체 그래프가 있으면 사용, 없으면 제출 그래프만 사용
+  const graphData =
+    fullGraphForQuestion != null && fullGraphForQuestion.nodes.length > 0
+      ? fullGraphForQuestion
+      : submissionGraph;
+
+  const hasGraph = graphData != null && graphData.nodes.length > 0;
+
+  // 제출에서 추가된 노드·엣지만 하이라이트 (전체 그래프 표시 시)
+  const highlightNodeIds =
+    fullGraphForQuestion != null &&
+    submissionGraph != null &&
+    submissionGraph.nodes.length > 0
+      ? submissionGraph.nodes.map((n) => n.id)
+      : undefined;
+  const highlightEdgeIds =
+    fullGraphForQuestion != null &&
+    submissionGraph != null &&
+    submissionGraph.edges.length > 0
+      ? submissionGraph.edges.map((e) => e.id)
+      : undefined;
 
   return (
     <Tabs defaultValue="feedback" className="w-full">
@@ -49,6 +79,10 @@ function ReportTabs({
         <TabsTrigger value="answer">
           <BookText className="mr-1.5 md:mr-2.5 w-4 h-4 hidden sm:block" /> 답변
           스크립트
+        </TabsTrigger>
+        <TabsTrigger value="graph">
+          <BarChart3 className="mr-1.5 md:mr-2.5 w-4 h-4 hidden sm:block" />{" "}
+          이번 제출 학습 그래프
         </TabsTrigger>
       </TabsList>
 
@@ -114,6 +148,35 @@ function ReportTabs({
                 </div>
               )}
           </div>
+        </div>
+      </TabsContent>
+
+      <TabsContent value="graph">
+        <div className="overflow-hidden rounded-lg border border-slate-200 bg-white">
+          {hasGraph ? (
+            <div className="relative w-full h-80 md:h-96">
+              <GraphView
+                key={selectedAttempt.submissionId}
+                graphData={graphData}
+                clickEventDisabled
+                zoomEnabled
+                highlightNodeIds={highlightNodeIds}
+                highlightEdgeIds={highlightEdgeIds}
+              />
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
+              <div className="w-12 h-12 mb-3 rounded-full bg-slate-100 flex items-center justify-center">
+                <BarChart3 className="w-6 h-6 text-slate-400" />
+              </div>
+              <p className="text-sm text-slate-500">
+                이 제출에서 추가된 학습 그래프가 없습니다.
+              </p>
+              <p className="text-xs text-slate-400 mt-1">
+                키워드가 추출된 답변만 그래프에 반영됩니다.
+              </p>
+            </div>
+          )}
         </div>
       </TabsContent>
     </Tabs>

--- a/apps/web/src/app/reports/[questionId]/_components/report-tabs.tsx
+++ b/apps/web/src/app/reports/[questionId]/_components/report-tabs.tsx
@@ -47,7 +47,7 @@ function ReportTabs({
       ? evaluation.feedback.extractedKeywords
       : [];
 
-  // 베이스: 이 문제 전체 그래프가 있으면 사용, 없으면 제출 그래프만 사용
+  // 베이스: 전체 누적 그래프가 있으면 사용, 없으면 제출 그래프만 사용
   const graphData =
     fullGraphForQuestion != null && fullGraphForQuestion.nodes.length > 0
       ? fullGraphForQuestion
@@ -152,7 +152,7 @@ function ReportTabs({
       </TabsContent>
 
       <TabsContent value="graph">
-        <div className="overflow-hidden rounded-lg border border-slate-200 bg-white">
+        <div className="overflow-hidden">
           {hasGraph ? (
             <div className="relative w-full h-80 md:h-96">
               <GraphView

--- a/apps/web/src/app/reports/[questionId]/_lib/services/graph-data.ts
+++ b/apps/web/src/app/reports/[questionId]/_lib/services/graph-data.ts
@@ -1,0 +1,97 @@
+import { apiGet } from "@/lib/api-client";
+import { logger } from "@/lib/sentry-logger";
+import type { GraphData } from "@/app/mypage/_types/graph-view";
+import { NodeType } from "@/app/mypage/_types/graph-view";
+
+/**
+ * 제출별로 해당 제출에서 추가된 그래프(노드·엣지)를 조회한다.
+ * 실패 시 null 반환 (리포트 페이지는 그래프 없이도 렌더링 가능하도록).
+ */
+async function getReportGraph(submissionId: number): Promise<GraphData | null> {
+  try {
+    return await apiGet<GraphData>(`/graph/submission/${submissionId}`);
+  } catch (error) {
+    logger.warn("제출별 그래프 조회 실패", {
+      submissionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+/**
+ * 전체 그래프를 조회한다. 실패 시 null 반환.
+ */
+async function getReportFullGraph(): Promise<GraphData | null> {
+  try {
+    return await apiGet<GraphData>("/graph");
+  } catch (error) {
+    logger.warn("전체 그래프 조회 실패", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+/**
+ * 여러 제출 ID까지의 누적 그래프를 조회한다.
+ * (이전 제출을 볼 때 그 시점의 그래프 모양 표시용). 실패 시 null 반환.
+ */
+async function getReportGraphBySubmissionIds(
+  submissionIds: number[],
+): Promise<GraphData | null> {
+  if (submissionIds.length === 0) return null;
+  try {
+    const ids = submissionIds.join(",");
+    return await apiGet<GraphData>(
+      `/graph/submissions?ids=${encodeURIComponent(ids)}`,
+    );
+  } catch (error) {
+    logger.warn("누적 그래프 조회 실패", {
+      submissionIds,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+/**
+ * 전체 그래프에서 특정 문제(questionId)에 해당하는 서브그래프만 추린다.
+ * 해당 문제 노드와 그에 연결된 키워드 노드·엣지를 반환한다.
+ */
+function filterGraphByQuestionId(
+  fullGraph: GraphData,
+  questionId: number,
+): GraphData {
+  const questionNode = fullGraph.nodes.find(
+    (n) => n.type === NodeType.QUESTION && n.questionId === questionId,
+  );
+  if (!questionNode) {
+    return { nodes: [], edges: [] };
+  }
+
+  const nodeIds = new Set<number>([questionNode.id]);
+  for (const edge of fullGraph.edges) {
+    if (
+      edge.sourceId === questionNode.id ||
+      edge.targetId === questionNode.id
+    ) {
+      nodeIds.add(edge.sourceId);
+      nodeIds.add(edge.targetId);
+    }
+  }
+
+  const nodes = fullGraph.nodes.filter((n) => nodeIds.has(n.id));
+  const edges = fullGraph.edges.filter(
+    (e) => nodeIds.has(e.sourceId) && nodeIds.has(e.targetId),
+  );
+
+  return { nodes, edges };
+}
+
+export {
+  getReportGraph,
+  getReportFullGraph,
+  getReportGraphBySubmissionIds,
+  filterGraphByQuestionId,
+};

--- a/apps/web/src/app/reports/[questionId]/_lib/services/graph-data.ts
+++ b/apps/web/src/app/reports/[questionId]/_lib/services/graph-data.ts
@@ -20,6 +20,20 @@ async function getReportGraph(submissionId: number): Promise<GraphData | null> {
 }
 
 /**
+ * 전체 그래프를 조회한다. 실패 시 null 반환.
+ */
+async function getReportFullGraph(): Promise<GraphData | null> {
+  try {
+    return await apiGet<GraphData>("/graph");
+  } catch (error) {
+    logger.warn("전체 그래프 조회 실패", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+/**
  * 여러 제출 ID까지의 누적 그래프를 조회한다.
  * (이전 제출을 볼 때 그 시점의 그래프 모양 표시용). 실패 시 null 반환.
  */
@@ -77,6 +91,7 @@ function filterGraphByQuestionId(
 
 export {
   getReportGraph,
+  getReportFullGraph,
   getReportGraphBySubmissionIds,
   filterGraphByQuestionId,
 };

--- a/apps/web/src/app/reports/[questionId]/_lib/services/graph-data.ts
+++ b/apps/web/src/app/reports/[questionId]/_lib/services/graph-data.ts
@@ -20,20 +20,6 @@ async function getReportGraph(submissionId: number): Promise<GraphData | null> {
 }
 
 /**
- * 전체 그래프를 조회한다. 실패 시 null 반환.
- */
-async function getReportFullGraph(): Promise<GraphData | null> {
-  try {
-    return await apiGet<GraphData>("/graph");
-  } catch (error) {
-    logger.warn("전체 그래프 조회 실패", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return null;
-  }
-}
-
-/**
  * 여러 제출 ID까지의 누적 그래프를 조회한다.
  * (이전 제출을 볼 때 그 시점의 그래프 모양 표시용). 실패 시 null 반환.
  */
@@ -91,7 +77,6 @@ function filterGraphByQuestionId(
 
 export {
   getReportGraph,
-  getReportFullGraph,
   getReportGraphBySubmissionIds,
   filterGraphByQuestionId,
 };

--- a/apps/web/src/app/reports/[questionId]/_lib/services/page-data.ts
+++ b/apps/web/src/app/reports/[questionId]/_lib/services/page-data.ts
@@ -1,4 +1,9 @@
 import { getReportEvaluation } from "./evaluation-data";
+import {
+  getReportGraph,
+  getReportGraphBySubmissionIds,
+  filterGraphByQuestionId,
+} from "./graph-data";
 import { getReportHistory } from "./history-data";
 import { getReportQuestion } from "./question-data";
 
@@ -10,9 +15,35 @@ async function getReportPageData(questionId: number, submissionId?: number) {
 
   const selectedSubmissionId = submissionId ?? history.at(-1)?.submissionId;
 
-  const evaluation = selectedSubmissionId
-    ? await getReportEvaluation(selectedSubmissionId)
-    : null;
+  // 선택한 제출까지의 제출 ID 목록 (시간순) → 그 시점의 그래프 모양 조회용
+  const submissionIdsUpToSelected =
+    selectedSubmissionId != null
+      ? (() => {
+          const idx = history.findIndex(
+            (h) => h.submissionId === selectedSubmissionId,
+          );
+          if (idx < 0) return [];
+          return history.slice(0, idx + 1).map((h) => h.submissionId);
+        })()
+      : [];
+
+  const [evaluation, submissionGraph, cumulativeGraph] = await Promise.all([
+    selectedSubmissionId
+      ? getReportEvaluation(selectedSubmissionId)
+      : Promise.resolve(null),
+    selectedSubmissionId
+      ? getReportGraph(selectedSubmissionId)
+      : Promise.resolve(null),
+    submissionIdsUpToSelected.length > 0
+      ? getReportGraphBySubmissionIds(submissionIdsUpToSelected)
+      : Promise.resolve(null),
+  ]);
+
+  // 그 시점까지의 누적 그래프에서 이 문제에 해당하는 서브그래프만 추림
+  const fullGraphForQuestion =
+    cumulativeGraph != null
+      ? filterGraphByQuestionId(cumulativeGraph, questionId)
+      : null;
 
   const highestScore = Math.max(
     ...history
@@ -26,6 +57,8 @@ async function getReportPageData(questionId: number, submissionId?: number) {
     history,
     evaluation,
     highestScore,
+    submissionGraph,
+    fullGraphForQuestion,
   };
 }
 

--- a/apps/web/src/app/reports/[questionId]/_lib/services/page-data.ts
+++ b/apps/web/src/app/reports/[questionId]/_lib/services/page-data.ts
@@ -1,9 +1,5 @@
 import { getReportEvaluation } from "./evaluation-data";
-import {
-  getReportGraph,
-  getReportGraphBySubmissionIds,
-  filterGraphByQuestionId,
-} from "./graph-data";
+import { getReportGraph, getReportFullGraph } from "./graph-data";
 import { getReportHistory } from "./history-data";
 import { getReportQuestion } from "./question-data";
 
@@ -15,35 +11,18 @@ async function getReportPageData(questionId: number, submissionId?: number) {
 
   const selectedSubmissionId = submissionId ?? history.at(-1)?.submissionId;
 
-  // 선택한 제출까지의 제출 ID 목록 (시간순) → 그 시점의 그래프 모양 조회용
-  const submissionIdsUpToSelected =
-    selectedSubmissionId != null
-      ? (() => {
-          const idx = history.findIndex(
-            (h) => h.submissionId === selectedSubmissionId,
-          );
-          if (idx < 0) return [];
-          return history.slice(0, idx + 1).map((h) => h.submissionId);
-        })()
-      : [];
-
-  const [evaluation, submissionGraph, cumulativeGraph] = await Promise.all([
+  const [evaluation, submissionGraph, fullGraph] = await Promise.all([
     selectedSubmissionId
       ? getReportEvaluation(selectedSubmissionId)
       : Promise.resolve(null),
     selectedSubmissionId
       ? getReportGraph(selectedSubmissionId)
       : Promise.resolve(null),
-    submissionIdsUpToSelected.length > 0
-      ? getReportGraphBySubmissionIds(submissionIdsUpToSelected)
-      : Promise.resolve(null),
+    getReportFullGraph(),
   ]);
 
-  // 그 시점까지의 누적 그래프에서 이 문제에 해당하는 서브그래프만 추림
-  const fullGraphForQuestion =
-    cumulativeGraph != null
-      ? filterGraphByQuestionId(cumulativeGraph, questionId)
-      : null;
+  // 전체 사용자 그래프를 사용 (모든 문제에서 추출된 키워드로 만든 그래프)
+  const fullGraphForQuestion = fullGraph;
 
   const highestScore = Math.max(
     ...history

--- a/apps/web/src/app/reports/[questionId]/page.tsx
+++ b/apps/web/src/app/reports/[questionId]/page.tsx
@@ -22,8 +22,14 @@ async function ReportPage({ params, searchParams }: ReportPageProps) {
     ? parsedSubmissionId
     : undefined;
 
-  const { question, history, evaluation, highestScore } =
-    await getReportPageData(Number(questionId), validSubmissionId);
+  const {
+    question,
+    history,
+    evaluation,
+    highestScore,
+    submissionGraph,
+    fullGraphForQuestion,
+  } = await getReportPageData(Number(questionId), validSubmissionId);
 
   // submissionId가 없거나 유효하지 않으면 최신 submission으로 fallback
   const selectedAttempt = validSubmissionId
@@ -47,6 +53,8 @@ async function ReportPage({ params, searchParams }: ReportPageProps) {
             selectedAttempt={selectedAttempt}
             evaluation={evaluation}
             question={question}
+            submissionGraph={submissionGraph}
+            fullGraphForQuestion={fullGraphForQuestion}
           />
 
           <ReportRefresh


### PR DESCRIPTION
## 🔸 작업 내용

- #372

### API 변경사항
- **GraphEdge 엔티티**: `submissionId` 컬럼 추가 (제출별 그래프 추적)
- **GraphService**: 
  - `createGraphFromEvaluation`에 `submissionId` 전달 및 엣지 저장 시 설정
  - `getGraphBySubmissionId(submissionId)`: 해당 제출에서 추가된 그래프만 조회
  - `getGraphBySubmissionIds(submissionIds)`: 여러 제출까지의 누적 그래프 조회 (이전 제출 시점의 그래프 모양 표시용)
- **GraphController**: 
  - `GET /graph/submission/:submissionId`: 제출별 추가 그래프 조회 API
  - `GET /graph/submissions?ids=1,2,3`: 누적 그래프 조회 API (본인 제출 검증 포함)
- **AnswerEvaluationService**: 그래프 생성 시 `submission.id` 전달

### Web 변경사항
- **리포트 페이지 그래프 탭 추가**: "이번 제출 학습 그래프" 탭 생성
- **그래프 하이라이트 기능**: 
  - 기존 그래프(문제 + 연결된 모든 키워드) 위에 이번 제출에서 추가된 노드·엣지만 강조 표시
  - 하이라이트: teal 색상 + 높은 투명도, 나머지: 흐리게 표시
- **시도별 그래프 모양 표시**: 
  - 이전 제출 선택 시 그 시점까지 누적된 그래프만 표시 (이후에 추가된 노드/엣지는 보이지 않음)
  - 선택한 제출까지의 `submissionIds`로 누적 그래프 조회
- **그래프 즉시 갱신**: 시도 변경 시 탭 전환 없이 바로 그래프 업데이트
  - `GraphView`에 `key={submissionId}` 추가로 컴포넌트 리마운트
  - `graphKey` 기반 NodeMap 재초기화 로직 추가

### 기타
- `fetch-categories`: API_URL 없을 때 `NEXT_PUBLIC_API_URL` 또는 localhost fallback 적용

## 🔸 고민 했던 부분

### 1. 그래프 히스토리 저장 vs 새로 추가된 것만 표시
**고민**: 리포트 페이지에서 그래프 히스토리마다 어떤 상태였는지 기록해야 할지 아니면 새로 추가된 것만 표시하면 될지

**결과**: 
- **제출별로 그때 당시 추가된 그래프 노드를 표시**하는 방향으로 결정
- `GraphEdge`에 `submissionId`를 저장하여 각 제출에서 생성된 엣지만 추적
- 히스토리 스냅샷을 별도로 저장하지 않고, 누적 그래프에서 `submissionId`로 필터링하여 "그 시점의 그래프 모양" 재구성
- 이전 제출 선택 시: 선택한 제출까지의 `submissionIds`로 누적 그래프 조회 → 그 시점까지 추가된 노드/엣지만 표시

### 2. 전체 그래프 vs 문제별 서브그래프
**고민**: 리포트 페이지에서 사용자의 전체 그래프를 보여줄지, 해당 문제에 대한 서브그래프만 보여줄지

**결과**:
- **문제별 서브그래프**로 결정 (문제 노드 + 그에 연결된 키워드 노드/엣지만)
- `filterGraphByQuestionId` 유틸로 전체 그래프에서 해당 문제만 추출
- 리포트 페이지의 맥락에 맞게 해당 문제와 관련된 학습 그래프만 집중 표시

### 3. 시도 변경 시 그래프 갱신 문제
**고민**: 시도를 바꿔도 그래프가 바로 반영되지 않고, 다른 탭을 갔다 와야 제대로 보이는 문제

**결과**:
- 원인: `useGraphRenderer`의 `nodeMapRef`가 한 번 생성되면 `graphData`가 바뀌어도 재초기화되지 않음
- 해결:
  1. `GraphView`에 `key={selectedAttempt.submissionId}` 추가 → 시도 변경 시 컴포넌트 리마운트로 완전 초기화
  2. `graphKey`(노드 id 정렬 + 엣지 개수)로 그래프 변경 감지 → 변경 시 `nodeMapRef`를 null로 초기화하여 새 NodeMap 생성
- 두 가지 방법을 모두 적용하여 안정적으로 전환이 되도록 함

### 4. 하이라이트 시각적 표현
**고민**: 기존 그래프 위에 "이번 제출에서 추가된 부분"을 어떻게 구분할지

**결과**:
- 하이라이트 모드: 제출에서 추가된 노드·엣지는 **teal 색상 + 높은 투명도(0.9~1.0)**
- 비하이라이트: 나머지 노드·엣지는 **낮은 투명도(0.2)**로 흐리게 표시
- 호버/연결 하이라이트와 구분되도록 별도 로직으로 처리

### 5. 그래프 표시 위치: 추출된 키워드 아래 vs 새로운 탭
**고민**: 학습 그래프를 "답변 스크립트" 탭의 추출된 키워드(CORE KEYWORDS) 아래에 표시할지, 별도의 "학습 그래프" 탭으로 분리할지

**고려사항**:
- **추출된 키워드 아래**: 
  - 장점: 키워드와 그래프가 한 화면에서 연관성 있게 보임, 탭 전환 없이 바로 확인 가능
  - 단점: "답변 스크립트" 탭이 길어질 수 있음, 그래프가 작은 공간에 제한됨, 시도별 그래프 모양 비교가 어려움
- **새로운 탭**:
  - 장점: 그래프에 충분한 공간 할당 (h-80 ~ h-96), 시도 변경 시 그래프만 독립적으로 갱신 가능, 이전 제출 선택 시 "그 시점의 그래프 모양" 비교 용이
  - 단점: 탭 전환이 필요함

**결과**:
- **새로운 탭("이번 제출 학습 그래프")으로 분리** 결정
- 이유:
  1. **시도별 그래프 모양 비교**: 이전 제출 선택 시 그 시점까지의 누적 그래프를 보여주는 기능이 핵심인데, 탭으로 분리해야 시도 변경 시 그래프만 독립적으로 갱신 가능
  2. **충분한 공간**: 그래프는 인터랙티브한 시각화(줌, 드래그)가 필요하므로 충분한 공간이 필요
  3. **명확한 정보 구조**: 리포트 페이지의 탭 구조(분석 리포트, 답변 스크립트, 학습 그래프)로 각 정보의 역할이 명확히 구분됨
  4. **확장성**: 향후 그래프 관련 기능(필터, 검색 등) 추가 시 탭 구조가 더 적합

## 🔸 참고

### API 엔드포인트
- `GET /graph/submission/:submissionId` - 제출별 추가 그래프
- `GET /graph/submissions?ids=1,2,3` - 누적 그래프 (쉼표 구분)

### 주요 파일
- `apps/api/src/graph/entities/graph-edge.entity.ts` - submissionId 컬럼 추가
- `apps/api/src/graph/graph.service.ts` - 제출별/누적 그래프 조회 로직
- `apps/web/src/app/reports/[questionId]/_lib/services/graph-data.ts` - 리포트용 그래프 fetch/필터 유틸 (신규)
- `apps/web/src/app/reports/[questionId]/_components/report-tabs.tsx` - 그래프 탭 UI
- `apps/web/src/app/mypage/_lib/graph-view/draw-graph-view.ts` - 하이라이트 렌더링 로직

### 마이그레이션
- `graph_edges` 테이블에 `submission_id` 컬럼 추가 필요
- 기존 엣지는 `submission_id = null` (이전 제출용 그래프 조회 불가, 새 제출부터 추적)

### 첨부 영상

https://github.com/user-attachments/assets/9d974b38-4b3f-430e-9a10-3e8b9460230e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 리포트 페이지에 제출별 및 누적 학습 그래프 탭과 노드·엣지 하이라이트 표시 기능 추가

* **API**
  * 특정 제출 및 복수 제출용 그래프 조회 엔드포인트 추가(권한 검증 포함)
  * 그래프 생성 호출에 제출 ID 전달 지원(생성시 엣지에 제출 ID 저장)

* **Database**
  * 그래프 엣지에 제출 식별자(submissionId) 컬럼 및 인덱스 추가

* **Web**
  * 리포트용 그래프 조회·필터 유틸 및 GraphView 하이라이트 옵션/렌더링 개선 추가

* **Tests**
  * 그래프 생성 관련 테스트가 제출 ID 인자 반영하도록 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->