### PR TITLE
error 페이지, not-found 페이지 정적 헤더 추가

### DIFF
--- a/apps/web/src/app/_components/not-found-logger.tsx
+++ b/apps/web/src/app/_components/not-found-logger.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { logger } from "@/lib/sentry-logger";
+import { useParams, usePathname, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+interface NotFoundLoggerProps {
+  pageName: string;
+}
+
+export function NotFoundLogger({ pageName }: NotFoundLoggerProps) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const params = useParams();
+
+  useEffect(() => {
+    const context = {
+      pathname,
+      questionId: params?.questionId,
+      attempt: searchParams?.get("attempt"),
+      fullUrl: `${pathname}${searchParams?.toString() ? `?${searchParams.toString()}` : ""}`,
+    };
+
+    if (process.env.NODE_ENV === "production") {
+      logger.warn(`404 Not Found - ${pageName}`, context);
+    }
+  }, [pathname, searchParams, params, pageName]);
+
+  return null;
+}

--- a/apps/web/src/app/daily/questions/[questionId]/not-found.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/not-found.tsx
@@ -1,60 +1,44 @@
-"use client";
-
-import { logger } from "@/lib/sentry-logger";
 import { TriangleAlert } from "lucide-react";
 import Link from "next/link";
-import { useParams, usePathname, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import Header from "@/components/header/header";
+import { NotFoundLogger } from "@/app/_components/not-found-logger";
 
-function NotFound() {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const params = useParams();
-
-  useEffect(() => {
-    const context = {
-      pathname,
-      questionId: params?.questionId,
-      attempt: searchParams?.get("attempt"),
-      fullUrl: `${pathname}${searchParams?.toString() ? `?${searchParams.toString()}` : ""}`,
-    };
-
-    if (process.env.NODE_ENV === "production") {
-      logger.warn("404 Not Found - Question Detail Page", context);
-    }
-  }, [pathname, searchParams, params]);
-
+async function NotFound() {
   return (
-    <div className="flex flex-col items-center justify-center min-h-[90vh] gap-6 px-4">
-      <div className="p-8 w-full text-center space-y-6">
-        <h1 className="flex items-center justify-center gap-3 text-6xl font-bold text-gray-300">
-          <TriangleAlert size={64} />
-          404
-        </h1>
-        <div className="space-y-2">
-          <h2 className="text-2xl font-semibold text-slate-900">
-            요청하신 문제를 찾을 수 없습니다
-          </h2>
-          <p className="text-slate-600 text-lg">
-            존재하지 않는 문제입니다. 문제 리스트에서 문제를 뽑아주세요.
-          </p>
+    <>
+      <NotFoundLogger pageName="Question Detail Page" />
+      <Header />
+      <main className="flex flex-col items-center justify-center flex-1 w-full gap-6 px-4">
+        <div className="p-8 w-full text-center space-y-6">
+          <h1 className="flex items-center justify-center gap-3 text-6xl font-bold text-gray-300">
+            <TriangleAlert size={64} />
+            404
+          </h1>
+          <div className="space-y-2">
+            <h2 className="text-2xl font-semibold text-slate-900">
+              요청하신 문제를 찾을 수 없습니다
+            </h2>
+            <p className="text-slate-600 text-lg">
+              존재하지 않는 문제입니다. 문제 리스트에서 문제를 뽑아주세요.
+            </p>
+          </div>
+          <div className="flex gap-4 justify-center">
+            <Link
+              href="/daily/questions"
+              className="px-6 py-2 bg-teal-500 text-white rounded-lg hover:bg-teal-600 transition font-bold cursor-pointer"
+            >
+              문제 목록으로 가기
+            </Link>
+            <Link
+              href="/"
+              className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition cursor-pointer"
+            >
+              홈으로 돌아가기
+            </Link>
+          </div>
         </div>
-        <div className="flex gap-4 justify-center">
-          <Link
-            href="/daily/questions"
-            className="px-6 py-2 bg-teal-500 text-white rounded-lg hover:bg-teal-600 transition font-bold cursor-pointer"
-          >
-            문제 목록으로 가기
-          </Link>
-          <Link
-            href="/"
-            className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition cursor-pointer"
-          >
-            홈으로 돌아가기
-          </Link>
-        </div>
-      </div>
-    </div>
+      </main>
+    </>
   );
 }
 

--- a/apps/web/src/app/daily/questions/[questionId]/not-found.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/not-found.tsx
@@ -1,13 +1,13 @@
 import { TriangleAlert } from "lucide-react";
 import Link from "next/link";
-import Header from "@/components/header/header";
+import StaticHeader from "@/components/header/header";
 import { NotFoundLogger } from "@/app/_components/not-found-logger";
 
 async function NotFound() {
   return (
     <>
       <NotFoundLogger pageName="Question Detail Page" />
-      <Header />
+      <StaticHeader />
       <main className="flex flex-col items-center justify-center flex-1 w-full gap-6 px-4">
         <div className="p-8 w-full text-center space-y-6">
           <h1 className="flex items-center justify-center gap-3 text-6xl font-bold text-gray-300">

--- a/apps/web/src/app/daily/questions/[questionId]/not-found.tsx
+++ b/apps/web/src/app/daily/questions/[questionId]/not-found.tsx
@@ -1,6 +1,6 @@
 import { TriangleAlert } from "lucide-react";
 import Link from "next/link";
-import StaticHeader from "@/components/header/header";
+import StaticHeader from "@/components/header/static-header";
 import { NotFoundLogger } from "@/app/_components/not-found-logger";
 
 async function NotFound() {

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -2,6 +2,7 @@
 
 import { AlertCircle, RefreshCcw, WifiOff } from "lucide-react";
 import { useRouter } from "next/navigation";
+import StaticHeader from "@/components/header/static-header";
 
 interface ErrorBoundaryProps {
   error: Error & { digest?: string };
@@ -43,31 +44,34 @@ function ErrorBoundary({ error, reset }: ErrorBoundaryProps) {
     // 401/403 인증 에러
     if (isAuthError) {
       return (
-        <div className="flex flex-col items-center justify-center min-h-[90vh] gap-6 px-4">
-          <div className="p-8 w-full text-center space-y-6">
-            <div className="flex justify-center">
-              <div className="w-25 h-25 bg-orange-50 rounded-full flex items-center justify-center">
-                <AlertCircle className="w-15 h-15 text-orange-500" />
+        <>
+          <StaticHeader />
+          <div className="flex flex-col items-center justify-center flex-1 w-full gap-6 px-4">
+            <div className="p-8 w-full text-center space-y-6">
+              <div className="flex justify-center">
+                <div className="w-25 h-25 bg-orange-50 rounded-full flex items-center justify-center">
+                  <AlertCircle className="w-15 h-15 text-orange-500" />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <h2 className="text-2xl font-semibold text-slate-900">
+                  로그인이 필요합니다
+                </h2>
+                <p className="text-slate-600 text-lg">
+                  인증이 만료되었거나 권한이 없습니다. 다시 로그인해주세요.
+                </p>
+              </div>
+              <div className="flex gap-4 justify-center">
+                <button
+                  className="px-6 py-2 bg-teal-500 text-white rounded-lg hover:bg-teal-600 transition font-bold cursor-pointer"
+                  onClick={() => router.push("/login")}
+                >
+                  로그인 페이지로 이동
+                </button>
               </div>
             </div>
-            <div className="space-y-2">
-              <h2 className="text-2xl font-semibold text-slate-900">
-                로그인이 필요합니다
-              </h2>
-              <p className="text-slate-600 text-lg">
-                인증이 만료되었거나 권한이 없습니다. 다시 로그인해주세요.
-              </p>
-            </div>
-            <div className="flex gap-4 justify-center">
-              <button
-                className="px-6 py-2 bg-teal-500 text-white rounded-lg hover:bg-teal-600 transition font-bold cursor-pointer"
-                onClick={() => router.push("/login")}
-              >
-                로그인 페이지로 이동
-              </button>
-            </div>
           </div>
-        </div>
+        </>
       );
     }
 
@@ -113,181 +117,193 @@ function ErrorBoundary({ error, reset }: ErrorBoundaryProps) {
     // 네트워크 에러 (연결 실패)
     if (isNetworkError) {
       return (
-        <div className="flex flex-col items-center justify-center min-h-[90vh] gap-6 px-4">
-          <div className="p-8 w-full text-center space-y-6">
-            <div className="flex justify-center">
-              <div className="w-25 h-25 bg-red-50 rounded-full flex items-center justify-center">
-                <WifiOff className="w-15 h-15 text-red-500" />
+        <>
+          <StaticHeader />
+          <div className="flex flex-col items-center justify-center flex-1 w-full gap-6 px-4">
+            <div className="p-8 w-full text-center space-y-6">
+              <div className="flex justify-center">
+                <div className="w-25 h-25 bg-red-50 rounded-full flex items-center justify-center">
+                  <WifiOff className="w-15 h-15 text-red-500" />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <h2 className="text-2xl font-semibold text-slate-900">
+                  서버와 연결할 수 없습니다
+                </h2>
+                <p className="text-slate-600 text-lg">{userMessage}</p>
+                {process.env.NODE_ENV === "development" && requestId && (
+                  <p className="text-slate-400 text-xs mt-2">
+                    Request ID: {requestId}
+                  </p>
+                )}
+              </div>
+              <div className="flex gap-4 justify-center">
+                <button
+                  className="px-6 py-2 bg-teal-500 text-white rounded-lg hover:bg-teal-600 transition font-bold flex items-center gap-2 cursor-pointer"
+                  onClick={reset}
+                >
+                  <RefreshCcw className="w-4 h-4" />
+                  다시 시도
+                </button>
+                <button
+                  className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition cursor-pointer"
+                  onClick={() => router.back()}
+                >
+                  이전으로
+                </button>
               </div>
             </div>
-            <div className="space-y-2">
-              <h2 className="text-2xl font-semibold text-slate-900">
-                서버와 연결할 수 없습니다
-              </h2>
-              <p className="text-slate-600 text-lg">{userMessage}</p>
-              {process.env.NODE_ENV === "development" && requestId && (
-                <p className="text-slate-400 text-xs mt-2">
-                  Request ID: {requestId}
-                </p>
-              )}
-            </div>
-            <div className="flex gap-4 justify-center">
-              <button
-                className="px-6 py-2 bg-teal-500 text-white rounded-lg hover:bg-teal-600 transition font-bold flex items-center gap-2 cursor-pointer"
-                onClick={reset}
-              >
-                <RefreshCcw className="w-4 h-4" />
-                다시 시도
-              </button>
-              <button
-                className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition cursor-pointer"
-                onClick={() => router.back()}
-              >
-                이전으로
-              </button>
-            </div>
           </div>
-        </div>
+        </>
       );
     }
 
     // 5xx 서버 에러
     if (isServerError) {
       return (
-        <div className="flex flex-col items-center justify-center min-h-[90vh] gap-6 px-4">
-          <div className="p-8 w-full text-center space-y-6">
-            <div className="flex justify-center">
-              <div className="w-25 h-25 bg-red-50 rounded-full flex items-center justify-center">
-                <AlertCircle className="w-15 h-15 text-red-500" />
+        <>
+          <StaticHeader />
+          <div className="flex flex-col items-center justify-center flex-1 w-full gap-6 px-4">
+            <div className="p-8 w-full text-center space-y-6">
+              <div className="flex justify-center">
+                <div className="w-25 h-25 bg-red-50 rounded-full flex items-center justify-center">
+                  <AlertCircle className="w-15 h-15 text-red-500" />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <h2 className="text-2xl font-semibold text-slate-900">
+                  서버 오류가 발생했습니다
+                </h2>
+                <p className="text-slate-600 text-lg">{userMessage}</p>
+                {process.env.NODE_ENV === "development" && requestId && (
+                  <p className="text-slate-400 text-xs mt-2">
+                    Request ID: {requestId}
+                  </p>
+                )}
+              </div>
+              <div className="flex gap-4 justify-center">
+                <button
+                  className="px-6 py-2 bg-teal-500 text-white rounded-lg hover:bg-teal-600 transition font-bold flex items-center gap-2 cursor-pointer"
+                  onClick={reset}
+                >
+                  <RefreshCcw className="w-4 h-4" />
+                  다시 시도
+                </button>
+                <button
+                  className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition cursor-pointer"
+                  onClick={() => router.back()}
+                >
+                  이전으로
+                </button>
               </div>
             </div>
-            <div className="space-y-2">
-              <h2 className="text-2xl font-semibold text-slate-900">
-                서버 오류가 발생했습니다
-              </h2>
-              <p className="text-slate-600 text-lg">{userMessage}</p>
-              {process.env.NODE_ENV === "development" && requestId && (
-                <p className="text-slate-400 text-xs mt-2">
-                  Request ID: {requestId}
-                </p>
-              )}
-            </div>
-            <div className="flex gap-4 justify-center">
-              <button
-                className="px-6 py-2 bg-teal-500 text-white rounded-lg hover:bg-teal-600 transition font-bold flex items-center gap-2 cursor-pointer"
-                onClick={reset}
-              >
-                <RefreshCcw className="w-4 h-4" />
-                다시 시도
-              </button>
-              <button
-                className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition cursor-pointer"
-                onClick={() => router.back()}
-              >
-                이전으로
-              </button>
-            </div>
           </div>
-        </div>
+        </>
       );
     }
 
     // 4xx 클라이언트 에러
     if (isClientError && !isAuthError) {
       return (
-        <div className="flex flex-col items-center justify-center min-h-[90vh] gap-6 px-4">
-          <div className="p-8 w-full text-center space-y-6">
-            <div className="flex justify-center">
-              <div className="w-25 h-25 bg-orange-50 rounded-full flex items-center justify-center">
-                <AlertCircle className="w-15 h-15 text-orange-500" />
+        <>
+          <StaticHeader />
+          <div className="flex flex-col items-center justify-center flex-1 w-full gap-6 px-4">
+            <div className="p-8 w-full text-center space-y-6">
+              <div className="flex justify-center">
+                <div className="w-25 h-25 bg-orange-50 rounded-full flex items-center justify-center">
+                  <AlertCircle className="w-15 h-15 text-orange-500" />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <h2 className="text-2xl font-semibold text-slate-900">
+                  요청을 처리할 수 없습니다
+                </h2>
+                <p className="text-slate-600 text-lg">{userMessage}</p>
+                {validationErrors && validationErrors.length > 0 && (
+                  <div className="mt-3 text-left">
+                    <p className="text-xs text-slate-500 mb-1">상세 정보:</p>
+                    <ul className="text-xs text-slate-600 list-disc list-inside space-y-1">
+                      {validationErrors.map((err, idx) => (
+                        <li key={idx}>{err}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {process.env.NODE_ENV === "development" && requestId && (
+                  <p className="text-slate-400 text-xs mt-2">
+                    Request ID: {requestId}
+                  </p>
+                )}
+              </div>
+              <div className="flex gap-4 justify-center">
+                <button
+                  className="px-6 py-2 bg-teal-500 text-white rounded-lg hover:bg-teal-600 transition font-bold cursor-pointer"
+                  onClick={() => router.back()}
+                >
+                  이전으로
+                </button>
+                <button
+                  className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition cursor-pointer"
+                  onClick={() => router.push("/")}
+                >
+                  홈으로 돌아가기
+                </button>
               </div>
             </div>
-            <div className="space-y-2">
-              <h2 className="text-2xl font-semibold text-slate-900">
-                요청을 처리할 수 없습니다
-              </h2>
-              <p className="text-slate-600 text-lg">{userMessage}</p>
-              {validationErrors && validationErrors.length > 0 && (
-                <div className="mt-3 text-left">
-                  <p className="text-xs text-slate-500 mb-1">상세 정보:</p>
-                  <ul className="text-xs text-slate-600 list-disc list-inside space-y-1">
-                    {validationErrors.map((err, idx) => (
-                      <li key={idx}>{err}</li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              {process.env.NODE_ENV === "development" && requestId && (
-                <p className="text-slate-400 text-xs mt-2">
-                  Request ID: {requestId}
-                </p>
-              )}
-            </div>
-            <div className="flex gap-4 justify-center">
-              <button
-                className="px-6 py-2 bg-teal-500 text-white rounded-lg hover:bg-teal-600 transition font-bold cursor-pointer"
-                onClick={() => router.back()}
-              >
-                이전으로
-              </button>
-              <button
-                className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition cursor-pointer"
-                onClick={() => router.push("/")}
-              >
-                홈으로 돌아가기
-              </button>
-            </div>
           </div>
-        </div>
+        </>
       );
     }
   }
 
   // 예상치 못한 에러
   return (
-    <div className="flex flex-col items-center justify-center min-h-[90vh] gap-6 px-4">
-      <div className="p-8 w-full text-center space-y-6">
-        <div className="flex justify-center">
-          <div className="w-25 h-25 bg-red-50 rounded-full flex items-center justify-center">
-            <AlertCircle className="w-15 h-15 text-red-500" />
+    <>
+      <StaticHeader />
+      <div className="flex flex-col items-center justify-center flex-1 w-full gap-6 px-4">
+        <div className="p-8 w-full text-center space-y-6">
+          <div className="flex justify-center">
+            <div className="w-25 h-25 bg-red-50 rounded-full flex items-center justify-center">
+              <AlertCircle className="w-15 h-15 text-red-500" />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <h2 className="text-2xl font-semibold text-slate-900">
+              문제가 발생했습니다
+            </h2>
+            <p className="text-slate-600 text-lg">
+              예상치 못한 오류가 발생했습니다. 잠시 후 다시 시도해주세요.
+            </p>
+            {process.env.NODE_ENV === "development" && (
+              <details className="mt-4 text-left">
+                <summary className="cursor-pointer text-xs text-slate-500 hover:text-slate-700">
+                  개발자 정보
+                </summary>
+                <pre className="mt-2 text-xs text-slate-700 bg-slate-50 p-2 rounded overflow-auto">
+                  {error.message}
+                  {error.stack && `\n\n${error.stack}`}
+                </pre>
+              </details>
+            )}
+          </div>
+          <div className="flex gap-4 justify-center">
+            <button
+              className="px-6 py-2 bg-teal-500 text-white rounded-lg hover:bg-teal-600 transition font-bold flex items-center gap-2 cursor-pointer"
+              onClick={reset}
+            >
+              <RefreshCcw className="w-4 h-4" />
+              다시 시도
+            </button>
+            <button
+              className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition cursor-pointer"
+              onClick={() => router.push("/")}
+            >
+              홈으로 돌아가기
+            </button>
           </div>
         </div>
-        <div className="space-y-2">
-          <h2 className="text-2xl font-semibold text-slate-900">
-            문제가 발생했습니다
-          </h2>
-          <p className="text-slate-600 text-lg">
-            예상치 못한 오류가 발생했습니다. 잠시 후 다시 시도해주세요.
-          </p>
-          {process.env.NODE_ENV === "development" && (
-            <details className="mt-4 text-left">
-              <summary className="cursor-pointer text-xs text-slate-500 hover:text-slate-700">
-                개발자 정보
-              </summary>
-              <pre className="mt-2 text-xs text-slate-700 bg-slate-50 p-2 rounded overflow-auto">
-                {error.message}
-                {error.stack && `\n\n${error.stack}`}
-              </pre>
-            </details>
-          )}
-        </div>
-        <div className="flex gap-4 justify-center">
-          <button
-            className="px-6 py-2 bg-teal-500 text-white rounded-lg hover:bg-teal-600 transition font-bold flex items-center gap-2 cursor-pointer"
-            onClick={reset}
-          >
-            <RefreshCcw className="w-4 h-4" />
-            다시 시도
-          </button>
-          <button
-            className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition cursor-pointer"
-            onClick={() => router.push("/")}
-          >
-            홈으로 돌아가기
-          </button>
-        </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -26,7 +26,7 @@ function RootLayout({ children }: Readonly<RootLayoutProps>) {
       <body
         className={cn(
           pretendard.className,
-          "antialiased bg-slate-50 w-full flex flex-col items-center overflow-x-hidden",
+          "antialiased bg-slate-50 w-full flex flex-col items-center overflow-x-hidden min-h-screen",
         )}
       >
         {children}

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,34 +1,36 @@
-"use client";
-
 import { TriangleAlert } from "lucide-react";
 import Link from "next/link";
+import Header from "@/components/header/header";
 
 function NotFound() {
   return (
-    <div className="flex flex-col items-center justify-center min-h-[90vh] gap-6 px-4">
-      <div className="p-8 w-full text-center space-y-6">
-        <h1 className="flex items-center justify-center gap-3 text-6xl font-bold text-gray-300">
-          <TriangleAlert size={64} />
-          404
-        </h1>
-        <div className="space-y-2">
-          <h2 className="text-2xl font-semibold text-slate-900">
-            페이지를 찾을 수 없습니다
-          </h2>
-          <p className="text-slate-600 text-lg">
-            요청하신 페이지가 존재하지 않습니다. URL을 다시 확인해주세요.
-          </p>
+    <>
+      <Header />
+      <main className="flex flex-col items-center justify-center flex-1 w-full gap-6 px-4">
+        <div className="p-8 w-full text-center space-y-6">
+          <h1 className="flex items-center justify-center gap-3 text-6xl font-bold text-gray-300">
+            <TriangleAlert size={64} />
+            404
+          </h1>
+          <div className="space-y-2">
+            <h2 className="text-2xl font-semibold text-slate-900">
+              페이지를 찾을 수 없습니다
+            </h2>
+            <p className="text-slate-600 text-lg">
+              요청하신 페이지가 존재하지 않습니다. URL을 다시 확인해주세요.
+            </p>
+          </div>
+          <div className="flex gap-4 justify-center">
+            <Link
+              href="/"
+              className="px-6 py-2 bg-teal-500 text-white rounded-lg hover:bg-teal-600 transition font-bold cursor-pointer"
+            >
+              홈으로 돌아가기
+            </Link>
+          </div>
         </div>
-        <div className="flex gap-4 justify-center">
-          <Link
-            href="/"
-            className="px-6 py-2 bg-teal-500 text-white rounded-lg hover:bg-teal-600 transition font-bold cursor-pointer"
-          >
-            홈으로 돌아가기
-          </Link>
-        </div>
-      </div>
-    </div>
+      </main>
+    </>
   );
 }
 

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,11 +1,11 @@
 import { TriangleAlert } from "lucide-react";
 import Link from "next/link";
-import Header from "@/components/header/header";
+import StaticHeader from "@/components/header/static-header";
 
 function NotFound() {
   return (
     <>
-      <Header />
+      <StaticHeader />
       <main className="flex flex-col items-center justify-center flex-1 w-full gap-6 px-4">
         <div className="p-8 w-full text-center space-y-6">
           <h1 className="flex items-center justify-center gap-3 text-6xl font-bold text-gray-300">

--- a/apps/web/src/app/reports/[questionId]/not-found.tsx
+++ b/apps/web/src/app/reports/[questionId]/not-found.tsx
@@ -1,61 +1,45 @@
-"use client";
-
-import { logger } from "@/lib/sentry-logger";
 import { TriangleAlert } from "lucide-react";
 import Link from "next/link";
-import { useParams, usePathname, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import Header from "@/components/header/header";
+import { NotFoundLogger } from "@/app/_components/not-found-logger";
 
-function NotFound() {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const params = useParams();
-
-  useEffect(() => {
-    const context = {
-      pathname,
-      questionId: params?.questionId,
-      attempt: searchParams?.get("attempt"),
-      fullUrl: `${pathname}${searchParams?.toString() ? `?${searchParams.toString()}` : ""}`,
-    };
-
-    if (process.env.NODE_ENV === "production") {
-      logger.warn("404 Not Found - Report Page", context);
-    }
-  }, [pathname, searchParams, params]);
-
+async function NotFound() {
   return (
-    <div className="flex flex-col items-center justify-center min-h-[90vh] gap-6 px-4">
-      <div className="p-8 w-full text-center space-y-6">
-        <h1 className="flex items-center justify-center gap-3 text-6xl font-bold text-gray-300">
-          <TriangleAlert size={64} />
-          404
-        </h1>
-        <div className="space-y-2">
-          <h2 className="text-2xl font-semibold text-slate-900">
-            요청하신 리포트를 찾을 수 없습니다
-          </h2>
-          <p className="text-slate-600 text-lg">
-            존재하지 않는 문제이거나, 유효하지 않은 제출 기록입니다. URL을 다시
-            확인해 주세요.
-          </p>
+    <>
+      <NotFoundLogger pageName="Report Page" />
+      <Header />
+      <main className="flex flex-col items-center justify-center flex-1 w-full gap-6 px-4">
+        <div className="p-8 w-full text-center space-y-6">
+          <h1 className="flex items-center justify-center gap-3 text-6xl font-bold text-gray-300">
+            <TriangleAlert size={64} />
+            404
+          </h1>
+          <div className="space-y-2">
+            <h2 className="text-2xl font-semibold text-slate-900">
+              요청하신 리포트를 찾을 수 없습니다
+            </h2>
+            <p className="text-slate-600 text-lg">
+              존재하지 않는 문제이거나, 유효하지 않은 제출 기록입니다. URL을
+              다시 확인해 주세요.
+            </p>
+          </div>
+          <div className="flex gap-4 justify-center">
+            <Link
+              href="/daily/questions"
+              className="px-6 py-2 bg-teal-500 text-white rounded-lg hover:bg-teal-600 transition font-bold cursor-pointer"
+            >
+              문제 목록으로 가기
+            </Link>
+            <Link
+              href="/"
+              className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition cursor-pointer"
+            >
+              홈으로 돌아가기
+            </Link>
+          </div>
         </div>
-        <div className="flex gap-4 justify-center">
-          <Link
-            href="/daily/questions"
-            className="px-6 py-2 bg-teal-500 text-white rounded-lg hover:bg-teal-600 transition font-bold cursor-pointer"
-          >
-            문제 목록으로 가기
-          </Link>
-          <Link
-            href="/"
-            className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition cursor-pointer"
-          >
-            홈으로 돌아가기
-          </Link>
-        </div>
-      </div>
-    </div>
+      </main>
+    </>
   );
 }
 

--- a/apps/web/src/app/reports/[questionId]/not-found.tsx
+++ b/apps/web/src/app/reports/[questionId]/not-found.tsx
@@ -1,13 +1,13 @@
 import { TriangleAlert } from "lucide-react";
 import Link from "next/link";
-import Header from "@/components/header/header";
+import StaticHeader from "@/components/header/header";
 import { NotFoundLogger } from "@/app/_components/not-found-logger";
 
 async function NotFound() {
   return (
     <>
       <NotFoundLogger pageName="Report Page" />
-      <Header />
+      <StaticHeader />
       <main className="flex flex-col items-center justify-center flex-1 w-full gap-6 px-4">
         <div className="p-8 w-full text-center space-y-6">
           <h1 className="flex items-center justify-center gap-3 text-6xl font-bold text-gray-300">

--- a/apps/web/src/app/reports/[questionId]/not-found.tsx
+++ b/apps/web/src/app/reports/[questionId]/not-found.tsx
@@ -1,6 +1,6 @@
 import { TriangleAlert } from "lucide-react";
 import Link from "next/link";
-import StaticHeader from "@/components/header/header";
+import StaticHeader from "@/components/header/static-header";
 import { NotFoundLogger } from "@/app/_components/not-found-logger";
 
 async function NotFound() {

--- a/apps/web/src/components/footer/footer.tsx
+++ b/apps/web/src/components/footer/footer.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 
 async function Footer() {
   return (
-    <div className="w-full bg-white flex flex-col justify-center items-center h-60 gap-6 border-t border-slate-200">
+    <div className="w-full bg-white flex flex-col justify-center items-center h-50 gap-6 border-t border-slate-200">
       <div className="flex flex-col">
         <div className="flex gap-2 items-center">
           <Image width={32} height={32} src={"/mmh-logo.svg"} alt="logo" />

--- a/apps/web/src/components/header/static-header.tsx
+++ b/apps/web/src/components/header/static-header.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+
+function StaticHeader() {
+  return (
+    <header className="sticky top-0 z-40 w-full h-16 flex justify-center items-center bg-white border-slate-200 border-b">
+      <div className="w-full h-full max-w-5xl px-4 md:px-8 flex justify-between items-center">
+        <Link href={"/"} className="flex gap-2 items-center">
+          <Image
+            width={32}
+            height={32}
+            src={"/mmh-logo.svg"}
+            alt="말만해 로고"
+          />
+          <div className="font-bold text-xl text-slate-700">말만해</div>
+        </Link>
+      </div>
+    </header>
+  );
+}
+
+export default StaticHeader;


### PR DESCRIPTION
## 🔸 작업 내용

- layout에서 body의 최소 높이 설정을 추가 했습니다.
- error.tsx와 not-found.tsx에 빠진 헤더를 추가했습니다.
- not-found 페이지를 서버 컴포넌트로 수정했습니다.

## 🔸 고민 했던 부분

- 기존 헤더를 사용하고 싶었으나 error.tsx에서는 서버 컴포넌트 사용을 할 수 없어서 로고만 있는 헤더를 추가로 만들었습니다.

## 🔸 참고
- 기존
<img width="1918" height="905" alt="image" src="https://github.com/user-attachments/assets/c3257817-1195-4c3c-8b60-6adf8efbd259" />


- 수정 후
  - 스크롤도 생기지 않도록 수정했습니다.
<img width="1876" height="885" alt="image" src="https://github.com/user-attachments/assets/67b42fdd-2b46-4b56-8d17-6607b5609f25" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 모든 에러/404 화면에 일관된 상단 헤더 추가
  * 404 접근 이벤트 로깅 컴포넌트 도입
  * 인증/네트워크/서버/클라이언트 에러 UI 개선(명확한 메시지, 동작 버튼, 인증용 로그인 유도)
  * 개발 환경에서 상세한 오류 정보 노출 강화

* **Style**
  * 푸터 높이 조정(기존보다 축소)
  * 전체 레이아웃에 최소 화면 높이 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->