### PR TITLE
마이페이지 내가 푼 문제 페이지네이션 프론트엔드 적용

### DIFF
--- a/apps/api/src/user/dtos/request/solved-problems-query.dto.ts
+++ b/apps/api/src/user/dtos/request/solved-problems-query.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+/**
+ * 내가 푼 문제 목록 조회 쿼리 파라미터 DTO
+ */
+export class SolvedProblemsQueryDto {
+  @ApiProperty({
+    description: '페이지 번호 (기본값: 1)',
+    example: 1,
+    required: false,
+    minimum: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiProperty({
+    description: '페이지 크기 (기본값: 10)',
+    example: 10,
+    required: false,
+    minimum: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  size?: number = 10;
+}

--- a/apps/api/src/user/dtos/response/solved-problem.dto.ts
+++ b/apps/api/src/user/dtos/response/solved-problem.dto.ts
@@ -18,9 +18,15 @@ export class SolvedProblemDto {
 
   @ApiProperty({
     description: '문제 분류(카테고리)',
-    example: '프론트엔드',
+    example: 'JavaScript',
   })
   category: string;
+
+  @ApiProperty({
+    description: '문제 분류(상위 카테고리)',
+    example: '프론트엔드',
+  })
+  parentCategory: string;
 
   @ApiProperty({
     description: '풀이 완료 시각 (ISO-8601 포맷)',

--- a/apps/api/src/user/dtos/response/solved-problems-list-response.dto.ts
+++ b/apps/api/src/user/dtos/response/solved-problems-list-response.dto.ts
@@ -12,8 +12,26 @@ export class SolvedProblemsListResponseDto {
   problems: SolvedProblemDto[];
 
   @ApiProperty({
-    description: '푼 문제 갯수',
-    example: 15,
+    description: '전체 문제 개수',
+    example: 100,
   })
   totalCount: number;
+
+  @ApiProperty({
+    description: '현재 페이지 번호',
+    example: 1,
+  })
+  currentPage: number;
+
+  @ApiProperty({
+    description: '페이지 크기',
+    example: 10,
+  })
+  pageSize: number;
+
+  @ApiProperty({
+    description: '전체 페이지 수',
+    example: 10,
+  })
+  totalPages: number;
 }

--- a/apps/api/src/user/user.controller.ts
+++ b/apps/api/src/user/user.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpStatus,
   Patch,
   Post,
+  Query,
   Res,
   UseGuards,
   UsePipes,
@@ -15,6 +16,7 @@ import {
   ApiBearerAuth,
   ApiBody,
   ApiOperation,
+  ApiQuery,
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
@@ -27,6 +29,7 @@ import { CreateUserRequestDto } from './dtos/request/create-user.request.dto';
 import { EditUserRequestDto } from './dtos/request/edit-user.request.dto';
 import { LoginRequestDto } from './dtos/request/login.request.dto';
 import { RequestVerificationCodeRequestDto } from './dtos/request/request-verification-code.request.dto';
+import { SolvedProblemsQueryDto } from './dtos/request/solved-problems-query.dto';
 import { UserPresignedUrlRequestDto } from './dtos/request/user-presigned-url.request.dto';
 import { LoginResponseDto } from './dtos/response/login.response.dto';
 import { SolvedProblemsListResponseDto } from './dtos/response/solved-problems-list-response.dto';
@@ -38,6 +41,13 @@ const USER_CONTROLLER_VALIDATION_PIPE = new ValidationPipe({
   transform: true,
   whitelist: true,
   forbidNonWhitelisted: true,
+});
+
+/** 쿼리 파라미터 검증용 (Swagger 등 외부 요청에서 추가 파라미터 허용) */
+const QUERY_VALIDATION_PIPE = new ValidationPipe({
+  transform: true,
+  whitelist: true,
+  forbidNonWhitelisted: false,
 });
 
 @ApiTags('users')
@@ -233,6 +243,20 @@ export class UserController {
   @ApiBearerAuth('JWT-auth')
   @UseGuards(JwtAuthGuard)
   @HttpCode(HttpStatus.OK)
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: '페이지 번호 (기본값: 1)',
+    example: 1,
+  })
+  @ApiQuery({
+    name: 'size',
+    required: false,
+    type: Number,
+    description: '페이지 크기 (기본값: 10)',
+    example: 10,
+  })
   @ApiResponse({
     status: 200,
     description: '푼 문제 목록 조회 성공',
@@ -242,10 +266,16 @@ export class UserController {
     status: 401,
     description: '로그인이 필요합니다',
   })
+  @UsePipes(QUERY_VALIDATION_PIPE)
   async getSolvedProblems(
     @UserId() userId: number,
+    @Query() query: SolvedProblemsQueryDto,
   ): Promise<SolvedProblemsListResponseDto> {
-    return await this.userService.getSolvedProblems(userId);
+    return await this.userService.getSolvedProblems(
+      userId,
+      query.page ?? 1,
+      query.size ?? 10,
+    );
   }
 
   @Post('presigned-url')

--- a/apps/api/src/user/user.service.spec.ts
+++ b/apps/api/src/user/user.service.spec.ts
@@ -45,11 +45,17 @@ const mockQueryBuilder = {
   where: jest.fn().mockReturnThis(),
   andWhere: jest.fn().mockReturnThis(),
   orderBy: jest.fn().mockReturnThis(),
+  skip: jest.fn().mockReturnThis(),
+  take: jest.fn().mockReturnThis(),
+  getCount: jest.fn(),
   getMany: jest.fn(),
 };
 
 const mockAnswerSubmissionRepository = {
   createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+  manager: {
+    query: jest.fn(),
+  },
 };
 
 describe('UserService', () => {
@@ -315,10 +321,15 @@ describe('UserService', () => {
         },
       ] as unknown as AnswerSubmission[];
 
+      mockAnswerSubmissionRepository.manager.query.mockResolvedValue([
+        { id: 1 },
+      ]);
+      mockQueryBuilder.getCount.mockResolvedValue(1);
       mockQueryBuilder.getMany.mockResolvedValue(mockSubmissions);
 
       const result = await service.getSolvedProblems(userId);
 
+      expect(mockAnswerSubmissionRepository.manager.query).toHaveBeenCalled();
       expect(
         mockAnswerSubmissionRepository.createQueryBuilder,
       ).toHaveBeenCalledWith('submission');
@@ -327,6 +338,9 @@ describe('UserService', () => {
       expect(result.problems[0].title).toBe('질문1');
       expect(result.problems[0].category).toBe('카테고리A');
       expect(result.totalCount).toBe(1);
+      expect(result.currentPage).toBe(1);
+      expect(result.pageSize).toBe(10);
+      expect(result.totalPages).toBe(1);
     });
   });
 

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -17,6 +17,7 @@ import { ObjectStorageService } from 'src/object-storage/object-storage.service'
 import { QueryFailedError, Repository } from 'typeorm';
 import { EvaluationStatus } from '../answer-evaluation/answer-evaluation.constants';
 import { AnswerSubmission } from '../answer-submission/entities/answer-submission.entity';
+import { GoogleProfile } from '../auth/strategies/google.strategy';
 import { EditUserRequestDto } from './dtos/request/edit-user.request.dto';
 import { SolvedProblemDto } from './dtos/response/solved-problem.dto';
 import { SolvedProblemsListResponseDto } from './dtos/response/solved-problems-list-response.dto';
@@ -24,7 +25,6 @@ import { AuthProvider } from './entities/auth-provider.enum';
 import { UserRole } from './entities/user-role.enum';
 import { User } from './entities/user.entity';
 import { UserRepository } from './user.repository';
-import { GoogleProfile } from '../auth/strategies/google.strategy';
 import {
   hashPassword,
   isHashedPassword,
@@ -327,6 +327,7 @@ export class UserService implements OnModuleInit, OnModuleDestroy {
       .createQueryBuilder('submission')
       .innerJoinAndSelect('submission.question', 'question')
       .leftJoinAndSelect('question.category', 'category')
+      .leftJoinAndSelect('category.parent', 'parentCategory')
       .where('submission.id IN (:...submissionIds)', { submissionIds })
       .orderBy('submission.submittedAt', 'DESC'); // 최신 풀이순 정렬
 
@@ -342,6 +343,7 @@ export class UserService implements OnModuleInit, OnModuleDestroy {
       questionId: submission.questionId,
       title: submission.question?.title ?? '',
       category: submission.question?.category?.name ?? '미분류',
+      parentCategory: submission.question?.category?.parent?.name ?? '미분류',
       completedAt: submission.submittedAt.toISOString(),
       reportId: submission.id,
       score: submission.score,

--- a/apps/api/src/user/user.service.ts
+++ b/apps/api/src/user/user.service.ts
@@ -276,80 +276,85 @@ export class UserService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
-   * 채점 및 AI 피드백이 완료된 문제 목록 조회
+   * 채점·피드백 완료된 제출 중 문제별 최근 제출 ID 목록 조회 (raw SQL)
+   */
+  private async findLatestSolvedSubmissionIds(
+    userId: number,
+  ): Promise<number[]> {
+    const rows = await this.answerSubmissionRepository.manager.query<
+      { id: number }[]
+    >(
+      `
+      SELECT DISTINCT ON (sub.question_id) sub.id
+      FROM answer_submissions sub
+      INNER JOIN answer_evaluations eval ON eval.submission_id = sub.id
+      WHERE sub.user_id = $1
+        AND sub.evaluation_status = $2
+        AND eval.feedback_message IS NOT NULL
+      ORDER BY sub.question_id, sub.submitted_at DESC
+    `,
+      [userId, EvaluationStatus.COMPLETED],
+    );
+    return Array.isArray(rows) ? rows.map((row) => row.id) : [];
+  }
+
+  /**
+   * 채점 및 AI 피드백이 완료된 문제 목록 조회 (페이지네이션 적용)
    * @param userId 사용자 ID
-   * @returns 푼 문제 목록 및 총 갯수
+   * @param page 페이지 번호 (기본값: 1)
+   * @param size 페이지 크기 (기본값: 10)
+   * @returns 푼 문제 목록 및 페이지네이션 정보
    */
   async getSolvedProblems(
     userId: number,
+    page: number = 1,
+    size: number = 10,
   ): Promise<SolvedProblemsListResponseDto> {
-    // 채점 및 피드백이 완료된 제출 내역 조회
-    const submissions = await this.answerSubmissionRepository
+    const submissionIds = await this.findLatestSolvedSubmissionIds(userId);
+
+    if (submissionIds.length === 0) {
+      return {
+        problems: [],
+        totalCount: 0,
+        currentPage: page,
+        pageSize: size,
+        totalPages: 0,
+      };
+    }
+
+    // 조회된 제출 ID로 상세 정보 조회 (페이지네이션 적용)
+    const queryBuilder = this.answerSubmissionRepository
       .createQueryBuilder('submission')
-      .innerJoin(
-        'answer_evaluations',
-        'evaluation',
-        'evaluation.submission_id = submission.id',
-      )
       .innerJoinAndSelect('submission.question', 'question')
       .leftJoinAndSelect('question.category', 'category')
-      .where('submission.user_id = :userId', { userId })
-      .andWhere('submission.evaluation_status = :status', {
-        status: EvaluationStatus.COMPLETED,
-      })
-      .andWhere('evaluation.feedback_message IS NOT NULL')
-      .orderBy('submission.score', 'DESC')
-      .getMany();
+      .where('submission.id IN (:...submissionIds)', { submissionIds })
+      .orderBy('submission.submittedAt', 'DESC'); // 최신 풀이순 정렬
 
-    // 문제별로 가장 최근 제출 내역만 선택
-    const problemMap = new Map<
-      number,
-      {
-        submissionId: number;
-        questionId: number;
-        title: string;
-        category: string;
-        completedAt: Date;
-        score: number;
-      }
-    >();
+    // 전체 개수 조회 (페이지네이션 적용 전)
+    const totalCount = await queryBuilder.getCount();
 
-    submissions.forEach((submission) => {
-      const questionId = submission.questionId;
-      const existing = problemMap.get(questionId);
+    // 페이지네이션 적용
+    const skip = (page - 1) * size;
+    const submissions = await queryBuilder.skip(skip).take(size).getMany();
 
-      if (!existing || submission.submittedAt > existing.completedAt) {
-        const categoryName = submission.question?.category?.name ?? '미분류';
+    // DTO 변환
+    const problems: SolvedProblemDto[] = submissions.map((submission) => ({
+      questionId: submission.questionId,
+      title: submission.question?.title ?? '',
+      category: submission.question?.category?.name ?? '미분류',
+      completedAt: submission.submittedAt.toISOString(),
+      reportId: submission.id,
+      score: submission.score,
+    }));
 
-        problemMap.set(questionId, {
-          submissionId: submission.id,
-          questionId,
-          title: submission.question?.title ?? '',
-          category: categoryName,
-          completedAt: submission.submittedAt,
-          score: submission.score,
-        });
-      }
-    });
-
-    // DTO 변환 및 정렬
-    const problems: SolvedProblemDto[] = Array.from(problemMap.values())
-      .map((data) => ({
-        questionId: data.questionId,
-        title: data.title,
-        category: data.category,
-        completedAt: data.completedAt.toISOString(),
-        reportId: data.submissionId,
-        score: data.score,
-      }))
-      .sort(
-        (a, b) =>
-          new Date(b.completedAt).getTime() - new Date(a.completedAt).getTime(),
-      );
+    const totalPages = Math.ceil(totalCount / size);
 
     return {
       problems,
-      totalCount: problems.length,
+      totalCount,
+      currentPage: page,
+      pageSize: size,
+      totalPages,
     };
   }
 

--- a/apps/web/src/app/mypage/_contents/solved-content.tsx
+++ b/apps/web/src/app/mypage/_contents/solved-content.tsx
@@ -114,53 +114,57 @@ function SolvedContent({
             ))
           )}
         </TableBody>
-        <TableFooter>
-          <TableRow className="hover:bg-transparent">
-            <TableCell colSpan={1} className="hidden sm:table-cell">
-              <span className="text-muted-foreground text-sm">
-                {startIndex} - {endIndex} / 총 {totalCount}개
-              </span>
-            </TableCell>
-            <TableCell colSpan={3} className="sm:text-right">
-              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-end gap-2">
-                <span className="text-muted-foreground text-sm sm:hidden">
+        {totalCount > 0 && (
+          <TableFooter>
+            <TableRow className="hover:bg-transparent">
+              <TableCell colSpan={1} className="hidden sm:table-cell">
+                <span className="text-muted-foreground text-sm">
                   {startIndex} - {endIndex} / 총 {totalCount}개
                 </span>
-                <Pagination className="justify-center sm:justify-end">
-                  <PaginationContent>
-                    <PaginationItem>
-                      {currentPage > 1 ? (
-                        <PaginationPrevious href={buildUrl(currentPage - 1)} />
-                      ) : (
-                        <PaginationPrevious
-                          href={buildUrl(currentPage)}
-                          className="pointer-events-none opacity-50"
-                          aria-disabled="true"
-                        />
-                      )}
-                    </PaginationItem>
-                    <PaginationItem>
-                      <div className="px-2">
-                        {currentPage} / {totalPages}
-                      </div>
-                    </PaginationItem>
-                    <PaginationItem>
-                      {currentPage < totalPages ? (
-                        <PaginationNext href={buildUrl(currentPage + 1)} />
-                      ) : (
-                        <PaginationNext
-                          href={buildUrl(currentPage)}
-                          className="pointer-events-none opacity-50"
-                          aria-disabled="true"
-                        />
-                      )}
-                    </PaginationItem>
-                  </PaginationContent>
-                </Pagination>
-              </div>
-            </TableCell>
-          </TableRow>
-        </TableFooter>
+              </TableCell>
+              <TableCell colSpan={3} className="sm:text-right">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-end gap-2">
+                  <span className="text-muted-foreground text-sm sm:hidden">
+                    {startIndex} - {endIndex} / 총 {totalCount}개
+                  </span>
+                  <Pagination className="justify-center sm:justify-end">
+                    <PaginationContent>
+                      <PaginationItem>
+                        {currentPage > 1 ? (
+                          <PaginationPrevious
+                            href={buildUrl(currentPage - 1)}
+                          />
+                        ) : (
+                          <PaginationPrevious
+                            href={buildUrl(currentPage)}
+                            className="pointer-events-none opacity-50"
+                            aria-disabled="true"
+                          />
+                        )}
+                      </PaginationItem>
+                      <PaginationItem>
+                        <div className="px-2">
+                          {currentPage} / {totalPages}
+                        </div>
+                      </PaginationItem>
+                      <PaginationItem>
+                        {currentPage < totalPages ? (
+                          <PaginationNext href={buildUrl(currentPage + 1)} />
+                        ) : (
+                          <PaginationNext
+                            href={buildUrl(currentPage)}
+                            className="pointer-events-none opacity-50"
+                            aria-disabled="true"
+                          />
+                        )}
+                      </PaginationItem>
+                    </PaginationContent>
+                  </Pagination>
+                </div>
+              </TableCell>
+            </TableRow>
+          </TableFooter>
+        )}
       </Table>
     </>
   );

--- a/apps/web/src/app/mypage/_contents/solved-content.tsx
+++ b/apps/web/src/app/mypage/_contents/solved-content.tsx
@@ -1,3 +1,4 @@
+import { CategoryBadge } from "@/components/category-badge/category-badge";
 import {
   Pagination,
   PaginationContent,
@@ -83,9 +84,11 @@ function SolvedContent({
             solvedProblems.map((problem) => (
               <TableRow key={problem.questionId}>
                 <TableCell className="hidden sm:table-cell">
-                  <span className="text-xs md:text-sm py-1 px-2 bg-muted text-muted-foreground rounded-sm font-medium">
-                    {problem.category}
-                  </span>
+                  <CategoryBadge
+                    category={problem.parentCategory}
+                    subCategory={problem.category}
+                    orientation="vertical"
+                  />
                 </TableCell>
                 <TableCell className="whitespace-normal">
                   <Link

--- a/apps/web/src/app/mypage/_contents/solved-content.tsx
+++ b/apps/web/src/app/mypage/_contents/solved-content.tsx
@@ -1,24 +1,49 @@
 import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/pagination/pagination";
+import { ScoreBadge } from "@/components/score-badge/score-badge";
+import {
   Table,
   TableBody,
   TableCell,
+  TableFooter,
   TableHead,
   TableHeader,
   TableRow,
 } from "@/components/table/table";
 import Link from "next/link";
 import { SolvedProblem } from "../_types/solved-problem";
-import { ScoreBadge } from "@/components/score-badge/score-badge";
 
-async function SolvedContent({
-  solvedProblems,
-}: {
+interface SolvedContentProps {
   solvedProblems: SolvedProblem[];
-}) {
+  currentPage: number;
+  totalPages: number;
+  totalCount: number;
+  pageSize: number;
+}
+
+function SolvedContent({
+  solvedProblems,
+  currentPage,
+  totalPages,
+  totalCount,
+  pageSize,
+}: SolvedContentProps) {
   const formattingDate = (completedAt: string) => {
     const date = new Date(completedAt);
     return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, "0")}.${String(date.getDate()).padStart(2, "0")}`;
   };
+
+  const startIndex = totalCount === 0 ? 0 : (currentPage - 1) * pageSize + 1;
+  const endIndex =
+    totalCount === 0 ? 0 : Math.min(currentPage * pageSize, totalCount);
+
+  const buildUrl = (page: number) => `?page=${page}`;
+
   return (
     <>
       <div className="flex py-6 md:py-8 justify-between items-center">
@@ -86,6 +111,53 @@ async function SolvedContent({
             ))
           )}
         </TableBody>
+        <TableFooter>
+          <TableRow className="hover:bg-transparent">
+            <TableCell colSpan={1} className="hidden sm:table-cell">
+              <span className="text-muted-foreground text-sm">
+                {startIndex} - {endIndex} / 총 {totalCount}개
+              </span>
+            </TableCell>
+            <TableCell colSpan={3} className="sm:text-right">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-end gap-2">
+                <span className="text-muted-foreground text-sm sm:hidden">
+                  {startIndex} - {endIndex} / 총 {totalCount}개
+                </span>
+                <Pagination className="justify-center sm:justify-end">
+                  <PaginationContent>
+                    <PaginationItem>
+                      {currentPage > 1 ? (
+                        <PaginationPrevious href={buildUrl(currentPage - 1)} />
+                      ) : (
+                        <PaginationPrevious
+                          href={buildUrl(currentPage)}
+                          className="pointer-events-none opacity-50"
+                          aria-disabled="true"
+                        />
+                      )}
+                    </PaginationItem>
+                    <PaginationItem>
+                      <div className="px-2">
+                        {currentPage} / {totalPages}
+                      </div>
+                    </PaginationItem>
+                    <PaginationItem>
+                      {currentPage < totalPages ? (
+                        <PaginationNext href={buildUrl(currentPage + 1)} />
+                      ) : (
+                        <PaginationNext
+                          href={buildUrl(currentPage)}
+                          className="pointer-events-none opacity-50"
+                          aria-disabled="true"
+                        />
+                      )}
+                    </PaginationItem>
+                  </PaginationContent>
+                </Pagination>
+              </div>
+            </TableCell>
+          </TableRow>
+        </TableFooter>
       </Table>
     </>
   );

--- a/apps/web/src/app/mypage/_lib/fetch/fetch-solved-problem.ts
+++ b/apps/web/src/app/mypage/_lib/fetch/fetch-solved-problem.ts
@@ -1,10 +1,26 @@
 import { apiGet } from "@/lib/api-client";
 import { logger } from "@/lib/sentry-logger";
-import { SolvedProblemResDto } from "../../_types/solved-problem";
+import { SolvedProblemsResDto } from "../../_types/solved-problem";
 
-async function fetchSolvedProblem(): Promise<SolvedProblemResDto> {
+interface FetchSolvedProblemParams {
+  page?: number;
+  size?: number;
+}
+async function fetchSolvedProblems(
+  params: FetchSolvedProblemParams = {},
+): Promise<SolvedProblemsResDto> {
+  const searchParams = new URLSearchParams();
+  if (params.page) {
+    searchParams.set("page", params.page.toString());
+  }
+  if (params.size) {
+    searchParams.set("size", params.size.toString());
+  }
+
+  const queryString = searchParams.toString();
+  const baseUrl = "/api/users/solved-problems";
   try {
-    return await apiGet<SolvedProblemResDto>("/api/users/solved-problems");
+    return await apiGet<SolvedProblemsResDto>(`${baseUrl}?${queryString}`);
   } catch (error) {
     logger.error("풀이 문제 목록 조회 실패", {
       error: error instanceof Error ? error.message : String(error),
@@ -13,4 +29,4 @@ async function fetchSolvedProblem(): Promise<SolvedProblemResDto> {
   }
 }
 
-export { fetchSolvedProblem };
+export { fetchSolvedProblems };

--- a/apps/web/src/app/mypage/_types/solved-problem.ts
+++ b/apps/web/src/app/mypage/_types/solved-problem.ts
@@ -2,6 +2,7 @@ export interface SolvedProblem {
   questionId: number;
   title: string;
   category: string;
+  parentCategory: string;
   completedAt: string;
   reportId: number;
   score: number;

--- a/apps/web/src/app/mypage/_types/solved-problem.ts
+++ b/apps/web/src/app/mypage/_types/solved-problem.ts
@@ -7,7 +7,10 @@ export interface SolvedProblem {
   score: number;
 }
 
-export interface SolvedProblemResDto {
+export interface SolvedProblemsResDto {
   problems: SolvedProblem[];
   totalCount: number;
+  currentPage: number;
+  pageSize: number;
+  totalPages: number;
 }

--- a/apps/web/src/app/mypage/page.tsx
+++ b/apps/web/src/app/mypage/page.tsx
@@ -23,7 +23,9 @@ async function MyPage({
   searchParams: Promise<{ page?: string }>;
 }) {
   const resolvedSearchParams = await searchParams;
-  const currentPage = parseInt(resolvedSearchParams.page || "1");
+  const parsedPage = parseInt(resolvedSearchParams.page || "1", 10);
+  const currentPage =
+    Number.isNaN(parsedPage) || parsedPage < 1 ? 1 : parsedPage;
 
   const user = await getCurrentUser();
   if (!user) {

--- a/apps/web/src/app/mypage/page.tsx
+++ b/apps/web/src/app/mypage/page.tsx
@@ -13,27 +13,42 @@ import GraphContent from "./_contents/graph-content";
 import SolvedContent from "./_contents/solved-content";
 import StreakContent from "./_contents/streak-content";
 import { fetchGraph } from "./_lib/fetch/fetch-graph";
-import { fetchSolvedProblem } from "./_lib/fetch/fetch-solved-problem";
+import { fetchSolvedProblems } from "./_lib/fetch/fetch-solved-problem";
 import { fetchStreaks } from "./_lib/fetch/fetch-streaks";
 import { fetchUserInfo } from "./_lib/fetch/fetch-user-info";
 
-async function MyPage() {
+async function MyPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ page?: string }>;
+}) {
+  const resolvedSearchParams = await searchParams;
+  const currentPage = parseInt(resolvedSearchParams.page || "1");
+
   const user = await getCurrentUser();
   if (!user) {
     redirect("/login");
   }
+
   const [userData, graphData, streakData, solvedData] = await Promise.all([
     fetchUserInfo(),
     fetchGraph(),
     fetchStreaks(),
-    fetchSolvedProblem(),
+    fetchSolvedProblems({ page: currentPage, size: 10 }),
   ]);
+
   const {
     submittedQuestionCount,
     yearlyAnswerSubmissions,
     consecutiveDayCount,
   } = streakData;
-  const { problems, totalCount } = solvedData;
+  const {
+    problems,
+    totalCount,
+    currentPage: solvedCurrentPage,
+    totalPages,
+    pageSize,
+  } = solvedData;
 
   // Refactor Todo: 365개 전부 채웠을 때 새로운 그림으로 전환하기
   const imageSrc = "/starry-night.jpg";
@@ -83,7 +98,13 @@ async function MyPage() {
             className="w-full px-4 md:px-8 pb-4 md:pb-8"
             value="solvedList"
           >
-            <SolvedContent solvedProblems={problems} />
+            <SolvedContent
+              solvedProblems={problems}
+              currentPage={solvedCurrentPage}
+              totalPages={totalPages}
+              totalCount={totalCount}
+              pageSize={pageSize}
+            />
           </TabsContent>
         </Tabs>
         <div data-boostad-zone className="overflow-x-hidden"></div>


### PR DESCRIPTION
## 🔸 작업 내용
- #381 
- 내가 푼 문제 목록 조회시 상위 카테고리도 같이 제공하도록 수정
- 내가 푼 문제 목록에 페이지네이션 추가
- 테이블에서 카테고리 형식을 문제 리스트처럼 CategoryBadge로 보여주도록 변경

## 🔸 참고

<img width="832" height="802" alt="스크린샷 2026-02-05 오후 3 37 01" src="https://github.com/user-attachments/assets/5ab42ef8-5c60-41bd-aded-be3f988baf91" />
<img width="837" height="814" alt="스크린샷 2026-02-05 오후 3 36 50" src="https://github.com/user-attachments/assets/18d81399-8a53-4830-8e59-5c407a9e537e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 풀이한 문제 목록에 페이지네이션 API 추가(페이지/크기 지정 가능) 및 클라이언트 페이징 호출 연동
  * UI에 페이지네이션 네비게이션 및 범위 표시 추가
  * 문제 데이터에 상위 카테고리(parentCategory) 필드 추가, 카테고리 표시 개선

* **테스트**
  * 페이지네이션 동작과 총건수 계산을 검증하는 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->