### PR TITLE
모바일 환경에서의 그래프뷰 개선

### DIFF
--- a/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
+++ b/apps/web/src/app/mypage/_components/graph-view/graph-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCanvas2D } from "@/hooks/use-canvas-2d";
 import useAnimationFrame from "@/hooks/use-animation-frame";
+import { useCanvas2D } from "@/hooks/use-canvas-2d";
 import * as React from "react";
 import { GraphData } from "../../_types/graph-view";
 import useGraphRenderer from "./use-graph-renderer";
@@ -74,7 +74,7 @@ function GraphView({
   return (
     <canvas
       ref={canvasRef}
-      className="w-full h-full"
+      className="w-full h-full touch-none"
       role="img"
       aria-label={`지식 그래프: ${graphData.nodes.length}개의 질문, ${graphData.edges.length}개의 연결`}
       {...bindEvents}

--- a/apps/web/src/app/mypage/_components/graph-view/use-graph-renderer.ts
+++ b/apps/web/src/app/mypage/_components/graph-view/use-graph-renderer.ts
@@ -1,7 +1,9 @@
 import * as React from "react";
 import { GRAPH_NUMBER_CONSTANT } from "../../_constants/graph-view-constant";
 import { addRandomEdgeDistance } from "../../_lib/graph-view/add-random-edge-distance";
-import drawGraphView from "../../_lib/graph-view/draw-graph-view";
+import drawGraphView, {
+  type GraphHighlightSets,
+} from "../../_lib/graph-view/draw-graph-view";
 import {
   GraphData,
   GraphEdge,
@@ -43,6 +45,8 @@ export interface UseGraphRendererOptions {
   initialScale?: number; // scale의 초기값만 저장
   scale?: number; // 외부에서 scale 조정할 때 사용
   onScaleChange?: (scale: number) => void;
+  /** 제출에서 추가된 노드·엣지 하이라이트용 (리포트 탭 등) */
+  highlight?: GraphHighlightSets | null;
 }
 
 export interface GraphRendererReturn {
@@ -76,6 +80,7 @@ function useGraphRenderer({
   initialScale = 0.5,
   scale: externalScale,
   onScaleChange,
+  highlight = null,
 }: UseGraphRendererOptions): GraphRendererReturn {
   // 엣지에 랜덤 거리 적용 (한 번만 계산)
   const processedEdges = React.useMemo(
@@ -101,6 +106,24 @@ function useGraphRenderer({
 
   // NodeMap 관리
   const nodeMapRef = React.useRef<NodeMap | null>(externalNodeMap || null);
+
+  // 그래프 데이터가 바뀌면 NodeMap 무효화 (다른 시도 선택 시 등)
+  const graphKey = React.useMemo(() => {
+    const nodeKey = graphData.nodes
+      .map((n) => n.id)
+      .sort((a, b) => a - b)
+      .join(",");
+    const edgeKey = graphData.edges
+      .map((e) => e.id)
+      .sort((a, b) => a - b)
+      .join(",");
+    return `${nodeKey}|${edgeKey}`;
+  }, [graphData.nodes, graphData.edges]);
+
+  // graphKey가 변경되면 NodeMap 초기화 (새 그래프로 재시작)
+  React.useEffect(() => {
+    nodeMapRef.current = null;
+  }, [graphKey]);
 
   // NodeMap 변경 콜백 throttle 용
   const shouldNotify = React.useRef(true);
@@ -504,6 +527,7 @@ function useGraphRenderer({
         hoveredNodeId.current,
         textRenderScale,
         showLabels,
+        highlight,
       );
 
       // NodeMap 변경 콜백 (throttle 처리 - 100ms 마다)
@@ -525,6 +549,7 @@ function useGraphRenderer({
       textRenderScale,
       showLabels,
       onNodeMapChange,
+      highlight,
     ],
   );
 

--- a/apps/web/src/app/mypage/_components/graph-view/use-graph-renderer.ts
+++ b/apps/web/src/app/mypage/_components/graph-view/use-graph-renderer.ts
@@ -128,14 +128,6 @@ function useGraphRenderer({
   // NodeMap 변경 콜백 throttle 용
   const shouldNotify = React.useRef(true);
 
-  // 모바일 환경에서 캔버스 터치시 스크롤 동작을 멈추기
-  React.useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-
-    canvas.style.touchAction = "none";
-  }, [canvasRef]);
-
   // NodeMap 초기화 및 물리엔진 미리 동작
   React.useEffect(() => {
     const width = getWidth();

--- a/apps/web/src/app/mypage/_components/graph-view/use-graph-renderer.ts
+++ b/apps/web/src/app/mypage/_components/graph-view/use-graph-renderer.ts
@@ -1,9 +1,7 @@
 import * as React from "react";
 import { GRAPH_NUMBER_CONSTANT } from "../../_constants/graph-view-constant";
 import { addRandomEdgeDistance } from "../../_lib/graph-view/add-random-edge-distance";
-import drawGraphView, {
-  type GraphHighlightSets,
-} from "../../_lib/graph-view/draw-graph-view";
+import drawGraphView from "../../_lib/graph-view/draw-graph-view";
 import {
   GraphData,
   GraphEdge,
@@ -45,8 +43,6 @@ export interface UseGraphRendererOptions {
   initialScale?: number; // scale의 초기값만 저장
   scale?: number; // 외부에서 scale 조정할 때 사용
   onScaleChange?: (scale: number) => void;
-  /** 제출에서 추가된 노드·엣지 하이라이트용 (리포트 탭 등) */
-  highlight?: GraphHighlightSets | null;
 }
 
 export interface GraphRendererReturn {
@@ -55,6 +51,9 @@ export interface GraphRendererReturn {
     onMouseMove: (e: React.MouseEvent<HTMLCanvasElement>) => void;
     onMouseUp: (e: React.MouseEvent<HTMLCanvasElement>) => void;
     onMouseLeave: (e: React.MouseEvent<HTMLCanvasElement>) => void;
+    onTouchStart: (e: React.TouchEvent<HTMLCanvasElement>) => void;
+    onTouchMove: (e: React.TouchEvent<HTMLCanvasElement>) => void;
+    onTouchEnd: (e: React.TouchEvent<HTMLCanvasElement>) => void;
   };
   bindWheelEvent: () => () => void;
   drawGraph: (deltaTime: number) => void;
@@ -77,7 +76,6 @@ function useGraphRenderer({
   initialScale = 0.5,
   scale: externalScale,
   onScaleChange,
-  highlight = null,
 }: UseGraphRendererOptions): GraphRendererReturn {
   // 엣지에 랜덤 거리 적용 (한 번만 계산)
   const processedEdges = React.useMemo(
@@ -97,29 +95,23 @@ function useGraphRenderer({
   const dragStart = React.useRef({ x: 0, y: 0 });
   const hoveredNodeId = React.useRef<number | null>(null);
 
+  // 터치 인터랙션 상태
+  const lastTouchDistance = React.useRef<number | null>(null);
+  const touchStartNodeId = React.useRef<number | null>(null);
+
   // NodeMap 관리
   const nodeMapRef = React.useRef<NodeMap | null>(externalNodeMap || null);
 
-  // 그래프 데이터가 바뀌면 NodeMap 무효화 (다른 시도 선택 시 등)
-  const graphKey = React.useMemo(() => {
-    const nodeKey = graphData.nodes
-      .map((n) => n.id)
-      .sort((a, b) => a - b)
-      .join(",");
-    const edgeKey = graphData.edges
-      .map((e) => e.id)
-      .sort((a, b) => a - b)
-      .join(",");
-    return `${nodeKey}|${edgeKey}`;
-  }, [graphData.nodes, graphData.edges]);
-
-  // graphKey가 변경되면 NodeMap 초기화 (새 그래프로 재시작)
-  React.useEffect(() => {
-    nodeMapRef.current = null;
-  }, [graphKey]);
-
   // NodeMap 변경 콜백 throttle 용
   const shouldNotify = React.useRef(true);
+
+  // 모바일 환경에서 캔버스 터치시 스크롤 동작을 멈추기
+  React.useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    canvas.style.touchAction = "none";
+  }, [canvasRef]);
 
   // NodeMap 초기화 및 물리엔진 미리 동작
   React.useEffect(() => {
@@ -304,6 +296,149 @@ function useGraphRenderer({
     [onScaleChange],
   );
 
+  // 두 터치 포인트 간 거리 계산
+  const getTouchDistance = (touches: React.TouchList): number => {
+    const dx = touches[0].clientX - touches[1].clientX;
+    const dy = touches[0].clientY - touches[1].clientY;
+    return Math.sqrt(dx * dx + dy * dy);
+  };
+
+  // 두 터치 포인트의 중점 계산
+  const getTouchCenter = (
+    touches: React.TouchList,
+  ): { x: number; y: number } => {
+    return {
+      x: (touches[0].clientX + touches[1].clientX) / 2,
+      y: (touches[0].clientY + touches[1].clientY) / 2,
+    };
+  };
+
+  // 터치 시작 핸들러
+  const handleTouchStart = React.useCallback(
+    (e: React.TouchEvent<HTMLCanvasElement>) => {
+      e.preventDefault();
+
+      if (e.touches.length === 1) {
+        // 단일 터치: 마우스 다운과 동일
+        const touch = e.touches[0];
+        dragStart.current = { x: touch.clientX, y: touch.clientY };
+
+        const { x, y } = convertCursorToCanvasCoords(
+          touch.clientX,
+          touch.clientY,
+        );
+        const clickedNode = findNodeAtPosition(x, y);
+
+        if (clickedNode) {
+          draggedNodeId.current = clickedNode.id;
+          touchStartNodeId.current = clickedNode.id;
+          nodeMapRef.current?.setNodeFixedCoords(clickedNode.id, x, y);
+        } else {
+          isDraggingCanvas.current = true;
+        }
+      } else if (e.touches.length === 2) {
+        // 핀치 줌 시작
+        lastTouchDistance.current = getTouchDistance(e.touches);
+
+        // 노드 드래그 중이었으면 종료
+        if (draggedNodeId.current !== null) {
+          nodeMapRef.current?.clearNodeFixedCoords(draggedNodeId.current);
+          draggedNodeId.current = null;
+        }
+        isDraggingCanvas.current = false;
+      }
+    },
+    [convertCursorToCanvasCoords, findNodeAtPosition],
+  );
+
+  // 터치 이동 핸들러
+  const handleTouchMove = React.useCallback(
+    (e: React.TouchEvent<HTMLCanvasElement>) => {
+      e.preventDefault();
+
+      if (e.touches.length === 1) {
+        // 단일 터치: 마우스 무브와 동일
+        const touch = e.touches[0];
+        const { x, y } = convertCursorToCanvasCoords(
+          touch.clientX,
+          touch.clientY,
+        );
+
+        if (draggedNodeId.current !== null) {
+          nodeMapRef.current?.setNodeFixedCoords(draggedNodeId.current, x, y);
+        } else if (isDraggingCanvas.current) {
+          const dx = touch.clientX - dragStart.current.x;
+          const dy = touch.clientY - dragStart.current.y;
+
+          offset.current.x += dx;
+          offset.current.y += dy;
+
+          dragStart.current = { x: touch.clientX, y: touch.clientY };
+        }
+      } else if (e.touches.length === 2) {
+        // 핀치 줌(터치스크린으로 확대/축소 동작) 처리
+        const currentDistance = getTouchDistance(e.touches);
+        if (lastTouchDistance.current !== null) {
+          const distanceRatio = currentDistance / lastTouchDistance.current;
+          const scaleAmount = (distanceRatio - 1) * scale.current;
+
+          const center = getTouchCenter(e.touches);
+          const canvas = canvasRef.current;
+          if (canvas) {
+            const rect = canvas.getBoundingClientRect();
+            handleZoom(center.x - rect.left, center.y - rect.top, scaleAmount);
+          }
+        }
+        lastTouchDistance.current = currentDistance;
+      }
+    },
+    [convertCursorToCanvasCoords, handleZoom, canvasRef],
+  );
+
+  // 터치 종료 핸들러
+  const handleTouchEnd = React.useCallback(
+    (e: React.TouchEvent<HTMLCanvasElement>) => {
+      e.preventDefault();
+
+      // 클릭 이벤트 처리 (단일 터치로 노드를 탭한 경우)
+      if (
+        e.touches.length === 0 &&
+        e.changedTouches.length === 1 &&
+        touchStartNodeId.current !== null &&
+        draggedNodeId.current !== null
+      ) {
+        const touch = e.changedTouches[0];
+
+        const dx = touch.clientX - dragStart.current.x;
+        const dy = touch.clientY - dragStart.current.y;
+
+        // 노드 드래그하여 이동한 거리 5px 미만이면 터치로 처리
+        const distance = Math.sqrt(dx * dx + dy * dy);
+
+        if (distance < 5 && onClickNode) {
+          const questionId = nodeMapRef.current?.getNode(
+            touchStartNodeId.current,
+          )?.questionId;
+          if (questionId) {
+            onClickNode(questionId);
+          }
+        }
+      }
+
+      // 모든 터치가 종료되면 상태 초기화
+      if (e.touches.length === 0) {
+        if (draggedNodeId.current !== null) {
+          nodeMapRef.current?.clearNodeFixedCoords(draggedNodeId.current);
+        }
+        draggedNodeId.current = null;
+        touchStartNodeId.current = null;
+        isDraggingCanvas.current = false;
+        lastTouchDistance.current = null;
+      }
+    },
+    [onClickNode],
+  );
+
   // 휠 이벤트 바인딩
   const bindWheelEvent = React.useCallback(() => {
     const canvas = canvasRef.current;
@@ -369,7 +504,6 @@ function useGraphRenderer({
         hoveredNodeId.current,
         textRenderScale,
         showLabels,
-        highlight,
       );
 
       // NodeMap 변경 콜백 (throttle 처리 - 100ms 마다)
@@ -391,7 +525,6 @@ function useGraphRenderer({
       textRenderScale,
       showLabels,
       onNodeMapChange,
-      highlight,
     ],
   );
 
@@ -401,8 +534,18 @@ function useGraphRenderer({
       onMouseMove: handleMouseMove,
       onMouseUp: handleMouseUp,
       onMouseLeave: handleMouseUp,
+      onTouchStart: handleTouchStart,
+      onTouchMove: handleTouchMove,
+      onTouchEnd: handleTouchEnd,
     }),
-    [handleMouseDown, handleMouseMove, handleMouseUp],
+    [
+      handleMouseDown,
+      handleMouseMove,
+      handleMouseUp,
+      handleTouchStart,
+      handleTouchMove,
+      handleTouchEnd,
+    ],
   );
 
   return {

--- a/apps/web/src/app/mypage/_contents/graph-content.tsx
+++ b/apps/web/src/app/mypage/_contents/graph-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/button/button";
-import { BarChart3, Expand } from "lucide-react";
+import { BarChart3, Expand, XIcon } from "lucide-react";
 import * as React from "react";
 import GraphView from "../_components/graph-view/graph-view";
 import ScaleSlider from "../_components/graph-view/scale-slider";
@@ -63,7 +63,16 @@ function GraphContent({ graphData }: { graphData: GraphData }) {
             onClick={(e) => e.stopPropagation()}
             className="bg-white rounded-xl md:rounded-2xl w-full h-full max-w-5xl max-h-[90vh] md:max-h-5/6 shadow-xl overflow-hidden relative"
           >
-            <div className="absolute right-4 top-4 z-10">
+            <div className="absolute right-4 top-4 z-10 flex flex-col items-center gap-5 ">
+              <Button
+                onClick={handleModalToggle}
+                size="icon"
+                variant="outline"
+                aria-label="그래프 모달 제거"
+                className="md:hidden"
+              >
+                <XIcon className="text-muted-foreground" />
+              </Button>
               <ScaleSlider scale={scale} onScaleChange={setScale} />
             </div>
             <div className="w-full h-full">


### PR DESCRIPTION
## 🔸 작업 내용

- 모바일 환경에서 모달 닫기 버튼 추가
- 핀치줌과 터치 이벤트 추가

## 🔸 고민 했던 부분

### useGraphRenderer가 너무 커지는 문제
- useGraphRenderer에서 모바일 환경을 위한 인터렉션까지 추가되면서 코드의 길이 자체가 많이 길어짐을 느꼈습니다.
- graph interaction과 관련된 부분을 따로 빼서 관리를할지 지금 상태에서 모바일 인터렉션을 추가할지에 대한 고민을 하였습니다.
- 현재 훅에서 상당수의 부분이 인터렉션과 관련된 내용이기 때문에 역할 분리를 하더라도 크게 개선점이 보이지 않을 것이라 판단해서 현재 구조를 유지하면서 모바일 인터렉션 이벤트만 추가하였습니다.

## 🔸 참고
### 핀치줌을 포함한 모바일 환경에서의 인터렉션 적용
https://github.com/user-attachments/assets/bc38e04c-46b0-4b88-abcd-7dc449ef0427

### 모바일 환경에서 모달 닫기 버튼 활성화
https://github.com/user-attachments/assets/d0d148fb-802f-4ae8-8609-c41d8cd20df3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 그래프 뷰에 터치 상호작용 추가: 한 손가락 드래그(노드 이동/팬) 및 두 손가락 핀치로 확대/축소 지원.
  * 모바일에서 그래프 모달을 닫을 수 있는 전용 닫기 버튼(모바일 전용)이 추가되고 헤더 UI가 세로로 정렬됨.

* **접근성**
  * 닫기 버튼에 명시적 aria-label이 추가되어 스크린리더 접근성이 향상됨.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->