### PR TITLE
refactor: reports 관련 공통 타입 packages/types로 관리하도록 수정

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,68 @@
+# Dependencies
+node_modules
+**/node_modules
+
+# Build outputs
+dist
+**/dist
+.next
+**/.next
+build
+**/build
+out
+**/out
+storybook-static
+**/storybook-static
+
+# Development files
+.git
+.gitignore
+.env
+.env.*
+!.env.example
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+loki-data
+logs
+
+# Test coverage
+coverage
+**/.coverage
+.nyc_output
+
+# Temp files
+*.tmp
+*.temp
+.cache
+
+# Docker
+Dockerfile
+docker-compose*.yaml
+.dockerignore
+
+# CI/CD
+.github
+
+# Documentation
+*.md
+!README.md
+
+# Misc
+.turbo
+.claude

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -35,6 +35,10 @@ ENV NODE_ENV=production
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/apps/api/node_modules ./apps/api/node_modules
 
+# packages/types 빌드 결과물
+COPY --from=builder /app/packages/types/dist ./packages/types/dist
+COPY --from=builder /app/packages/types/package.json ./packages/types/package.json
+
 # 빌드 결과값
 COPY --from=builder /app/apps/api/dist ./apps/api/dist
 COPY --from=builder /app/apps/api/package.json ./apps/api/package.json
@@ -42,5 +46,5 @@ COPY --from=builder /app/apps/api/package.json ./apps/api/package.json
 EXPOSE 8000
 
 # 애플리케이션 실행
-CMD ["node", "apps/api/dist/src/main"]
+CMD ["node", "apps/api/dist/apps/api/src/main.js"]
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -106,7 +106,8 @@
     "coverageDirectory": "../coverage",
     "testEnvironment": "node",
     "moduleNameMapper": {
-      "^src/(.*)$": "<rootDir>/$1"
+      "^src/(.*)$": "<rootDir>/$1",
+      "^@repo/types$": "<rootDir>/../../../packages/types/src/index.ts"
     }
   }
 }

--- a/apps/api/src/answer-evaluation/answer-evaluation.constants.ts
+++ b/apps/api/src/answer-evaluation/answer-evaluation.constants.ts
@@ -1,36 +1,7 @@
-export const CoreConceptEval = {
-  CORRECT: 'CORRECT', // 개념 자체가 정확
-  MINOR_ERROR: 'MINOR_ERROR', // 용어 혼동, 작은 실수
-  WRONG: 'WRONG', // 개념 자체가 틀림
-} as const;
-export type CoreConceptEval =
-  (typeof CoreConceptEval)[keyof typeof CoreConceptEval];
-
-export const CoverageEval = {
-  COMPLETE: 'COMPLETE', // 모범답안의 주요 포인트 대부분 언급
-  ADEQUATE: 'ADEQUATE', // 핵심만 언급
-  MINIMAL: 'MINIMAL', // 최소한만
-} as const;
-export type CoverageEval = (typeof CoverageEval)[keyof typeof CoverageEval];
-
-export const LogicEval = {
-  CLEAR: 'CLEAR',
-  WEAK: 'WEAK',
-  NONE: 'NONE',
-} as const;
-export type LogicEval = (typeof LogicEval)[keyof typeof LogicEval];
-
-export const DepthEval = {
-  ADVANCED: 'ADVANCED', // 원리/이유/비교/적용 중 2개 이상
-  BASIC: 'BASIC', // 정의 + 하나의 요소
-  NONE: 'NONE', // 정의만
-} as const;
-export type DepthEval = (typeof DepthEval)[keyof typeof DepthEval];
-
-export const EvaluationStatus = {
-  COMPLETED: 'COMPLETED',
-  PENDING: 'PENDING',
-  FAILED: 'FAILED',
-} as const;
-export type EvaluationStatus =
-  (typeof EvaluationStatus)[keyof typeof EvaluationStatus];
+export {
+  CoreConceptEval,
+  CoverageEval,
+  LogicEval,
+  DepthEval,
+  EvaluationStatus,
+} from '@repo/types';

