### PR TITLE
마이페이지 내가 푼 문제 페이지네이션 적용 

### DIFF
--- a/apps/api/src/user/dtos/request/solved-problems-query.dto.ts
+++ b/apps/api/src/user/dtos/request/solved-problems-query.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+/**
+ * 내가 푼 문제 목록 조회 쿼리 파라미터 DTO
+ */
+export class SolvedProblemsQueryDto {
+  @ApiProperty({
+    description: '페이지 번호 (기본값: 1)',
+    example: 1,
+    required: false,
+    minimum: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiProperty({
+    description: '페이지 크기 (기본값: 10)',
+    example: 10,
+    required: false,
+    minimum: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  size?: number = 10;
+}

--- a/apps/api/src/user/dtos/response/solved-problems-list-response.dto.ts
+++ b/apps/api/src/user/dtos/response/solved-problems-list-response.dto.ts
@@ -12,8 +12,26 @@ export class SolvedProblemsListResponseDto {
   problems: SolvedProblemDto[];
 
   @ApiProperty({
-    description: '푼 문제 갯수',
-    example: 15,
+    description: '전체 문제 개수',
+    example: 100,
   })
   totalCount: number;
+
+  @ApiProperty({
+    description: '현재 페이지 번호',
+    example: 1,
+  })
+  currentPage: number;
+
+  @ApiProperty({
+    description: '페이지 크기',
+    example: 10,
+  })
+  pageSize: number;
+
+  @ApiProperty({
+    description: '전체 페이지 수',
+    example: 10,
+  })
+  totalPages: number;
 }

--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpStatus,
   Patch,
   Post,
+  Query,
   Res,
   UseGuards,
   UsePipes,
@@ -15,6 +16,7 @@ import {
   ApiBearerAuth,
   ApiBody,
   ApiOperation,
+  ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -27,6 +29,7 @@ import { CreateUserRequestDto } from './dtos/request/create-user.request.dto';
 import { EditUserRequestDto } from './dtos/request/edit-user.request.dto';
 import { LoginRequestDto } from './dtos/request/login.request.dto';
 import { RequestVerificationCodeRequestDto } from './dtos/request/request-verification-code.request.dto';
+import { SolvedProblemsQueryDto } from './dtos/request/solved-problems-query.dto';
 import { UserPresignedUrlRequestDto } from './dtos/request/user-presigned-url.request.dto';
 import { LoginResponseDto } from './dtos/response/login.response.dto';
 import { SolvedProblemsListResponseDto } from './dtos/response/solved-problems-list-response.dto';
@@ -38,6 +41,13 @@ const USER_CONTROLLER_VALIDATION_PIPE = new ValidationPipe({
   transform: true,
   whitelist: true,
   forbidNonWhitelisted: true,
+});
+
+/** 쿼리 파라미터 검증용 (Swagger 등 외부 요청에서 추가 파라미터 허용) */
+const QUERY_VALIDATION_PIPE = new ValidationPipe({
+  transform: true,
+  whitelist: true,
+  forbidNonWhitelisted: false,
 });
 
 @ApiTags('users')
@@ -233,6 +243,20 @@ export class UserController {
   @ApiBearerAuth('JWT-auth')
   @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.OK)
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: '페이지 번호 (기본값: 1)',
+    example: 1,
+  })
+  @ApiQuery({
+    name: 'size',
+    required: false,
+    type: Number,
+    description: '페이지 크기 (기본값: 10)',
+    example: 10,
+  })
   @ApiResponse({
     status: 200,
     description: '푼 문제 목록 조회 성공',
@@ -242,10 +266,16 @@ export class UserController {
     status: 401,
     description: '로그인이 필요합니다',
   })
+  @UsePipes(QUERY_VALIDATION_PIPE)
   async getSolvedProblems(
     @UserId() userId: number,
+    @Query() query: SolvedProblemsQueryDto,
   ): Promise<SolvedProblemsListResponseDto> {
-    return await this.userService.getSolvedProblems(userId);
+    return await this.userService.getSolvedProblems(
+      userId,
+      query.page ?? 1,
+      query.size ?? 10,
+    );
   }
 
   @Post('presigned-url')

--- a/apps/api/src/user/user.service.spec.ts
+++ b/apps/api/src/user/user.service.spec.ts
@@ -45,11 +45,17 @@ const mockQueryBuilder = {
   where: jest.fn().mockReturnThis(),
   andWhere: jest.fn().mockReturnThis(),
   orderBy: jest.fn().mockReturnThis(),
+  skip: jest.fn().mockReturnThis(),
+  take: jest.fn().mockReturnThis(),
+  getCount: jest.fn(),
   getMany: jest.fn(),
 };
 
 const mockAnswerSubmissionRepository = {
   createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+  manager: {
+    query: jest.fn(),
+  },
 };
 
 describe('UserService', () => {
@@ -315,10 +321,15 @@ describe('UserService', () => {
         },
       ] as unknown as AnswerSubmission[];
 
+      mockAnswerSubmissionRepository.manager.query.mockResolvedValue([
+        { id: 1 },
+      ]);
+      mockQueryBuilder.getCount.mockResolvedValue(1);
       mockQueryBuilder.getMany.mockResolvedValue(mockSubmissions);
 
       const result = await service.getSolvedProblems(userId);
 
+      expect(mockAnswerSubmissionRepository.manager.query).toHaveBeenCalled();
       expect(
         mockAnswerSubmissionRepository.createQueryBuilder,
       ).toHaveBeenCalledWith('submission');
@@ -327,6 +338,9 @@ describe('UserService', () => {
       expect(result.problems[0].title).toBe('질문1');
       expect(result.problems[0].category).toBe('카테고리A');
       expect(result.totalCount).toBe(1);
+      expect(result.currentPage).toBe(1);
+      expect(result.pageSize).toBe(10);
+      expect(result.totalPages).toBe(1);
     });
   });
 

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -276,80 +276,85 @@ export class UserService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
-   * 채점 및 AI 피드백이 완료된 문제 목록 조회
+   * 채점·피드백 완료된 제출 중 문제별 최근 제출 ID 목록 조회 (raw SQL)
+   */
+  private async findLatestSolvedSubmissionIds(
+    userId: number,
+  ): Promise<number[]> {
+    const rows = await this.answerSubmissionRepository.manager.query<
+      { id: number }[]
+    >(
+      `
+      SELECT DISTINCT ON (sub.question_id) sub.id
+      FROM answer_submissions sub
+      INNER JOIN answer_evaluations eval ON eval.submission_id = sub.id
+      WHERE sub.user_id = $1
+        AND sub.evaluation_status = $2
+        AND eval.feedback_message IS NOT NULL
+      ORDER BY sub.question_id, sub.submitted_at DESC
+    `,
+      [userId, EvaluationStatus.COMPLETED],
+    );
+    return Array.isArray(rows) ? rows.map((row) => row.id) : [];
+  }
+
+  /**
+   * 채점 및 AI 피드백이 완료된 문제 목록 조회 (페이지네이션 적용)
    * @param userId 사용자 ID
-   * @returns 푼 문제 목록 및 총 갯수
+   * @param page 페이지 번호 (기본값: 1)
+   * @param size 페이지 크기 (기본값: 10)
+   * @returns 푼 문제 목록 및 페이지네이션 정보
    */
   async getSolvedProblems(
     userId: number,
+    page: number = 1,
+    size: number = 10,
   ): Promise<SolvedProblemsListResponseDto> {
-    // 채점 및 피드백이 완료된 제출 내역 조회
-    const submissions = await this.answerSubmissionRepository
+    const submissionIds = await this.findLatestSolvedSubmissionIds(userId);
+
+    if (submissionIds.length === 0) {
+      return {
+        problems: [],
+        totalCount: 0,
+        currentPage: page,
+        pageSize: size,
+        totalPages: 0,
+      };
+    }
+
+    // 조회된 제출 ID로 상세 정보 조회 (페이지네이션 적용)
+    const queryBuilder = this.answerSubmissionRepository
       .createQueryBuilder('submission')
-      .innerJoin(
-        'answer_evaluations',
-        'evaluation',
-        'evaluation.submission_id = submission.id',
-      )
       .innerJoinAndSelect('submission.question', 'question')
       .leftJoinAndSelect('question.category', 'category')
-      .where('submission.user_id = :userId', { userId })
-      .andWhere('submission.evaluation_status = :status', {
-        status: EvaluationStatus.COMPLETED,
-      })
-      .andWhere('evaluation.feedback_message IS NOT NULL')
-      .orderBy('submission.score', 'DESC')
-      .getMany();
+      .where('submission.id IN (:...submissionIds)', { submissionIds })
+      .orderBy('submission.submittedAt', 'DESC'); // 최신 풀이순 정렬
 
-    // 문제별로 가장 최근 제출 내역만 선택
-    const problemMap = new Map<
-      number,
-      {
-        submissionId: number;
-        questionId: number;
-        title: string;
-        category: string;
-        completedAt: Date;
-        score: number;
-      }
-    >();
+    // 전체 개수 조회 (페이지네이션 적용 전)
+    const totalCount = await queryBuilder.getCount();
 
-    submissions.forEach((submission) => {
-      const questionId = submission.questionId;
-      const existing = problemMap.get(questionId);
+    // 페이지네이션 적용
+    const skip = (page - 1) * size;
+    const submissions = await queryBuilder.skip(skip).take(size).getMany();
 
-      if (!existing || submission.submittedAt > existing.completedAt) {
-        const categoryName = submission.question?.category?.name ?? '미분류';
+    // DTO 변환
+    const problems: SolvedProblemDto[] = submissions.map((submission) => ({
+      questionId: submission.questionId,
+      title: submission.question?.title ?? '',
+      category: submission.question?.category?.name ?? '미분류',
+      completedAt: submission.submittedAt.toISOString(),
+      reportId: submission.id,
+      score: submission.score,
+    }));
 
-        problemMap.set(questionId, {
-          submissionId: submission.id,
-          questionId,
-          title: submission.question?.title ?? '',
-          category: categoryName,
-          completedAt: submission.submittedAt,
-          score: submission.score,
-        });
-      }
-    });
-
-    // DTO 변환 및 정렬
-    const problems: SolvedProblemDto[] = Array.from(problemMap.values())
-      .map((data) => ({
-        questionId: data.questionId,
-        title: data.title,
-        category: data.category,
-        completedAt: data.completedAt.toISOString(),
-        reportId: data.submissionId,
-        score: data.score,
-      }))
-      .sort(
-        (a, b) =>
-          new Date(b.completedAt).getTime() - new Date(a.completedAt).getTime(),
-      );
+    const totalPages = Math.ceil(totalCount / size);
 
     return {
       problems,
-      totalCount: problems.length,
+      totalCount,
+      currentPage: page,
+      pageSize: size,
+      totalPages,
     };
   }
 


### PR DESCRIPTION
## 🔸 작업 내용

- #381 

### API 변경
- GET `/api/users/solved-problems`에 쿼리 파라미터 추가
  - `page` (optional, 기본값: 1)
  - `size` (optional, 기본값: 10)
- **응답 스키마**에 페이지네이션 정보 추가
  - `currentPage`: 현재 페이지 번호
  - `pageSize`: 페이지 크기
  - `totalPages`: 전체 페이지 수
  - `totalCount`: 전체 문제 개수 (기존 유지)
  - `problems`: 해당 페이지의 문제 목록 (기존 유지)
- **정렬 기준**: 최신 풀이순 (`submittedAt` DESC)으로 명시
- **`user.service.ts`**
   - `findLatestSolvedSubmissionIds()`: raw SQL로 문제별 최근 제출 ID만 조회 후, `number[]` 반환으로 타입 안전성 확보
   - `getSolvedProblems()`: 위 ID 목록으로 QueryBuilder 조회 → `getCount()` 후 `skip`/`take` 적용
   - TypeORM `orderBy`는 엔티티 프로퍼티명(`submission.submittedAt`) 사용 (DB 컬럼명 `submitted_at` 사용 시 `databaseName` 관련 런타임 오류 발생)


## 🔸 고민 했던 부분

### 1. 문제별 “최근 제출 1건”만 가져오는 방식
- **고민**: 기존처럼 전체 제출을 메모리에서 문제별로 최신만 남기면, 데이터가 많을 때 조회·메모리 비용이 커짐.
- **결과**: DB에서 “문제별 최근 제출 ID”만 먼저 구한 뒤, 그 ID들로 상세 조회 + 페이지네이션을 적용하는 2단계로 변경.
  - 1단계: PostgreSQL `DISTINCT ON (sub.question_id)` + `ORDER BY sub.submitted_at DESC`로 문제당 최근 제출 ID만 raw SQL로 조회.
  - 2단계: 조회된 ID 리스트로 TypeORM QueryBuilder로 `question`, `category` 조인 후 `skip`/`take` 적용.

### 2. QueryBuilder `orderBy` 인자
- **고민**: `orderBy('submission.submitted_at', 'DESC')` 사용 시 TypeORM 내부에서 `databaseName`을 참조하다가 undefined로 인한 런타임 에러 발생.
- **결과**: TypeORM QueryBuilder는 **엔티티 프로퍼티명**을 사용해야 함. `submitted_at` → `submittedAt`으로 변경해 해결.


## 🔸 참고

- Talend API Tester 등에서는 `Authorization: Bearer <accessToken>` 헤더와 `?page=1&size=10` 쿼리로 동일하게 확인 가능.

<img width="1269" height="584" alt="스크린샷 2026-02-05 11 43 02" src="https://github.com/user-attachments/assets/46ae9aa1-1510-4367-964c-998774cc386c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 풀이한 문제 목록 조회 시 페이지네이션을 지원합니다. 페이지 번호(기본값: 1)와 페이지 크기(기본값: 10)를 쿼리 파라미터로 전달하여 조회 결과를 제어할 수 있으며, 응답에는 현재 페이지, 페이지 크기, 전체 페이지 수 등의 페이지네이션 정보가 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->