### PR TITLE
작은 높이 넓은 너비에서 랜딩 페이지의 로고가 잘리는 문제 해결

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -19,11 +19,11 @@ async function Home() {
   return (
     <>
       <Header />
-      <main className="w-full h-full flex flex-col bg-white overflow-x-hidden">
+      <main className="w-full flex flex-col bg-white overflow-x-hidden">
         <section className="w-full min-h-[calc(100svh-64px)] relative flex justify-center items-center overflow-hidden">
           <div
             className={cn(
-              "flex flex-col justify-center items-center z-10 w-full px-4 lg:px-0 py-8 md:py-16",
+              "flex flex-col justify-center items-center z-10 w-full px-4 lg:px-0 pb-8 md:pb-16 pt-20 md:pt-36",
               "pointer-events-none",
             )}
           >


### PR DESCRIPTION
## 🔸 작업 내용

- 작은 높이 넓은 너비의 화면에서 랜딩 페이지의 로고가 짤려보이는 문제 해결



https://github.com/user-attachments/assets/0db7b1eb-c8cd-4328-b7a9-0624377e5650




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 메인 컨테이너의 고정 높이 제약을 제거하여 콘텐츠 기반의 높이 결정 방식으로 변경
  * 반응형 화면 크기에 맞춘 상단 및 하단 여백 조정으로 개선된 페이지 레이아웃 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->