--- a/apps/api/src/answer-evaluation/dtos/evaluation-response.dto.ts
+++ b/apps/api/src/answer-evaluation/dtos/evaluation-response.dto.ts
@@ -4,9 +4,11 @@ import {
   CoverageEval,
   LogicEval,
   DepthEval,
-} from '../answer-evaluation.constants';
+  ScoreDetails,
+  DetailAnalysis,
+} from '@repo/types';
 
-class ScoreDetailsDto {
+class ScoreDetailsDto implements ScoreDetails {
   @ApiProperty({ description: '핵심 개념 점수', example: 50 })
   coreConcept: number;
 
@@ -20,7 +22,7 @@ class ScoreDetailsDto {
   depth: number;
 }
 
-class DetailAnalysisDto {
+class DetailAnalysisDto implements DetailAnalysis {
   @ApiProperty({
     description: '핵심 개념 분석 멘트',
     example: '핵심 개념이 정확하게 이해되었습니다.',

--- a/apps/api/src/answer-evaluation/dtos/evaluation-result.dto.ts
+++ b/apps/api/src/answer-evaluation/dtos/evaluation-result.dto.ts
@@ -11,7 +11,8 @@ import {
   CoverageEval,
   DepthEval,
   LogicEval,
-} from '../answer-evaluation.constants';
+} from '@repo/types';
+import type { ScoreDetails } from '@repo/types';
 
 export class EvaluationResultDto {
   @IsEnum(CoreConceptEval)
@@ -47,12 +48,7 @@ export class EvaluationResultDto {
 
   @IsOptional()
   @IsObject()
-  scoreDetails?: {
-    coreConcept: number;
-    coverage: number;
-    logic: number;
-    depth: number;
-  };
+  scoreDetails?: ScoreDetails;
 
   @IsOptional()
   @IsNumber()

--- a/apps/api/src/answer-evaluation/entities/answer-evaluation.entity.ts
+++ b/apps/api/src/answer-evaluation/entities/answer-evaluation.entity.ts
@@ -11,7 +11,9 @@ import {
   CoverageEval,
   LogicEval,
   DepthEval,
-} from '../answer-evaluation.constants';
+  ScoreDetails,
+  DetailAnalysis,
+} from '@repo/types';
 import { AnswerSubmission } from '../../answer-submission/entities/answer-submission.entity';
 
 @Entity('answer_evaluations')
@@ -26,20 +28,10 @@ export class AnswerEvaluation {
   feedbackMessage: string | null;
 
   @Column({ name: 'detail_analysis', type: 'jsonb', nullable: true })
-  detailAnalysis: {
-    coreConcept: string;
-    coverage: string;
-    logic: string;
-    depth: string;
-  } | null;
+  detailAnalysis: DetailAnalysis | null;
 
   @Column({ name: 'score_details', type: 'jsonb', nullable: true })
-  scoreDetails: {
-    coreConcept: number;
-    coverage: number;
-    logic: number;
-    depth: number;
-  } | null;
+  scoreDetails: ScoreDetails | null;
 
   @Column({
     name: 'core_concept_eval',

--- a/apps/api/src/answer-submission/answer-submission.constants.ts
+++ b/apps/api/src/answer-submission/answer-submission.constants.ts
@@ -1,21 +1,9 @@
+import { InputType, ProcessStatus } from '@repo/types';
+
 const QuizMode = {
   DAILY: 'DAILY',
   INTERVIEW: 'INTERVIEW',
 } as const;
 type QuizMode = (typeof QuizMode)[keyof typeof QuizMode];
-
-const InputType = {
-  VOICE: 'VOICE',
-  TEXT: 'TEXT',
-} as const;
-type InputType = (typeof InputType)[keyof typeof InputType];
-
-const ProcessStatus = {
-  PENDING: 'PENDING',
-  IN_PROGRESS: 'IN_PROGRESS',
-  DONE: 'DONE',
-  FAILED: 'FAILED',
-} as const;
-type ProcessStatus = (typeof ProcessStatus)[keyof typeof ProcessStatus];
 
 export { QuizMode, InputType, ProcessStatus };

--- a/apps/api/src/answer-submission/dtos/answer-submission-response.dto.ts
+++ b/apps/api/src/answer-submission/dtos/answer-submission-response.dto.ts
@@ -1,6 +1,5 @@
-import { EvaluationStatus } from 'src/answer-evaluation/answer-evaluation.constants';
-import { InputType, ProcessStatus } from '../answer-submission.constants';
 import { ApiProperty } from '@nestjs/swagger';
+import { EvaluationStatus, InputType, ProcessStatus } from '@repo/types';
 
 export class AnswerSubmissionResponseDto {
   @ApiProperty({ description: '제출 ID', example: 1 })

--- a/apps/api/src/answer-submission/entities/answer-submission.entity.ts
+++ b/apps/api/src/answer-submission/entities/answer-submission.entity.ts
@@ -7,14 +7,10 @@ import {
   JoinColumn,
   OneToOne,
 } from 'typeorm';
-import {
-  QuizMode,
-  InputType,
-  ProcessStatus,
-} from '../answer-submission.constants';
+import { QuizMode } from '../answer-submission.constants';
+import { InputType, ProcessStatus, EvaluationStatus } from '@repo/types';
 import { Question } from '../../question/entities/question.entity';
 import { AudioAsset } from '../../uploads/entities/audio-asset.entity';
-import { EvaluationStatus } from '../../answer-evaluation/answer-evaluation.constants';
 
 @Entity('answer_submissions')
 class AnswerSubmission {

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -41,6 +41,10 @@ ENV NEXT_PUBLIC_SOCKET_URL=$NEXT_PUBLIC_SOCKET_URL
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
+# packages/types 빌드 결과물 복사
+COPY --from=builder /app/packages/types/dist ./packages/types/dist
+COPY --from=builder /app/packages/types/package.json ./packages/types/package.json
+
 # Next.js 빌드 결과물 복사
 COPY --from=builder /app/apps/web/.next/standalone ./
 COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static

--- a/apps/web/src/app/reports/[questionId]/_types/evaluation-dto.ts
+++ b/apps/web/src/app/reports/[questionId]/_types/evaluation-dto.ts
@@ -1,31 +1,9 @@
-export type CoreConceptEval = "CORRECT" | "MINOR_ERROR" | "WRONG";
-export type CoverageEval = "COMPLETE" | "ADEQUATE" | "MINIMAL";
-export type LogicEval = "CLEAR" | "WEAK" | "NONE";
-export type DepthEval = "ADVANCED" | "BASIC" | "NONE";
-
-export interface EvaluationDTO {
-  id: number;
-  submissionId: number;
-  feedbackMessage: string;
-  coreConceptEval: CoreConceptEval;
-  coverageEval: CoverageEval;
-  logicEval: LogicEval;
-  depthEval: DepthEval;
-
-  detailAnalysis: {
-    coreConcept: string;
-    coverage: string;
-    logic: string;
-    depth: string;
-  };
-
-  scoreDetails: {
-    coreConcept: number;
-    coverage: number;
-    logic: number;
-    depth: number;
-  };
-
-  extractedKeywords: string[];
-  createdAt: string;
-}
+export type {
+  CoreConceptEval,
+  CoverageEval,
+  LogicEval,
+  DepthEval,
+  EvaluationDTO,
+  ScoreDetails,
+  DetailAnalysis,
+} from "@repo/types";

--- a/apps/web/src/app/reports/[questionId]/_types/report-detail.ts
+++ b/apps/web/src/app/reports/[questionId]/_types/report-detail.ts
@@ -1,6 +1,12 @@
-export type AnalysisStatus = "COMPLETED" | "PENDING" | "FAILED";
-export type STTStatus = "PENDING" | "IN_PROGRESS" | "DONE" | "FAILED";
-export type EvaluationStatus = AnalysisStatus;
+import type {
+  EvaluationStatus,
+  STTStatus,
+  InputType,
+  ScoreDetails,
+} from "@repo/types";
+
+export type AnalysisStatus = EvaluationStatus;
+export type { STTStatus, InputType, EvaluationStatus };
 
 export interface FeedbackResult {
   feedbackMessage: string;
@@ -8,18 +14,13 @@ export interface FeedbackResult {
   coverageReason: string;
   logicReason: string;
   depthReason: string;
-  scoreDetails: {
-    coreConcept: number;
-    coverage: number;
-    logic: number;
-    depth: number;
-  };
+  scoreDetails: ScoreDetails;
   extractedKeywords: string[];
 }
 
 export interface BaseReportDetail {
   submissionId: number;
-  inputType: "VOICE" | "TEXT";
+  inputType: InputType;
   questionId: number;
   date: string;
   duration: string;

--- a/apps/web/src/app/reports/[questionId]/_types/submission-dto.ts
+++ b/apps/web/src/app/reports/[questionId]/_types/submission-dto.ts
@@ -1,17 +1,6 @@
-import { AnalysisStatus } from "./report-detail";
-
-export type STTStatus = "PENDING" | "IN_PROGRESS" | "DONE" | "FAILED";
-export type InputType = "TEXT" | "VOICE";
-
-export interface SubmissionDTO {
-  id: number;
-  questionId: number;
-  submittedAt: string;
-  duration: number;
-  answerContent: string;
-  evaluationStatus: AnalysisStatus;
-  sttStatus: STTStatus;
-  inputType: InputType;
-  totalScore: number | null;
-  audioAssetId: number | null;
-}
+export type {
+  SubmissionDTO,
+  EvaluationStatus as AnalysisStatus,
+  STTStatus,
+  InputType,
+} from "@repo/types";

--- a/infra/docker-compose.local.yaml
+++ b/infra/docker-compose.local.yaml
@@ -15,7 +15,7 @@ services:
     networks:
       - malmanhae-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/infra/docker-compose.local.yaml
+++ b/infra/docker-compose.local.yaml
@@ -6,6 +6,9 @@ services:
     env_file:
       - ../apps/api/.env
     environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-malmanhae}
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - pgdata:/var/lib/postgresql/data
@@ -25,6 +28,12 @@ services:
     restart: unless-stopped
     env_file:
       - ../apps/api/.env
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_USERNAME: ${POSTGRES_USER:-postgres}
+      DB_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      DB_NAME: ${POSTGRES_DB:-malmanhae}
     depends_on:
       db:
         condition: service_healthy
@@ -55,8 +64,8 @@ services:
     ports:
       - "3001:3000"
     environment:
-      GF_SECURITY_ADMIN_USER=${GF_SECURITY_ADMIN_USER}
-      GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD}
+      GF_SECURITY_ADMIN_USER: ${GF_SECURITY_ADMIN_USER}
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
     depends_on:
       - prometheus
     networks:
@@ -68,7 +77,8 @@ services:
     restart: unless-stopped
     ports:
       - "3100:3100"
-    command: ["-config.file=/etc/loki/local-config.yaml"]
+    command:
+      - "-config.file=/etc/loki/local-config.yaml"
     volumes:
       - ./loki-config.local.yaml:/etc/loki/local-config.yaml:ro
     networks:

--- a/packages/types/src/domains/reports.ts
+++ b/packages/types/src/domains/reports.ts
@@ -1,1 +1,93 @@
-export {};
+export const CoreConceptEval = {
+  CORRECT: "CORRECT",
+  MINOR_ERROR: "MINOR_ERROR",
+  WRONG: "WRONG",
+} as const;
+export type CoreConceptEval =
+  (typeof CoreConceptEval)[keyof typeof CoreConceptEval];
+
+export const CoverageEval = {
+  COMPLETE: "COMPLETE",
+  ADEQUATE: "ADEQUATE",
+  MINIMAL: "MINIMAL",
+} as const;
+export type CoverageEval = (typeof CoverageEval)[keyof typeof CoverageEval];
+
+export const LogicEval = {
+  CLEAR: "CLEAR",
+  WEAK: "WEAK",
+  NONE: "NONE",
+} as const;
+export type LogicEval = (typeof LogicEval)[keyof typeof LogicEval];
+
+export const DepthEval = {
+  ADVANCED: "ADVANCED",
+  BASIC: "BASIC",
+  NONE: "NONE",
+} as const;
+export type DepthEval = (typeof DepthEval)[keyof typeof DepthEval];
+
+export const EvaluationStatus = {
+  COMPLETED: "COMPLETED",
+  PENDING: "PENDING",
+  FAILED: "FAILED",
+} as const;
+export type EvaluationStatus =
+  (typeof EvaluationStatus)[keyof typeof EvaluationStatus];
+
+export const InputType = {
+  VOICE: "VOICE",
+  TEXT: "TEXT",
+} as const;
+export type InputType = (typeof InputType)[keyof typeof InputType];
+
+export const ProcessStatus = {
+  PENDING: "PENDING",
+  IN_PROGRESS: "IN_PROGRESS",
+  DONE: "DONE",
+  FAILED: "FAILED",
+} as const;
+export type ProcessStatus = (typeof ProcessStatus)[keyof typeof ProcessStatus];
+
+export type STTStatus = ProcessStatus;
+
+export interface ScoreDetails {
+  coreConcept: number;
+  coverage: number;
+  logic: number;
+  depth: number;
+}
+
+export interface DetailAnalysis {
+  coreConcept: string;
+  coverage: string;
+  logic: string;
+  depth: string;
+}
+
+export interface EvaluationDTO {
+  id: number;
+  submissionId: number;
+  feedbackMessage: string;
+  coreConceptEval: CoreConceptEval;
+  coverageEval: CoverageEval;
+  logicEval: LogicEval;
+  depthEval: DepthEval;
+  detailAnalysis: DetailAnalysis;
+  scoreDetails: ScoreDetails;
+  extractedKeywords: string[];
+  createdAt: string;
+}
+
+export interface SubmissionDTO {
+  id: number;
+  questionId: number;
+  submittedAt: string;
+  duration: number;
+  answerContent: string;
+  evaluationStatus: EvaluationStatus;
+  sttStatus: STTStatus;
+  inputType: InputType;
+  totalScore: number | null;
+  audioAssetId: number | null;
+}


### PR DESCRIPTION
## 🔸 작업 내용

- reports 관련 공통 타입 packages/types/domain/reports.ts 하단에 선언 후 필요한 곳 수정 
- Docker 이미지에 packages/types 포함하도록 수정 후 로컬 Docker 빌드 확인
- `.dockerignore` 추가
- Jest 테스트에서 `@repo/types` 모듈을 찾지 못하는 에러 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 평가·제출 관련 중복 타입을 중앙 패키지로 통합하고 공개 타입들을 표준화했습니다.
  * 리포트/제출 데이터형이 외부 타입을 참조하도록 변경되어 일부 필드 타입 및 몇몇 필드가 명확해졌습니다.

* **Chores**
  * Docker 컨텍스트 최적화를 위한 ignore 규칙을 추가했습니다.
  * 로컬 개발용 데이터베이스 기본 환경과 Compose 구성이 추가/정리되었습니다.
  * 런타임 이미지에 타입 아티팩트를 포함하도록 빌드 단계가 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->